### PR TITLE
feat(setup): add guided npx MCP setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__/
 *.py[cod]
 htmlcov/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ Optional extras are independent:
 
 Flamo pins the official Python MCP SDK to `mcp==2.0.0b2`.
 
+To connect Flamo to supported coding agents, run the guided local setup:
+
+```console
+npx flamo setup
+```
+
+The wizard detects Claude Code, Cursor, OpenCode, Codex, Gemini CLI, and
+Antigravity, but detection never grants consent: the first run starts with no
+clients selected and previews every file it will change. It installs an exact,
+versioned `flamo-diagnostics` runtime with `uv`, verifies the stdio MCP
+handshake, and then atomically activates the selected client configurations.
+It does not initialize a project or create `.diagnostics/`.
+
+Run the command again to connect or disconnect clients, verify the active
+runtime, update to the npm package's matching version, or roll back to a
+previously installed version. `npx flamo@latest setup` forces npm to resolve
+the newest setup release. Automation can use explicit flags:
+
+```console
+npx flamo setup --codex --claude --yes
+npx flamo setup --all --dry-run --json
+npx flamo setup --verify --yes --json
+```
+
+The npm package is only a bootstrap. It delegates to the matching Python
+release and supplies the maintained `jsonc-parser` helper needed to preserve
+comments in OpenCode configuration. MCP clients launch the persistent managed
+runtime directly; they do not invoke `npx`, `uvx`, or a network-dependent
+installer at startup.
+
 ## Local data model
 
 Initialize a project-local workspace:

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -1,5 +1,33 @@
 # Architectural decisions
 
+## Versioned MCP setup runtimes
+
+Flamo's npm package is a bootstrap, not a second implementation or the runtime
+used by MCP clients. `npx flamo setup` launches the exactly matching
+`flamo-diagnostics` release through `uvx`. The Python setup service installs
+that release into a version-addressed user-data directory with
+`uv tool install --no-config --no-sources`, verifies both the CLI and an actual
+MCP stdio handshake, and only then changes client launchers.
+
+Client configs point directly at that immutable runtime. This avoids network
+access and package resolution during agent startup, permits deterministic
+rollback, and leaves the previous working runtime active if staging or
+verification fails. Old versions are retained until a future explicit
+retention command exists.
+
+JSON and TOML editing use maintained format libraries. TOML Kit preserves Codex
+configuration structure and comments. Standard JSON uses the Python standard
+library; OpenCode JSONC is edited by the npm package's `jsonc-parser` helper.
+The helper receives one bounded parse or nested-property-edit request over
+stdin. Flamo does not maintain a comment-preserving JSON parser.
+
+The Python distribution is published before the npm bootstrap for a release.
+Both package manifests must carry the same version, which is enforced by a
+repository test. The Python artifact should be installable and pass the managed
+runtime handshake before its matching npm package is published; otherwise
+`npx flamo setup` would resolve a bootstrap whose required runtime does not yet
+exist.
+
 These choices constrain Flamo's design and implementation. Revisit a settled
 choice only with concrete implementation evidence and an explicit update to
 this page. Open questions stay here until implementation evidence supports a

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,5 +1,36 @@
 # CLI and MCP boundaries
 
+## Local client setup
+
+`npx flamo setup` is the supported interactive path for connecting local MCP
+clients. The npm package and Python distribution share an exact release
+version. npm supplies a thin launcher and the upstream `jsonc-parser` editor;
+the Python application service owns discovery, planning, runtime installation,
+verification, locking, activation, rollback, and structured results. The same
+setup service is available from `flamo setup` for standard JSON and TOML
+clients.
+
+The first run requires an explicit multi-select. Detection annotates choices
+but does not preselect them. Every mutation has a complete preview and a
+confirmation whose default is no. Non-interactive application requires both an
+explicit target (`--codex`, another client flag, `--all`, `--refresh`,
+`--rollback`, or `--verify`) and `--yes`; `--dry-run --json` returns the plan
+without mutation.
+
+Client launchers contain the absolute path of a verified managed runtime and
+the fixed arguments `mcp serve --project-root .`. Setup never passes `--init`.
+Each MCP client therefore binds Flamo's project root to the client's launch
+directory and encounters an ordinary `WORKSPACE_NOT_FOUND` until the user
+initializes that repository deliberately.
+
+Setup serializes mutations with a user-local lock. Before applying, it compares
+every config with the exact bytes used for the preview. It writes a recovery
+journal before the first config change, uses atomic replacement, and restores
+all original files after a partial failure or on the next invocation after a
+crash. Existing comments, unrelated servers, permissions, and formatting are
+preserved where the native format supports it. Malformed or non-UTF-8 configs
+are refused rather than replaced.
+
 The CLI and MCP server expose the same application services to different trust
 contexts. The CLI may offer explicit local administration and destructive
 recovery operations. MCP exposes bounded, task-shaped operations suitable for

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,12 @@
+# flamo
+
+This is the small npm bootstrap for Flamo's local MCP setup wizard:
+
+```console
+npx flamo setup
+```
+
+It launches the matching `flamo-diagnostics` Python package with `uvx`. The
+wizard installs a persistent, versioned local runtime and writes only the MCP
+client configurations you approve. Run `npx flamo@latest setup` when you want
+to force npm to resolve the newest setup release.

--- a/npm/bin/flamo.cjs
+++ b/npm/bin/flamo.cjs
@@ -30,6 +30,8 @@ const child = spawn(
   [
     "--no-config",
     "--no-sources",
+    "--python",
+    "3.12",
     "--from",
     pythonPackage,
     "flamo",

--- a/npm/bin/flamo.cjs
+++ b/npm/bin/flamo.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const packageJson = require("../package.json");
+
+const args = process.argv.slice(2);
+if (args.length === 1 && (args[0] === "--version" || args[0] === "-V")) {
+  process.stdout.write(`${packageJson.version}\n`);
+  process.exit(0);
+}
+if (args[0] !== "setup") {
+  process.stderr.write(
+    "The npm package is the setup bootstrap. Run `npx flamo setup`.\n" +
+      "After setup, use Flamo through a connected MCP client or the Python CLI.\n",
+  );
+  process.exit(2);
+}
+
+const helper = path.resolve(__dirname, "../lib/jsonc-edit.cjs");
+const environment = {
+  ...process.env,
+  FLAMO_SETUP_JSONC_HELPER: helper,
+};
+const pythonPackage = `flamo-diagnostics==${packageJson.version}`;
+const child = spawn(
+  process.env.FLAMO_UV_EXECUTABLE || "uvx",
+  [
+    "--no-config",
+    "--no-sources",
+    "--from",
+    pythonPackage,
+    "flamo",
+    ...args,
+  ],
+  { env: environment, stdio: "inherit" },
+);
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+  process.on(signal, () => child.kill(signal));
+}
+
+child.on("error", (error) => {
+  if (error.code === "ENOENT") {
+    process.stderr.write(
+      "Flamo setup requires uv. Install it from https://docs.astral.sh/uv/ and retry.\n",
+    );
+  } else {
+    process.stderr.write(`Could not start Flamo setup: ${error.message}\n`);
+  }
+  process.exitCode = 1;
+});
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exitCode = code ?? 1;
+});

--- a/npm/bin/flamo.cjs
+++ b/npm/bin/flamo.cjs
@@ -38,11 +38,22 @@ const child = spawn(
   { env: environment, stdio: "inherit" },
 );
 
-for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
-  process.on(signal, () => child.kill(signal));
+const signals = ["SIGINT", "SIGTERM", "SIGHUP"];
+const signalHandlers = new Map();
+for (const signal of signals) {
+  const handler = () => child.kill(signal);
+  signalHandlers.set(signal, handler);
+  process.on(signal, handler);
+}
+
+function removeSignalHandlers() {
+  for (const [signal, handler] of signalHandlers) {
+    process.removeListener(signal, handler);
+  }
 }
 
 child.on("error", (error) => {
+  removeSignalHandlers();
   if (error.code === "ENOENT") {
     process.stderr.write(
       "Flamo setup requires uv. Install it from https://docs.astral.sh/uv/ and retry.\n",
@@ -53,6 +64,7 @@ child.on("error", (error) => {
   process.exitCode = 1;
 });
 child.on("exit", (code, signal) => {
+  removeSignalHandlers();
   if (signal) {
     process.kill(process.pid, signal);
     return;

--- a/npm/lib/jsonc-edit.cjs
+++ b/npm/lib/jsonc-edit.cjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const {
+  applyEdits,
+  modify,
+  parse,
+  printParseErrorCode,
+} = require("jsonc-parser");
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  input += chunk;
+});
+process.stdin.on("end", () => {
+  try {
+    const request = JSON.parse(input);
+    if (request.operation === "parse") {
+      const errors = [];
+      const value = parse(request.text, errors, {
+        allowTrailingComma: true,
+        disallowComments: false,
+      });
+      if (errors.length > 0) {
+        const detail = errors
+          .map((error) => `${printParseErrorCode(error.error)} at offset ${error.offset}`)
+          .join(", ");
+        throw new Error(detail);
+      }
+      process.stdout.write(JSON.stringify({ value }));
+      return;
+    }
+    if (request.operation === "modify") {
+      const value = request.remove ? undefined : request.value;
+      const edits = modify(request.text, request.path, value, {
+        formattingOptions: {
+          insertSpaces: true,
+          tabSize: 2,
+          eol: request.text.includes("\r\n") ? "\r\n" : "\n",
+        },
+      });
+      process.stdout.write(JSON.stringify({ text: applyEdits(request.text, edits) }));
+      return;
+    }
+    throw new Error("unsupported JSONC operation");
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+});

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "flamo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flamo",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonc-parser": "^3.3.1"
+      },
+      "bin": {
+        "flamo": "bin/flamo.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "flamo",
+  "version": "0.1.0",
+  "description": "Bootstrap the local Flamo MCP setup wizard",
+  "license": "Apache-2.0",
+  "bin": {
+    "flamo": "bin/flamo.cjs"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "jsonc-parser": "^3.3.1"
+  },
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/npm/test/jsonc-edit.test.cjs
+++ b/npm/test/jsonc-edit.test.cjs
@@ -74,6 +74,8 @@ test("bootstrap launches the exactly matching Python release", () => {
   assert.deepEqual(JSON.parse(fs.readFileSync(capture, "utf8")), [
     "--no-config",
     "--no-sources",
+    "--python",
+    "3.12",
     "--from",
     "flamo-diagnostics==0.1.0",
     "flamo",

--- a/npm/test/jsonc-edit.test.cjs
+++ b/npm/test/jsonc-edit.test.cjs
@@ -82,3 +82,31 @@ test("bootstrap launches the exactly matching Python release", () => {
     "--dry-run",
   ]);
 });
+
+test(
+  "bootstrap terminates when its child exits from a signal",
+  { skip: process.platform === "win32" },
+  () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "flamo-signal-"));
+    const fakeUvx = path.join(directory, "uvx");
+    fs.writeFileSync(
+      fakeUvx,
+      [
+        "#!/usr/bin/env node",
+        '"use strict";',
+        'setTimeout(() => process.kill(process.pid, "SIGTERM"), 20);',
+      ].join("\n"),
+      { mode: 0o700 },
+    );
+    const bootstrap = path.resolve(__dirname, "../bin/flamo.cjs");
+    const result = spawnSync(process.execPath, [bootstrap, "setup"], {
+      encoding: "utf8",
+      env: { ...process.env, FLAMO_UV_EXECUTABLE: fakeUvx },
+      timeout: 5000,
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.status, null);
+    assert.equal(result.signal, "SIGTERM");
+  },
+);

--- a/npm/test/jsonc-edit.test.cjs
+++ b/npm/test/jsonc-edit.test.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { spawnSync } = require("node:child_process");
+
+const helper = path.resolve(__dirname, "../lib/jsonc-edit.cjs");
+
+function edit(request) {
+  const result = spawnSync(process.execPath, [helper], {
+    input: JSON.stringify(request),
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("modifies one nested property without removing comments", () => {
+  const source = '{\n  // keep this note\n  "mcp": {},\n}\n';
+  const result = edit({
+    operation: "modify",
+    text: source,
+    path: ["mcp", "flamo"],
+    remove: false,
+    value: { type: "local", command: ["/managed/flamo", "mcp", "serve"] },
+  });
+
+  assert.match(result.text, /keep this note/);
+  const parsed = edit({ operation: "parse", text: result.text });
+  assert.equal(parsed.value.mcp.flamo.type, "local");
+});
+
+test("removes only the Flamo entry", () => {
+  const source =
+    '{\n  "mcp": {\n    "other": {"enabled": true},\n    "flamo": {"enabled": true}\n  }\n}\n';
+  const result = edit({
+    operation: "modify",
+    text: source,
+    path: ["mcp", "flamo"],
+    remove: true,
+  });
+  const parsed = edit({ operation: "parse", text: result.text });
+
+  assert.deepEqual(parsed.value.mcp, { other: { enabled: true } });
+});
+
+test("bootstrap launches the exactly matching Python release", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "flamo-bootstrap-"));
+  const capture = path.join(directory, "args.json");
+  const fakeUvx = path.join(directory, "uvx");
+  fs.writeFileSync(
+    fakeUvx,
+    [
+      "#!/usr/bin/env node",
+      '"use strict";',
+      'require("node:fs").writeFileSync(process.env.FLAMO_CAPTURE, JSON.stringify(process.argv.slice(2)));',
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+  const bootstrap = path.resolve(__dirname, "../bin/flamo.cjs");
+  const result = spawnSync(
+    process.execPath,
+    [bootstrap, "setup", "--codex", "--dry-run"],
+    {
+      encoding: "utf8",
+      env: { ...process.env, FLAMO_UV_EXECUTABLE: fakeUvx, FLAMO_CAPTURE: capture },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(capture, "utf8")), [
+    "--no-config",
+    "--no-sources",
+    "--from",
+    "flamo-diagnostics==0.1.0",
+    "flamo",
+    "setup",
+    "--codex",
+    "--dry-run",
+  ]);
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
-name = "flamo"
+name = "flamo-diagnostics"
 version = "0.1.0"
 description = "Local runtime evidence CLI and MCP server for coding agents"
 readme = "README.md"
@@ -16,11 +16,14 @@ dependencies = [
     "numpy>=2.2,<3",
     "packaging>=24,<27",
     "portalocker>=3.2,<4",
+    "platformdirs>=4.3,<5",
     "pyarrow>=20,<26",
     "pydantic>=2.13.4,<2.14",
+    "questionary>=2.1,<3",
     "scipy>=1.15,<2",
     "statsmodels>=0.14,<1",
     "tomli-w>=1.2,<2",
+    "tomlkit>=0.13,<1",
     "typer>=0.16,<1",
 ]
 

--- a/src/flamo/__init__.py
+++ b/src/flamo/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("flamo")
+    __version__ = version("flamo-diagnostics")
 except PackageNotFoundError:
     __version__ = "0.0.0"
 

--- a/src/flamo/adapters/__init__.py
+++ b/src/flamo/adapters/__init__.py
@@ -1,3 +1,11 @@
+from flamo.adapters.client_setup import (
+    ALL_SETUP_CLIENTS,
+    ClientConfigEdit,
+    ClientConfigRegistry,
+    ClientPlanAction,
+    Launcher,
+    SetupClient,
+)
 from flamo.adapters.coverage import CoverageExtractionResult, CoverageExtractor
 from flamo.adapters.memray import MemrayExtractionResult, MemrayExtractor
 from flamo.adapters.observations import (
@@ -17,14 +25,21 @@ from flamo.adapters.registry import (
     AdapterDiscoveryResult,
     AdapterRegistry,
 )
+from flamo.adapters.setup_runtime import ManagedRuntime, RuntimeInstallation
 
 __all__ = [
+    "ALL_SETUP_CLIENTS",
     "AdapterApproval",
     "AdapterDescriptor",
     "AdapterDiscoveryResult",
     "AdapterRegistry",
+    "ClientConfigEdit",
+    "ClientConfigRegistry",
+    "ClientPlanAction",
     "CoverageExtractionResult",
     "CoverageExtractor",
+    "Launcher",
+    "ManagedRuntime",
     "MemrayExtractionResult",
     "MemrayExtractor",
     "ObservationExtractionResult",
@@ -33,6 +48,8 @@ __all__ = [
     "PerfettoExtractor",
     "PyPerfExtractionResult",
     "PyPerfExtractor",
+    "RuntimeInstallation",
+    "SetupClient",
     "TraceEvent",
     "TraceWindowResult",
 ]

--- a/src/flamo/adapters/client_setup.py
+++ b/src/flamo/adapters/client_setup.py
@@ -268,7 +268,7 @@ class ClientConfigRegistry:
                 f"Editing {definition.path} requires the Flamo npm JSONC helper.",
                 remediation=("Run setup through `npx flamo setup`.",),
             )
-        json_document = self._parse_json(definition.path, text)
+        json_document = self._parse_json(definition, text)
         section = json_document.get(definition.config_key)
         if section is None:
             return None
@@ -294,7 +294,7 @@ class ClientConfigRegistry:
         text = self._decode(definition.path, original) if original is not None else ""
         if definition.format == "toml":
             return self._edit_toml(definition, text, value=value, remove=remove).encode()
-        if self.jsonc_helper is not None:
+        if definition.format == "jsonc" and self.jsonc_helper is not None:
             return self._edit_jsonc(
                 definition,
                 text,
@@ -307,7 +307,7 @@ class ClientConfigRegistry:
                 f"Editing {definition.path} requires the Flamo npm JSONC helper.",
                 remediation=("Run setup through `npx flamo setup`.",),
             )
-        document = self._parse_json(definition.path, text) if text else {}
+        document = self._parse_json(definition, text) if text else {}
         section = document.setdefault(definition.config_key, {})
         if not isinstance(section, dict):
             raise self._invalid_config(
@@ -349,19 +349,31 @@ class ClientConfigRegistry:
             section["flamo"] = table
         return tomlkit.dumps(document)
 
-    def _parse_json(self, path: Path, text: str) -> dict[str, Any]:
+    def _parse_json(self, definition: _ClientDefinition, text: str) -> dict[str, Any]:
         if not text.strip():
             return {}
-        if self.jsonc_helper is not None:
-            result = self._run_jsonc_helper({"operation": "parse", "text": text}, path)
+        if definition.format == "jsonc":
+            if self.jsonc_helper is None:
+                raise DomainError(
+                    ErrorCode.CAPABILITY_UNAVAILABLE,
+                    f"Editing {definition.path} requires the Flamo npm JSONC helper.",
+                    remediation=("Run setup through `npx flamo setup`.",),
+                )
+            result = self._run_jsonc_helper(
+                {"operation": "parse", "text": text},
+                definition.path,
+            )
             value = result.get("value")
         else:
             try:
                 value = json.loads(text)
             except json.JSONDecodeError as exc:
-                raise self._invalid_config(path, exc) from exc
+                raise self._invalid_config(definition.path, exc) from exc
         if not isinstance(value, dict):
-            raise self._invalid_config(path, "the document root is not an object")
+            raise self._invalid_config(
+                definition.path,
+                "the document root is not an object",
+            )
         return value
 
     def _edit_jsonc(

--- a/src/flamo/adapters/client_setup.py
+++ b/src/flamo/adapters/client_setup.py
@@ -407,6 +407,7 @@ class ClientConfigRegistry:
                 input=json.dumps(request),
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 check=False,
                 timeout=10,
             )

--- a/src/flamo/adapters/client_setup.py
+++ b/src/flamo/adapters/client_setup.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import json
+import stat
+import subprocess
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import tomlkit
+
+from flamo.domain import DomainError, ErrorCode
+
+
+class SetupClient(StrEnum):
+    CLAUDE = "claude"
+    CURSOR = "cursor"
+    OPENCODE = "opencode"
+    CODEX = "codex"
+    GEMINI = "gemini"
+    ANTIGRAVITY = "antigravity"
+
+    @property
+    def display_name(self) -> str:
+        return {
+            SetupClient.CLAUDE: "Claude Code",
+            SetupClient.CURSOR: "Cursor",
+            SetupClient.OPENCODE: "OpenCode",
+            SetupClient.CODEX: "Codex",
+            SetupClient.GEMINI: "Gemini CLI",
+            SetupClient.ANTIGRAVITY: "Antigravity",
+        }[self]
+
+
+ALL_SETUP_CLIENTS = tuple(SetupClient)
+
+
+class ClientPlanAction(StrEnum):
+    CREATE = "create"
+    UPDATE = "update"
+    ALREADY_CURRENT = "already_current"
+    REMOVE = "remove"
+    NOT_CONFIGURED = "not_configured"
+
+
+@dataclass(frozen=True, slots=True)
+class Launcher:
+    command: str
+    args: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ClientConfigEdit:
+    client: SetupClient
+    path: Path
+    action: ClientPlanAction
+    detected: bool
+    original: bytes | None
+    updated: bytes | None
+    mode: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ClientDefinition:
+    path: Path
+    format: str
+    config_key: str
+    detected: bool
+
+
+class ClientConfigRegistry:
+    """Resolve narrow, source-preserving edits to supported MCP client configs."""
+
+    def __init__(
+        self,
+        *,
+        home: Path,
+        jsonc_helper: Path | None = None,
+        node_executable: str = "node",
+    ) -> None:
+        self.home = home
+        self.jsonc_helper = jsonc_helper
+        self.node_executable = node_executable
+
+    def definition(self, client: SetupClient) -> _ClientDefinition:
+        if client is SetupClient.CLAUDE:
+            path = self.home / ".claude.json"
+            return _ClientDefinition(
+                path,
+                "json",
+                "mcpServers",
+                (self.home / ".claude").exists() or path.exists(),
+            )
+        if client is SetupClient.CURSOR:
+            path = self.home / ".cursor" / "mcp.json"
+            return _ClientDefinition(path, "json", "mcpServers", path.parent.exists())
+        if client is SetupClient.OPENCODE:
+            root = self.home / ".config" / "opencode"
+            candidates = (
+                root / "opencode.json",
+                root / "opencode.jsonc",
+                root / ".opencode.json",
+                root / ".opencode.jsonc",
+            )
+            path = next(
+                (candidate for candidate in candidates if candidate.exists()),
+                candidates[0],
+            )
+            format_name = "jsonc" if path.suffix == ".jsonc" else "json"
+            return _ClientDefinition(path, format_name, "mcp", root.exists())
+        if client is SetupClient.CODEX:
+            path = self.home / ".codex" / "config.toml"
+            return _ClientDefinition(path, "toml", "mcp_servers", path.parent.exists())
+        if client is SetupClient.GEMINI:
+            path = self.home / ".gemini" / "settings.json"
+            return _ClientDefinition(path, "json", "mcpServers", path.parent.exists())
+        path = self.home / ".gemini" / "config" / "mcp_config.json"
+        detected = (self.home / ".gemini" / "antigravity").exists() or (
+            self.home / ".agent"
+        ).exists()
+        return _ClientDefinition(path, "json", "mcpServers", detected)
+
+    def detected_clients(self) -> tuple[SetupClient, ...]:
+        return tuple(client for client in ALL_SETUP_CLIENTS if self.definition(client).detected)
+
+    def configured_clients(self) -> tuple[SetupClient, ...]:
+        configured: list[SetupClient] = []
+        for client in ALL_SETUP_CLIENTS:
+            definition = self.definition(client)
+            if not definition.path.exists():
+                continue
+            try:
+                value = self._read_entry(definition)
+            except DomainError:
+                continue
+            if value is not None:
+                configured.append(client)
+        return tuple(configured)
+
+    def allowed_config_paths(self) -> frozenset[Path]:
+        opencode_root = self.home / ".config" / "opencode"
+        return frozenset(
+            {
+                self.home / ".claude.json",
+                self.home / ".cursor" / "mcp.json",
+                opencode_root / "opencode.json",
+                opencode_root / "opencode.jsonc",
+                opencode_root / ".opencode.json",
+                opencode_root / ".opencode.jsonc",
+                self.home / ".codex" / "config.toml",
+                self.home / ".gemini" / "settings.json",
+                self.home / ".gemini" / "config" / "mcp_config.json",
+            }
+        )
+
+    def plan(
+        self,
+        client: SetupClient,
+        launcher: Launcher,
+        *,
+        remove: bool,
+    ) -> ClientConfigEdit:
+        definition = self.definition(client)
+        try:
+            metadata = definition.path.stat()
+        except FileNotFoundError:
+            original = None
+            mode = 0o600
+        except OSError as exc:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Could not inspect MCP client configuration {definition.path}.",
+                details={"error": str(exc)},
+            ) from exc
+        else:
+            original = self._read_bytes(definition.path)
+            mode = stat.S_IMODE(metadata.st_mode)
+        text = self._decode(definition.path, original) if original is not None else ""
+        current = self._read_entry(definition, text=text)
+
+        if remove:
+            if current is None:
+                return ClientConfigEdit(
+                    client,
+                    definition.path,
+                    ClientPlanAction.NOT_CONFIGURED,
+                    definition.detected,
+                    original,
+                    original,
+                    mode,
+                )
+            updated = self._updated_content(definition, original, value=None, remove=True)
+            return ClientConfigEdit(
+                client,
+                definition.path,
+                ClientPlanAction.REMOVE,
+                definition.detected,
+                original,
+                updated,
+                mode,
+            )
+
+        wanted = self._entry(client, launcher)
+        if current == wanted:
+            return ClientConfigEdit(
+                client,
+                definition.path,
+                ClientPlanAction.ALREADY_CURRENT,
+                definition.detected,
+                original,
+                original,
+                mode,
+            )
+        updated = self._updated_content(definition, original, value=wanted, remove=False)
+        action = ClientPlanAction.CREATE if original is None else ClientPlanAction.UPDATE
+        return ClientConfigEdit(
+            client,
+            definition.path,
+            action,
+            definition.detected,
+            original,
+            updated,
+            mode,
+        )
+
+    def _entry(self, client: SetupClient, launcher: Launcher) -> dict[str, Any]:
+        if client is SetupClient.OPENCODE:
+            return {
+                "type": "local",
+                "command": [launcher.command, *launcher.args],
+                "cwd": ".",
+                "enabled": True,
+            }
+        return {"command": launcher.command, "args": list(launcher.args)}
+
+    def _read_entry(
+        self,
+        definition: _ClientDefinition,
+        *,
+        text: str | None = None,
+    ) -> dict[str, Any] | None:
+        if not definition.path.exists():
+            return None
+        text = self._read_text(definition.path) if text is None else text
+        if definition.format == "toml":
+            try:
+                toml_document = tomlkit.parse(text)
+            except (ValueError, TypeError) as exc:
+                raise self._invalid_config(definition.path, exc) from exc
+            section = toml_document.get(definition.config_key)
+            if section is None:
+                return None
+            try:
+                value = section.get("flamo")
+            except AttributeError as exc:
+                raise self._invalid_config(
+                    definition.path, f"{definition.config_key} is not a table"
+                ) from exc
+            plain = _plain_mapping(value)
+            if value is not None and plain is None:
+                raise self._invalid_config(definition.path, "the flamo entry is not a table")
+            return plain
+
+        if definition.format == "jsonc" and self.jsonc_helper is None:
+            raise DomainError(
+                ErrorCode.CAPABILITY_UNAVAILABLE,
+                f"Editing {definition.path} requires the Flamo npm JSONC helper.",
+                remediation=("Run setup through `npx flamo setup`.",),
+            )
+        json_document = self._parse_json(definition.path, text)
+        section = json_document.get(definition.config_key)
+        if section is None:
+            return None
+        if not isinstance(section, dict):
+            raise self._invalid_config(
+                definition.path, f"{definition.config_key} is not an object"
+            )
+        value = section.get("flamo")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise self._invalid_config(definition.path, "the flamo entry is not an object")
+        return value
+
+    def _updated_content(
+        self,
+        definition: _ClientDefinition,
+        original: bytes | None,
+        *,
+        value: dict[str, Any] | None,
+        remove: bool,
+    ) -> bytes:
+        text = self._decode(definition.path, original) if original is not None else ""
+        if definition.format == "toml":
+            return self._edit_toml(definition, text, value=value, remove=remove).encode()
+        if self.jsonc_helper is not None:
+            return self._edit_jsonc(
+                definition,
+                text,
+                value=value,
+                remove=remove,
+            ).encode()
+        if definition.format == "jsonc":
+            raise DomainError(
+                ErrorCode.CAPABILITY_UNAVAILABLE,
+                f"Editing {definition.path} requires the Flamo npm JSONC helper.",
+                remediation=("Run setup through `npx flamo setup`.",),
+            )
+        document = self._parse_json(definition.path, text) if text else {}
+        section = document.setdefault(definition.config_key, {})
+        if not isinstance(section, dict):
+            raise self._invalid_config(
+                definition.path, f"{definition.config_key} is not an object"
+            )
+        if remove:
+            section.pop("flamo", None)
+        else:
+            section["flamo"] = value
+        return (json.dumps(document, ensure_ascii=False, indent=2) + "\n").encode()
+
+    def _edit_toml(
+        self,
+        definition: _ClientDefinition,
+        text: str,
+        *,
+        value: dict[str, Any] | None,
+        remove: bool,
+    ) -> str:
+        try:
+            document = tomlkit.parse(text) if text else tomlkit.document()
+        except (ValueError, TypeError) as exc:
+            raise self._invalid_config(definition.path, exc) from exc
+        section = document.get(definition.config_key)
+        if section is None:
+            section = tomlkit.table()
+            document[definition.config_key] = section
+        if not hasattr(section, "get") or not hasattr(section, "__setitem__"):
+            raise self._invalid_config(
+                definition.path, f"{definition.config_key} is not a table"
+            )
+        if remove:
+            section.pop("flamo", None)
+        else:
+            table = tomlkit.table()
+            assert value is not None
+            table.add("command", value["command"])
+            table.add("args", value["args"])
+            section["flamo"] = table
+        return tomlkit.dumps(document)
+
+    def _parse_json(self, path: Path, text: str) -> dict[str, Any]:
+        if not text.strip():
+            return {}
+        if self.jsonc_helper is not None:
+            result = self._run_jsonc_helper({"operation": "parse", "text": text}, path)
+            value = result.get("value")
+        else:
+            try:
+                value = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise self._invalid_config(path, exc) from exc
+        if not isinstance(value, dict):
+            raise self._invalid_config(path, "the document root is not an object")
+        return value
+
+    def _edit_jsonc(
+        self,
+        definition: _ClientDefinition,
+        text: str,
+        *,
+        value: dict[str, Any] | None,
+        remove: bool,
+    ) -> str:
+        result = self._run_jsonc_helper(
+            {
+                "operation": "modify",
+                "text": text or "{}\n",
+                "path": [definition.config_key, "flamo"],
+                "remove": remove,
+                "value": value,
+            },
+            definition.path,
+        )
+        updated = result.get("text")
+        if not isinstance(updated, str):
+            raise self._invalid_config(definition.path, "JSONC helper returned no text")
+        return updated
+
+    def _run_jsonc_helper(self, request: dict[str, Any], path: Path) -> dict[str, Any]:
+        assert self.jsonc_helper is not None
+        try:
+            completed = subprocess.run(
+                [self.node_executable, str(self.jsonc_helper)],
+                input=json.dumps(request),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise DomainError(
+                ErrorCode.CAPABILITY_UNAVAILABLE,
+                "The Flamo JSONC editor could not be started.",
+                details={"path": str(path), "error": str(exc)},
+                remediation=("Run setup through `npx flamo setup` with Node.js available.",),
+            ) from exc
+        if completed.returncode != 0:
+            message = completed.stderr.strip() or "unknown JSONC parser failure"
+            raise self._invalid_config(path, message)
+        try:
+            result = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise self._invalid_config(path, "JSONC helper returned invalid output") from exc
+        if not isinstance(result, dict):
+            raise self._invalid_config(path, "JSONC helper returned a non-object")
+        return result
+
+    @staticmethod
+    def _read_text(path: Path) -> str:
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Could not read MCP client configuration {path}.",
+                details={"error": str(exc)},
+            ) from exc
+
+    @staticmethod
+    def _read_bytes(path: Path) -> bytes:
+        try:
+            return path.read_bytes()
+        except OSError as exc:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Could not read MCP client configuration {path}.",
+                details={"error": str(exc)},
+            ) from exc
+
+    @staticmethod
+    def _decode(path: Path, value: bytes) -> str:
+        try:
+            return value.decode("utf-8")
+        except UnicodeError as exc:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"MCP client configuration is not UTF-8: {path}.",
+            ) from exc
+
+    @staticmethod
+    def _invalid_config(path: Path, error: object) -> DomainError:
+        return DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            f"Refusing to overwrite malformed client configuration {path}.",
+            details={"error": str(error)},
+            remediation=("Repair the configuration and run setup again.",),
+        )
+
+
+def _plain_mapping(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if hasattr(value, "unwrap"):
+        value = value.unwrap()
+    if not isinstance(value, dict):
+        return None
+    return {str(key): _plain_value(item) for key, item in value.items()}
+
+
+def _plain_value(value: Any) -> Any:
+    if hasattr(value, "unwrap"):
+        return _plain_value(value.unwrap())
+    if isinstance(value, dict):
+        return {str(key): _plain_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_value(item) for item in value]
+    return value

--- a/src/flamo/adapters/setup_runtime.py
+++ b/src/flamo/adapters/setup_runtime.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import anyio
+from mcp import Client, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from packaging.version import InvalidVersion, Version
+
+from flamo.domain import DomainError, ErrorCode
+from flamo.storage.atomic import atomic_write_json
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeInstallation:
+    version: str
+    executable: Path
+    installed: bool
+
+
+class ManagedRuntime:
+    """Install and verify immutable, version-addressed Flamo tool environments."""
+
+    distribution = "flamo-diagnostics"
+
+    def __init__(self, root: Path, *, uv_executable: str = "uv") -> None:
+        self.root = root
+        self.uv_executable = uv_executable
+
+    def executable(self, version: str) -> Path:
+        self._validated_version(version)
+        suffix = ".exe" if os.name == "nt" else ""
+        return self.root / "runtimes" / version / "bin" / f"flamo{suffix}"
+
+    def installed_versions(self) -> tuple[str, ...]:
+        runtimes = self.root / "runtimes"
+        if not runtimes.exists():
+            return ()
+        versions: list[str] = []
+        for path in runtimes.iterdir():
+            try:
+                parsed = Version(path.name)
+            except InvalidVersion:
+                continue
+            if str(parsed) != path.name:
+                continue
+            executable = self.executable(path.name)
+            if path.is_dir() and executable.is_file() and self._manifest_matches(
+                path / "runtime.json", path.name, executable
+            ):
+                versions.append(path.name)
+        return tuple(sorted(versions, key=Version, reverse=True))
+
+    async def install(self, version: str) -> RuntimeInstallation:
+        version = self._validated_version(version)
+        executable = self.executable(version)
+        manifest = executable.parent.parent / "runtime.json"
+        if executable.is_file() and manifest.is_file():
+            if not self._manifest_matches(manifest, version, executable):
+                raise self._verification_error(executable, "runtime metadata is invalid")
+            await self.verify(executable, version)
+            return RuntimeInstallation(version, executable, False)
+
+        runtime_root = executable.parent.parent
+        runtime_root.mkdir(parents=True, exist_ok=True)
+        environment = os.environ.copy()
+        environment["UV_TOOL_DIR"] = str(runtime_root / "tools")
+        environment["UV_TOOL_BIN_DIR"] = str(runtime_root / "bin")
+        try:
+            completed = subprocess.run(
+                [
+                    self.uv_executable,
+                    "tool",
+                    "install",
+                    "--force",
+                    "--no-config",
+                    "--no-sources",
+                    "--python",
+                    "3.12",
+                    f"{self.distribution}=={version}",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=600,
+                env=environment,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise self._installation_error(version, str(exc)) from exc
+        if completed.returncode != 0 or not executable.is_file():
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise self._installation_error(version, detail or "uv produced no launcher")
+
+        try:
+            await self.verify(executable, version)
+        except BaseException:
+            shutil.rmtree(runtime_root, ignore_errors=True)
+            raise
+        atomic_write_json(
+            manifest,
+            {
+                "schema_version": 1,
+                "distribution": self.distribution,
+                "version": version,
+                "executable": str(executable),
+            },
+        )
+        return RuntimeInstallation(version, executable, True)
+
+    async def verify(self, executable: Path, version: str) -> None:
+        try:
+            completed = subprocess.run(
+                [str(executable), "--version"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise self._verification_error(executable, str(exc)) from exc
+        if completed.returncode != 0:
+            raise self._verification_error(
+                executable,
+                completed.stderr.strip() or "the version command failed",
+            )
+        if completed.stdout.strip() != version:
+            raise self._verification_error(
+                executable,
+                f"expected version {version}, got {completed.stdout.strip()!r}",
+            )
+
+        parameters = StdioServerParameters(
+            command=str(executable),
+            args=["mcp", "serve", "--project-root", "."],
+            cwd=Path.cwd(),
+        )
+        try:
+            with anyio.fail_after(60):
+                async with Client(stdio_client(parameters), raise_exceptions=True) as client:
+                    tools = await client.list_tools()
+        except Exception as exc:
+            raise self._verification_error(executable, str(exc)) from exc
+        if not tools.tools:
+            raise self._verification_error(executable, "the MCP server exposed no tools")
+
+    @staticmethod
+    def _validated_version(version: str) -> str:
+        try:
+            parsed = Version(version)
+        except InvalidVersion as exc:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Invalid Flamo runtime version: {version}",
+            ) from exc
+        if str(parsed) != version:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Runtime version must be canonical: {version}",
+            )
+        return version
+
+    def _installation_error(self, version: str, detail: str) -> DomainError:
+        return DomainError(
+            ErrorCode.PROCESS_FAILED,
+            f"Could not install Flamo {version} with uv.",
+            details={"error": detail, "distribution": self.distribution},
+            remediation=("Install uv, check network access, and run setup again.",),
+        )
+
+    @staticmethod
+    def _manifest_matches(path: Path, version: str, executable: Path) -> bool:
+        try:
+            value = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return False
+        if not isinstance(value, dict):
+            return False
+        return value == {
+            "schema_version": 1,
+            "distribution": ManagedRuntime.distribution,
+            "version": version,
+            "executable": str(executable),
+        }
+
+    @staticmethod
+    def _verification_error(executable: Path, detail: str) -> DomainError:
+        return DomainError(
+            ErrorCode.PROCESS_FAILED,
+            "The staged Flamo runtime failed verification.",
+            details={"executable": str(executable), "error": detail},
+            remediation=("The previous configured runtime remains active.",),
+        )

--- a/src/flamo/application/__init__.py
+++ b/src/flamo/application/__init__.py
@@ -85,6 +85,16 @@ from flamo.application.recovery import (
     RecoveryService,
 )
 from flamo.application.repair import RepairEntry, RepairPlan, RepairResult, RepairService
+from flamo.application.setup import (
+    ClientSetupPlan,
+    ResolvedSetupPlan,
+    RuntimeAction,
+    SetupInspection,
+    SetupOperation,
+    SetupPlan,
+    SetupReport,
+    SetupService,
+)
 from flamo.application.status import WorkspaceStatus, workspace_status
 from flamo.application.viewers import (
     NativeViewerLaunchResult,
@@ -113,6 +123,7 @@ __all__ = [
     "CapturePlanRegistry",
     "CaptureResult",
     "CaptureService",
+    "ClientSetupPlan",
     "CompactionResult",
     "CompactionService",
     "CompareRunSetsRequest",
@@ -171,8 +182,15 @@ __all__ = [
     "RepairResult",
     "RepairService",
     "ResolvedOracle",
+    "ResolvedSetupPlan",
     "RunSetService",
+    "RuntimeAction",
     "Scalar",
+    "SetupInspection",
+    "SetupOperation",
+    "SetupPlan",
+    "SetupReport",
+    "SetupService",
     "StackExample",
     "StackExamplesResult",
     "TrashManifest",

--- a/src/flamo/application/setup.py
+++ b/src/flamo/application/setup.py
@@ -146,6 +146,7 @@ class SetupService:
         self.lock_path = self.data_root / "setup.lock"
 
     def inspect(self) -> SetupInspection:
+        self._recover_interrupted()
         manifest = self._read_install_manifest()
         return SetupInspection(
             active_version=manifest.active_version if manifest else None,
@@ -162,6 +163,7 @@ class SetupService:
         clients: tuple[SetupClient, ...],
         version: str | None,
     ) -> ResolvedSetupPlan:
+        self._recover_interrupted()
         if operation is SetupOperation.VERIFY:
             executable = self._active_executable()
             public = SetupPlan(
@@ -244,6 +246,21 @@ class SetupService:
             with lock:
                 self._recover_locked()
                 return await self._apply_locked(plan)
+        except portalocker.exceptions.LockException as exc:
+            raise DomainError(
+                ErrorCode.WRITE_LOCK_TIMEOUT,
+                "Another Flamo setup operation holds the setup lock.",
+                retryable=True,
+            ) from exc
+
+    def _recover_interrupted(self) -> None:
+        if not self.journal_path.exists():
+            return
+        self.data_root.mkdir(parents=True, exist_ok=True)
+        try:
+            lock = portalocker.Lock(self.lock_path, mode="a", timeout=10)
+            with lock:
+                self._recover_locked()
         except portalocker.exceptions.LockException as exc:
             raise DomainError(
                 ErrorCode.WRITE_LOCK_TIMEOUT,

--- a/src/flamo/application/setup.py
+++ b/src/flamo/application/setup.py
@@ -81,6 +81,8 @@ class SetupInspection(ContractModel):
 class ResolvedSetupPlan:
     public: SetupPlan
     edits: tuple[ClientConfigEdit, ...]
+    install_manifest_original: bytes | None
+    install_manifest_mode: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,16 +166,22 @@ class SetupService:
         version: str | None,
     ) -> ResolvedSetupPlan:
         self._recover_interrupted()
+        manifest_original, manifest_mode = self._snapshot_file(self.install_manifest)
         if operation is SetupOperation.VERIFY:
-            executable = self._active_executable()
+            manifest = self._read_install_manifest()
             public = SetupPlan(
                 operation=operation,
-                version=self.inspect().active_version,
+                version=manifest.active_version if manifest else None,
                 runtime_action=RuntimeAction.NOT_REQUIRED,
-                runtime_executable=executable,
+                runtime_executable=manifest.executable if manifest else None,
                 clients=(),
             )
-            return ResolvedSetupPlan(public, ())
+            return ResolvedSetupPlan(
+                public,
+                (),
+                manifest_original,
+                manifest_mode,
+            )
         if not clients:
             raise DomainError(
                 ErrorCode.EXECUTION_REFUSED,
@@ -237,7 +245,12 @@ class SetupService:
                 else ()
             ),
         )
-        return ResolvedSetupPlan(public, edits)
+        return ResolvedSetupPlan(
+            public,
+            edits,
+            manifest_original,
+            manifest_mode,
+        )
 
     async def apply(self, plan: ResolvedSetupPlan) -> SetupReport:
         self.data_root.mkdir(parents=True, exist_ok=True)
@@ -270,6 +283,7 @@ class SetupService:
 
     async def _apply_locked(self, plan: ResolvedSetupPlan) -> SetupReport:
         public = plan.public
+        self._check_preflight(plan)
         if public.operation is SetupOperation.VERIFY:
             executable = public.runtime_executable
             if executable is None:
@@ -293,7 +307,6 @@ class SetupService:
         if public.version is not None:
             installation = await self.runtime.install(public.version)
 
-        self._check_preflight(plan.edits)
         changed = tuple(
             edit
             for edit in plan.edits
@@ -301,9 +314,7 @@ class SetupService:
             not in (ClientPlanAction.ALREADY_CURRENT, ClientPlanAction.NOT_CONFIGURED)
         )
         unchanged = tuple(edit.client for edit in plan.edits if edit not in changed)
-        manifest_original = (
-            self.install_manifest.read_bytes() if self.install_manifest.exists() else None
-        )
+        manifest_original = plan.install_manifest_original
         manifest_updated = (
             manifest_original
             if public.operation is SetupOperation.REMOVE
@@ -327,7 +338,7 @@ class SetupService:
                     self.install_manifest,
                     manifest_original,
                     manifest_updated,
-                    0o600,
+                    plan.install_manifest_mode,
                 )
             )
         if not mutations:
@@ -374,21 +385,18 @@ class SetupService:
         self,
         plan: SetupPlan,
     ) -> bytes:
-        current = self._read_install_manifest()
-        version = plan.version or (current.active_version if current else None)
-        executable = plan.runtime_executable or (current.executable if current else None)
-        if version is None or executable is None:
+        if plan.version is None or plan.runtime_executable is None:
             return b""
         manifest = _InstallManifest(
-            active_version=version,
-            executable=executable,
+            active_version=plan.version,
+            executable=plan.runtime_executable,
         )
         return (
             json.dumps(manifest.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
         ).encode()
 
-    def _check_preflight(self, edits: tuple[ClientConfigEdit, ...]) -> None:
-        for edit in edits:
+    def _check_preflight(self, plan: ResolvedSetupPlan) -> None:
+        for edit in plan.edits:
             current = edit.path.read_bytes() if edit.path.exists() else None
             current_mode = (
                 stat.S_IMODE(edit.path.stat().st_mode) if edit.path.exists() else 0o600
@@ -400,6 +408,31 @@ class SetupService:
                     retryable=True,
                     remediation=("Review the new configuration and run setup again.",),
                 )
+        manifest, manifest_mode = self._snapshot_file(self.install_manifest)
+        if (
+            manifest != plan.install_manifest_original
+            or manifest_mode != plan.install_manifest_mode
+        ):
+            raise DomainError(
+                ErrorCode.REVISION_CONFLICT,
+                "Flamo setup metadata changed after the setup preview.",
+                retryable=True,
+                remediation=("Review the active runtime and run setup again.",),
+            )
+
+    @staticmethod
+    def _snapshot_file(path: Path) -> tuple[bytes | None, int]:
+        try:
+            metadata = path.stat()
+            return path.read_bytes(), stat.S_IMODE(metadata.st_mode)
+        except FileNotFoundError:
+            return None, 0o600
+        except OSError as exc:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Could not inspect setup state: {path}",
+                details={"error": str(exc)},
+            ) from exc
 
     def _write_journal(self, edits: list[_FileMutation]) -> None:
         journal = _SetupJournal(
@@ -514,11 +547,6 @@ class SetupService:
                 details={"error": str(exc)},
             ) from exc
         return manifest
-
-    def _active_executable(self) -> Path | None:
-        manifest = self._read_install_manifest()
-        return manifest.executable if manifest else None
-
 
 def _unique_clients(clients: tuple[SetupClient, ...]) -> tuple[SetupClient, ...]:
     selected = set(clients)

--- a/src/flamo/application/setup.py
+++ b/src/flamo/application/setup.py
@@ -305,6 +305,16 @@ class SetupService:
 
         installation: RuntimeInstallation | None = None
         if public.version is not None:
+            if (
+                public.operation is SetupOperation.ROLLBACK
+                and public.version not in self.runtime.installed_versions()
+            ):
+                raise DomainError(
+                    ErrorCode.REVISION_CONFLICT,
+                    f"Rollback runtime {public.version} is no longer installed.",
+                    retryable=True,
+                    remediation=("Review installed versions and run setup again.",),
+                )
             installation = await self.runtime.install(public.version)
 
         changed = tuple(

--- a/src/flamo/application/setup.py
+++ b/src/flamo/application/setup.py
@@ -1,0 +1,512 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import stat
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal, Protocol
+
+import portalocker
+from platformdirs import user_data_path
+from pydantic import Field
+
+from flamo.adapters.client_setup import (
+    ALL_SETUP_CLIENTS,
+    ClientConfigEdit,
+    ClientConfigRegistry,
+    ClientPlanAction,
+    Launcher,
+    SetupClient,
+)
+from flamo.adapters.setup_runtime import ManagedRuntime, RuntimeInstallation
+from flamo.domain import DomainError, ErrorCode
+from flamo.models import ContractModel
+from flamo.storage.atomic import atomic_write_bytes, atomic_write_json, fsync_directory
+
+
+class RuntimeAction(StrEnum):
+    INSTALL = "install"
+    REUSE = "reuse"
+    NOT_REQUIRED = "not_required"
+
+
+class SetupOperation(StrEnum):
+    CONFIGURE = "configure"
+    REMOVE = "remove"
+    ROLLBACK = "rollback"
+    VERIFY = "verify"
+
+
+class ClientSetupPlan(ContractModel):
+    client: SetupClient
+    display_name: str
+    path: Path
+    action: ClientPlanAction
+    detected: bool
+
+
+class SetupPlan(ContractModel):
+    schema_version: Literal[1] = 1
+    operation: SetupOperation
+    version: str | None
+    runtime_action: RuntimeAction
+    runtime_executable: Path | None
+    clients: tuple[ClientSetupPlan, ...]
+    warnings: tuple[str, ...] = ()
+
+
+class SetupReport(ContractModel):
+    schema_version: Literal[1] = 1
+    operation: SetupOperation
+    version: str | None
+    runtime_installed: bool
+    changed_clients: tuple[SetupClient, ...]
+    unchanged_clients: tuple[SetupClient, ...]
+    verified: bool
+
+
+class SetupInspection(ContractModel):
+    schema_version: Literal[1] = 1
+    active_version: str | None
+    active_executable: Path | None
+    configured_clients: tuple[SetupClient, ...]
+    detected_clients: tuple[SetupClient, ...]
+    installed_versions: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSetupPlan:
+    public: SetupPlan
+    edits: tuple[ClientConfigEdit, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _FileMutation:
+    path: Path
+    original: bytes | None
+    updated: bytes
+    mode: int
+
+
+class _InstallManifest(ContractModel):
+    schema_version: Literal[1] = 1
+    active_version: str
+    executable: Path
+
+
+class _JournalMutation(ContractModel):
+    path: Path
+    original: str | None
+    original_sha256: str | None
+    updated_sha256: str
+    mode: int = Field(ge=0, le=0o777)
+
+
+class _SetupJournal(ContractModel):
+    schema_version: Literal[1] = 1
+    mutations: tuple[_JournalMutation, ...]
+
+
+class RuntimeManager(Protocol):
+    def executable(self, version: str) -> Path: ...
+
+    def installed_versions(self) -> tuple[str, ...]: ...
+
+    async def install(self, version: str) -> RuntimeInstallation: ...
+
+    async def verify(self, executable: Path, version: str) -> None: ...
+
+
+class SetupService:
+    """Plan and atomically activate one managed Flamo runtime for MCP clients."""
+
+    def __init__(
+        self,
+        *,
+        home: Path | None = None,
+        data_root: Path | None = None,
+        jsonc_helper: Path | None = None,
+        node_executable: str = "node",
+        uv_executable: str = "uv",
+        runtime: RuntimeManager | None = None,
+    ) -> None:
+        resolved_home = home or Path.home()
+        self.data_root = data_root or Path(user_data_path("flamo", appauthor=False))
+        self.registry = ClientConfigRegistry(
+            home=resolved_home,
+            jsonc_helper=jsonc_helper,
+            node_executable=node_executable,
+        )
+        self.runtime = runtime or ManagedRuntime(self.data_root, uv_executable=uv_executable)
+        self.install_manifest = self.data_root / "install.json"
+        self.journal_path = self.data_root / "setup-journal.json"
+        self.lock_path = self.data_root / "setup.lock"
+
+    def inspect(self) -> SetupInspection:
+        manifest = self._read_install_manifest()
+        return SetupInspection(
+            active_version=manifest.active_version if manifest else None,
+            active_executable=manifest.executable if manifest else None,
+            configured_clients=self.registry.configured_clients(),
+            detected_clients=self.registry.detected_clients(),
+            installed_versions=self.runtime.installed_versions(),
+        )
+
+    def plan(
+        self,
+        *,
+        operation: SetupOperation,
+        clients: tuple[SetupClient, ...],
+        version: str | None,
+    ) -> ResolvedSetupPlan:
+        if operation is SetupOperation.VERIFY:
+            executable = self._active_executable()
+            public = SetupPlan(
+                operation=operation,
+                version=self.inspect().active_version,
+                runtime_action=RuntimeAction.NOT_REQUIRED,
+                runtime_executable=executable,
+                clients=(),
+            )
+            return ResolvedSetupPlan(public, ())
+        if not clients:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "Select at least one MCP client.",
+            )
+
+        remove = operation is SetupOperation.REMOVE
+        if remove:
+            launcher = Launcher(command="", args=())
+            runtime_action = RuntimeAction.NOT_REQUIRED
+            executable = None
+            version = None
+        else:
+            if version is None:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    "A target runtime version is required.",
+                )
+            installed_versions = self.runtime.installed_versions()
+            if (
+                operation is SetupOperation.ROLLBACK
+                and version not in installed_versions
+            ):
+                raise DomainError(
+                    ErrorCode.CAPABILITY_UNAVAILABLE,
+                    f"Flamo {version} is not installed locally.",
+                )
+            executable = self.runtime.executable(version)
+            launcher = Launcher(
+                command=str(executable),
+                args=("mcp", "serve", "--project-root", "."),
+            )
+            runtime_action = (
+                RuntimeAction.REUSE
+                if version in installed_versions
+                else RuntimeAction.INSTALL
+            )
+
+        edits = tuple(
+            self.registry.plan(client, launcher, remove=remove)
+            for client in _unique_clients(clients)
+        )
+        public = SetupPlan(
+            operation=operation,
+            version=version,
+            runtime_action=runtime_action,
+            runtime_executable=executable,
+            clients=tuple(
+                ClientSetupPlan(
+                    client=edit.client,
+                    display_name=edit.client.display_name,
+                    path=edit.path,
+                    action=edit.action,
+                    detected=edit.detected,
+                )
+                for edit in edits
+            ),
+            warnings=(
+                ("Client detection is informational; only selected clients will change.",)
+                if any(not edit.detected for edit in edits)
+                else ()
+            ),
+        )
+        return ResolvedSetupPlan(public, edits)
+
+    async def apply(self, plan: ResolvedSetupPlan) -> SetupReport:
+        self.data_root.mkdir(parents=True, exist_ok=True)
+        try:
+            lock = portalocker.Lock(self.lock_path, mode="a", timeout=10)
+            with lock:
+                self._recover_locked()
+                return await self._apply_locked(plan)
+        except portalocker.exceptions.LockException as exc:
+            raise DomainError(
+                ErrorCode.WRITE_LOCK_TIMEOUT,
+                "Another Flamo setup operation holds the setup lock.",
+                retryable=True,
+            ) from exc
+
+    async def _apply_locked(self, plan: ResolvedSetupPlan) -> SetupReport:
+        public = plan.public
+        if public.operation is SetupOperation.VERIFY:
+            executable = public.runtime_executable
+            if executable is None:
+                raise DomainError(
+                    ErrorCode.CAPABILITY_UNAVAILABLE,
+                    "No active Flamo runtime is configured.",
+                    remediation=("Run `npx flamo setup` first.",),
+                )
+            assert public.version is not None
+            await self.runtime.verify(executable, public.version)
+            return SetupReport(
+                operation=public.operation,
+                version=public.version,
+                runtime_installed=False,
+                changed_clients=(),
+                unchanged_clients=(),
+                verified=True,
+            )
+
+        installation: RuntimeInstallation | None = None
+        if public.version is not None:
+            installation = await self.runtime.install(public.version)
+
+        self._check_preflight(plan.edits)
+        changed = tuple(
+            edit
+            for edit in plan.edits
+            if edit.action
+            not in (ClientPlanAction.ALREADY_CURRENT, ClientPlanAction.NOT_CONFIGURED)
+        )
+        unchanged = tuple(edit.client for edit in plan.edits if edit not in changed)
+        manifest_original = (
+            self.install_manifest.read_bytes() if self.install_manifest.exists() else None
+        )
+        manifest_updated = (
+            manifest_original
+            if public.operation is SetupOperation.REMOVE
+            else self._updated_install_manifest(public)
+        )
+        mutations = [
+            _FileMutation(edit.path, edit.original, edit.updated, edit.mode)
+            for edit in changed
+            if edit.updated is not None
+        ]
+        if (
+            manifest_updated is not None
+            and manifest_updated != manifest_original
+            and (
+                manifest_original is not None
+                or public.operation is not SetupOperation.REMOVE
+            )
+        ):
+            mutations.append(
+                _FileMutation(
+                    self.install_manifest,
+                    manifest_original,
+                    manifest_updated,
+                    0o600,
+                )
+            )
+        if not mutations:
+            return SetupReport(
+                operation=public.operation,
+                version=public.version,
+                runtime_installed=installation.installed if installation else False,
+                changed_clients=(),
+                unchanged_clients=unchanged,
+                verified=installation is not None,
+            )
+
+        self._write_journal(mutations)
+        try:
+            for mutation in mutations:
+                current = mutation.path.read_bytes() if mutation.path.exists() else None
+                if current != mutation.original:
+                    raise DomainError(
+                        ErrorCode.REVISION_CONFLICT,
+                        f"Configuration changed during setup: {mutation.path}",
+                        retryable=True,
+                        remediation=("Review the file and run setup again.",),
+                    )
+                atomic_write_bytes(
+                    mutation.path,
+                    mutation.updated,
+                    mode=mutation.mode,
+                )
+        except BaseException:
+            self._restore_mutations(mutations)
+            self._remove_journal()
+            raise
+        self._remove_journal()
+        return SetupReport(
+            operation=public.operation,
+            version=public.version,
+            runtime_installed=installation.installed if installation else False,
+            changed_clients=tuple(edit.client for edit in changed),
+            unchanged_clients=unchanged,
+            verified=installation is not None,
+        )
+
+    def _updated_install_manifest(
+        self,
+        plan: SetupPlan,
+    ) -> bytes:
+        current = self._read_install_manifest()
+        version = plan.version or (current.active_version if current else None)
+        executable = plan.runtime_executable or (current.executable if current else None)
+        if version is None or executable is None:
+            return b""
+        manifest = _InstallManifest(
+            active_version=version,
+            executable=executable,
+        )
+        return (
+            json.dumps(manifest.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+        ).encode()
+
+    def _check_preflight(self, edits: tuple[ClientConfigEdit, ...]) -> None:
+        for edit in edits:
+            current = edit.path.read_bytes() if edit.path.exists() else None
+            current_mode = (
+                stat.S_IMODE(edit.path.stat().st_mode) if edit.path.exists() else 0o600
+            )
+            if current != edit.original or current_mode != edit.mode:
+                raise DomainError(
+                    ErrorCode.REVISION_CONFLICT,
+                    f"Client configuration changed after the setup preview: {edit.path}",
+                    retryable=True,
+                    remediation=("Review the new configuration and run setup again.",),
+                )
+
+    def _write_journal(self, edits: list[_FileMutation]) -> None:
+        journal = _SetupJournal(
+            mutations=tuple(
+                _JournalMutation(
+                    path=edit.path,
+                    original=(
+                        base64.b64encode(edit.original).decode()
+                        if edit.original is not None
+                        else None
+                    ),
+                    original_sha256=_digest(edit.original),
+                    updated_sha256=hashlib.sha256(edit.updated).hexdigest(),
+                    mode=edit.mode,
+                )
+                for edit in edits
+            )
+        )
+        atomic_write_json(self.journal_path, journal.model_dump(mode="json"))
+
+    def _recover_locked(self) -> None:
+        if not self.journal_path.exists():
+            return
+        try:
+            journal = _SetupJournal.model_validate_json(self.journal_path.read_text())
+            allowed_paths = {
+                *self.registry.allowed_config_paths(),
+                self.install_manifest,
+            }
+            decoded: dict[Path, bytes | None] = {}
+            for mutation in journal.mutations:
+                path = mutation.path
+                if path not in allowed_paths:
+                    raise ValueError(f"journal contains an unexpected path: {path}")
+                original = (
+                    base64.b64decode(mutation.original, validate=True)
+                    if mutation.original is not None
+                    else None
+                )
+                if _digest(original) != mutation.original_sha256:
+                    raise ValueError(f"journal digest mismatch: {path}")
+                decoded[path] = original
+            for mutation in reversed(journal.mutations):
+                path = mutation.path
+                current = path.read_bytes() if path.exists() else None
+                original_digest = mutation.original_sha256
+                current_digest = _digest(current)
+                if current_digest == original_digest:
+                    continue
+                if current_digest != mutation.updated_sha256:
+                    raise ValueError(f"configuration changed after interruption: {path}")
+                original = decoded[path]
+                if original is None:
+                    path.unlink(missing_ok=True)
+                else:
+                    atomic_write_bytes(path, original, mode=mutation.mode)
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                "The interrupted setup journal could not be recovered safely.",
+                details={"path": str(self.journal_path), "error": str(exc)},
+                remediation=("Preserve the journal and repair the affected client configs.",),
+            ) from exc
+        self._remove_journal()
+
+    @staticmethod
+    def _restore_mutations(edits: list[_FileMutation]) -> None:
+        conflicts: list[Path] = []
+        for edit in reversed(edits):
+            current = edit.path.read_bytes() if edit.path.exists() else None
+            if current == edit.original:
+                continue
+            if current != edit.updated:
+                conflicts.append(edit.path)
+                continue
+            if edit.original is None:
+                edit.path.unlink(missing_ok=True)
+            else:
+                atomic_write_bytes(edit.path, edit.original, mode=edit.mode)
+        if conflicts:
+            raise DomainError(
+                ErrorCode.REVISION_CONFLICT,
+                "One or more configs changed during setup rollback.",
+                details={"paths": [str(path) for path in conflicts]},
+                remediation=("Preserve the setup journal and review the files manually.",),
+            )
+
+    def _remove_journal(self) -> None:
+        self.journal_path.unlink(missing_ok=True)
+        fsync_directory(self.journal_path.parent)
+
+    def _read_install_manifest(self) -> _InstallManifest | None:
+        if not self.install_manifest.exists():
+            return None
+        try:
+            manifest = _InstallManifest.model_validate_json(
+                self.install_manifest.read_text()
+            )
+            expected = self.runtime.executable(manifest.active_version)
+            if manifest.executable != expected:
+                raise ValueError("managed runtime path does not match its version")
+        except DomainError as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                f"Flamo setup metadata is invalid: {self.install_manifest}",
+                details={"error": exc.message},
+            ) from exc
+        except (OSError, ValueError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                f"Flamo setup metadata is invalid: {self.install_manifest}",
+                details={"error": str(exc)},
+            ) from exc
+        return manifest
+
+    def _active_executable(self) -> Path | None:
+        manifest = self._read_install_manifest()
+        return manifest.executable if manifest else None
+
+
+def _unique_clients(clients: tuple[SetupClient, ...]) -> tuple[SetupClient, ...]:
+    selected = set(clients)
+    return tuple(client for client in ALL_SETUP_CLIENTS if client in selected)
+
+
+def _digest(value: bytes | None) -> str | None:
+    return hashlib.sha256(value).hexdigest() if value is not None else None

--- a/src/flamo/cli.py
+++ b/src/flamo/cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import sys
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -13,7 +15,7 @@ import typer
 from mcp import Client
 from pydantic import BaseModel
 
-from flamo import __version__
+from flamo import __version__, setup_ui
 from flamo.adapters import (
     AdapterRegistry,
     CoverageExtractor,
@@ -21,6 +23,7 @@ from flamo.adapters import (
     ObservationExtractor,
     PerfettoExtractor,
     PyPerfExtractor,
+    SetupClient,
 )
 from flamo.analysis import RecipeService
 from flamo.application import (
@@ -53,6 +56,8 @@ from flamo.application import (
     RepairPlan,
     RepairService,
     RunSetService,
+    SetupOperation,
+    SetupService,
     WorkloadService,
     workspace_status,
 )
@@ -301,6 +306,189 @@ def initialize(
     except DomainError as error:
         _fail(error)
     _emit(result, as_json=json_output)
+
+
+@app.command("setup")
+def setup(
+    claude: Annotated[bool, typer.Option("--claude", help="Configure Claude Code.")] = False,
+    cursor: Annotated[bool, typer.Option("--cursor", help="Configure Cursor.")] = False,
+    opencode: Annotated[bool, typer.Option("--opencode", help="Configure OpenCode.")] = False,
+    codex: Annotated[bool, typer.Option("--codex", help="Configure Codex.")] = False,
+    gemini: Annotated[bool, typer.Option("--gemini", help="Configure Gemini CLI.")] = False,
+    antigravity: Annotated[
+        bool,
+        typer.Option("--antigravity", help="Configure Antigravity."),
+    ] = False,
+    all_clients: Annotated[
+        bool,
+        typer.Option("--all", help="Select every supported MCP client."),
+    ] = False,
+    refresh: Annotated[
+        bool,
+        typer.Option("--refresh", help="Select every currently detected MCP client."),
+    ] = False,
+    remove: Annotated[
+        bool,
+        typer.Option("--remove", help="Remove Flamo from the selected MCP clients."),
+    ] = False,
+    rollback: Annotated[
+        str | None,
+        typer.Option("--rollback", metavar="VERSION", help="Activate an installed version."),
+    ] = None,
+    verify: Annotated[
+        bool,
+        typer.Option("--verify", help="Verify the active MCP runtime without changing configs."),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Apply an explicit plan without confirmation."),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Print the exact plan without making changes."),
+    ] = False,
+    json_output: JsonOption = False,
+) -> None:
+    """Install a managed runtime and connect local MCP clients."""
+    service = SetupService(
+        home=Path(os.environ["FLAMO_SETUP_HOME"])
+        if "FLAMO_SETUP_HOME" in os.environ
+        else None,
+        data_root=Path(os.environ["FLAMO_SETUP_DATA_ROOT"])
+        if "FLAMO_SETUP_DATA_ROOT" in os.environ
+        else None,
+        jsonc_helper=Path(os.environ["FLAMO_SETUP_JSONC_HELPER"])
+        if "FLAMO_SETUP_JSONC_HELPER" in os.environ
+        else None,
+        node_executable=os.environ.get("FLAMO_SETUP_NODE", "node"),
+        uv_executable=os.environ.get("FLAMO_SETUP_UV", "uv"),
+    )
+    inspection = service.inspect()
+    explicit_clients = setup_ui.selected_clients(
+        (
+            (SetupClient.CLAUDE, claude),
+            (SetupClient.CURSOR, cursor),
+            (SetupClient.OPENCODE, opencode),
+            (SetupClient.CODEX, codex),
+            (SetupClient.GEMINI, gemini),
+            (SetupClient.ANTIGRAVITY, antigravity),
+        )
+    )
+    action_count = sum((remove, rollback is not None, verify))
+    if action_count > 1:
+        _fail(
+            DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "Choose only one of --remove, --rollback, or --verify.",
+            )
+        )
+    explicit_selection = bool(explicit_clients or all_clients or refresh)
+    if sum((bool(explicit_clients), all_clients, refresh)) > 1:
+        _fail(
+            DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "Choose client flags, --all, or --refresh; do not combine them.",
+            )
+        )
+    if verify and explicit_selection:
+        _fail(
+            DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "--verify does not accept client selections.",
+            )
+        )
+    if yes and not (explicit_selection or rollback is not None or verify):
+        _fail(
+            DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "--yes requires explicit clients, --all, --refresh, --rollback, or --verify.",
+            )
+        )
+
+    operation = (
+        SetupOperation.VERIFY
+        if verify
+        else SetupOperation.ROLLBACK
+        if rollback is not None
+        else SetupOperation.REMOVE
+        if remove
+        else SetupOperation.CONFIGURE
+    )
+    version: str | None = rollback if rollback is not None else __version__
+    clients = explicit_clients
+    if all_clients:
+        clients = tuple(SetupClient)
+    elif refresh:
+        clients = inspection.detected_clients
+
+    interactive = not (
+        explicit_selection
+        or rollback is not None
+        or verify
+        or dry_run
+        or json_output
+        or _cli_defaults().json_output
+        or yes
+    )
+    try:
+        if interactive:
+            if not sys.stdin.isatty():
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    "Interactive setup requires a terminal.",
+                    remediation=("Select clients explicitly and pass --yes or --dry-run.",),
+                )
+            setup_ui.print_banner(inspection)
+            if remove:
+                action = SetupOperation.REMOVE.value
+            elif inspection.active_version is None:
+                action = SetupOperation.CONFIGURE.value
+            else:
+                action = setup_ui.choose_action(inspection, __version__)
+            if action == "exit":
+                raise typer.Exit
+            if action == "update":
+                operation = SetupOperation.CONFIGURE
+                clients = inspection.configured_clients
+            else:
+                operation = SetupOperation(action)
+            if operation is SetupOperation.VERIFY:
+                clients = ()
+            elif operation is SetupOperation.ROLLBACK:
+                version = setup_ui.choose_rollback_version(
+                    inspection, inspection.active_version
+                )
+                clients = inspection.configured_clients
+            elif action != "update":
+                clients = setup_ui.choose_clients(
+                    inspection,
+                    remove=operation is SetupOperation.REMOVE,
+                )
+                version = None if operation is SetupOperation.REMOVE else __version__
+        elif operation is SetupOperation.ROLLBACK:
+            clients = clients or inspection.configured_clients
+
+        resolved = service.plan(operation=operation, clients=clients, version=version)
+        if dry_run:
+            _emit(resolved.public, as_json=json_output)
+            return
+        if json_output or _cli_defaults().json_output:
+            if not yes:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    "JSON setup requires --yes or --dry-run.",
+                )
+        elif not yes:
+            setup_ui.print_plan(resolved.public)
+            if not setup_ui.confirm_apply():
+                raise DomainError(ErrorCode.PROCESS_CANCELLED, "Setup cancelled.")
+        report = _run_async(lambda: service.apply(resolved))
+    except DomainError as error:
+        _fail(error)
+    if json_output or _cli_defaults().json_output:
+        _emit(report, as_json=True)
+    else:
+        setup_ui.print_report(report)
 
 
 @app.command("status")

--- a/src/flamo/cli.py
+++ b/src/flamo/cli.py
@@ -363,7 +363,10 @@ def setup(
         node_executable=os.environ.get("FLAMO_SETUP_NODE", "node"),
         uv_executable=os.environ.get("FLAMO_SETUP_UV", "uv"),
     )
-    inspection = service.inspect()
+    try:
+        inspection = service.inspect()
+    except DomainError as error:
+        _fail(error)
     explicit_clients = setup_ui.selected_clients(
         (
             (SetupClient.CLAUDE, claude),

--- a/src/flamo/setup_ui.py
+++ b/src/flamo/setup_ui.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import cast
+
+import questionary
+import typer
+from questionary import Choice
+
+from flamo.adapters.client_setup import ALL_SETUP_CLIENTS, SetupClient
+from flamo.application.setup import SetupInspection, SetupPlan, SetupReport
+from flamo.domain import DomainError, ErrorCode
+
+
+def print_banner(inspection: SetupInspection) -> None:
+    typer.echo()
+    typer.secho("  Flamo setup", bold=True)
+    typer.echo("  Connect local coding agents to a versioned Flamo MCP runtime.")
+    typer.echo()
+    if inspection.active_version is not None:
+        clients = ", ".join(client.display_name for client in inspection.configured_clients)
+        typer.echo(f"  Active runtime: {inspection.active_version}")
+        typer.echo(f"  Connected: {clients or 'none'}")
+        typer.echo()
+
+
+def choose_action(inspection: SetupInspection, target_version: str) -> str:
+    choices: list[Choice] = []
+    if (
+        inspection.active_version is not None
+        and inspection.active_version != target_version
+        and inspection.configured_clients
+    ):
+        choices.append(Choice(f"Update Flamo to {target_version}", "update"))
+    choices.extend(
+        (
+            Choice("Connect or update MCP clients", "configure"),
+            Choice("Disconnect MCP clients", "remove"),
+            Choice("Verify the active MCP runtime", "verify"),
+        )
+    )
+    if len(inspection.installed_versions) > 1 and inspection.configured_clients:
+        choices.append(Choice("Roll back to an installed version", "rollback"))
+    choices.append(Choice("Exit", "exit"))
+    answer = questionary.select("What would you like to do?", choices=choices).ask()
+    return cast(str, _answer(answer))
+
+
+def choose_clients(
+    inspection: SetupInspection,
+    *,
+    remove: bool,
+) -> tuple[SetupClient, ...]:
+    selected = set(inspection.configured_clients if remove else ())
+    detected = set(inspection.detected_clients)
+    choices = [
+        Choice(
+            title=_client_label(client, detected=client in detected),
+            value=client,
+            checked=client in selected,
+        )
+        for client in ALL_SETUP_CLIENTS
+    ]
+    answer = questionary.checkbox(
+        "Select MCP clients to disconnect:" if remove else "Select MCP clients to connect:",
+        choices=choices,
+    ).ask()
+    values = _answer(answer)
+    return tuple(client for client in ALL_SETUP_CLIENTS if client in values)
+
+
+def choose_rollback_version(
+    inspection: SetupInspection,
+    current_version: str | None,
+) -> str:
+    choices = [
+        version for version in inspection.installed_versions if version != current_version
+    ]
+    answer = questionary.select("Select an installed runtime:", choices=choices).ask()
+    return str(_answer(answer))
+
+
+def print_plan(plan: SetupPlan) -> None:
+    typer.echo()
+    typer.secho("Planned changes", bold=True)
+    if plan.runtime_executable is not None:
+        typer.echo(f"  Runtime: {plan.runtime_action.value} {plan.version}")
+        typer.echo(f"  Launcher: {plan.runtime_executable}")
+    for client in plan.clients:
+        detected = "" if client.detected else " (not detected)"
+        typer.echo(
+            f"  {client.display_name}: {client.action.value} {client.path}{detected}"
+        )
+    for warning in plan.warnings:
+        typer.secho(f"  Warning: {warning}", fg=typer.colors.YELLOW)
+    typer.echo()
+
+
+def confirm_apply() -> bool:
+    answer = questionary.confirm("Apply these changes?", default=False).ask()
+    return bool(_answer(answer))
+
+
+def print_report(report: SetupReport) -> None:
+    typer.echo()
+    if report.operation.value == "verify":
+        typer.secho("Flamo MCP runtime verified.", fg=typer.colors.GREEN)
+        return
+    changed = ", ".join(client.display_name for client in report.changed_clients)
+    if changed:
+        verb = "Disconnected" if report.operation.value == "remove" else "Updated"
+        typer.secho(f"{verb}: {changed}", fg=typer.colors.GREEN)
+    else:
+        typer.secho("Everything is already current.", fg=typer.colors.GREEN)
+    typer.echo("Restart connected clients so they reload their MCP configuration.")
+
+
+def _client_label(client: SetupClient, *, detected: bool) -> str:
+    return f"{client.display_name}{'  detected' if detected else ''}"
+
+
+def _answer[T](value: T | None) -> T:
+    if value is None:
+        raise DomainError(ErrorCode.PROCESS_CANCELLED, "Setup cancelled.")
+    return value
+
+
+def selected_clients(flags: Iterable[tuple[SetupClient, bool]]) -> tuple[SetupClient, ...]:
+    selected = {client for client, enabled in flags if enabled}
+    return tuple(client for client in ALL_SETUP_CLIENTS if client in selected)

--- a/tests/adapters/test_setup_runtime.py
+++ b/tests/adapters/test_setup_runtime.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from flamo.adapters import ManagedRuntime
+
+
+class RecordingRuntime(ManagedRuntime):
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.verified: list[Path] = []
+
+    async def verify(self, executable: Path, version: str) -> None:
+        assert executable == self.executable(version)
+        self.verified.append(executable)
+
+
+@pytest.mark.anyio
+async def test_runtime_install_uses_an_exact_isolated_uv_tool_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = RecordingRuntime(tmp_path)
+    recorded_command: list[str] = []
+    recorded_environment: dict[str, str] = {}
+
+    def install(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        recorded_command.extend(command)
+        environment = kwargs["env"]
+        assert isinstance(environment, dict)
+        recorded_environment.update(environment)
+        bin_directory = Path(environment["UV_TOOL_BIN_DIR"])
+        bin_directory.mkdir(parents=True)
+        (bin_directory / ("flamo.exe" if os.name == "nt" else "flamo")).write_text("")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", install)
+
+    result = await runtime.install("0.1.0")
+
+    assert recorded_command == [
+        "uv",
+        "tool",
+        "install",
+        "--force",
+        "--no-config",
+        "--no-sources",
+        "--python",
+        "3.12",
+        "flamo-diagnostics==0.1.0",
+    ]
+    assert recorded_environment["UV_TOOL_DIR"] == str(
+        tmp_path / "runtimes" / "0.1.0" / "tools"
+    )
+    assert result.installed is True
+    assert runtime.verified == [result.executable]
+    assert runtime.installed_versions() == ("0.1.0",)
+
+
+def test_installed_version_discovery_ignores_unmanaged_directories(tmp_path: Path) -> None:
+    unmanaged = tmp_path / "runtimes" / "not-a-version"
+    unmanaged.mkdir(parents=True)
+    (unmanaged / "runtime.json").write_text("{}")
+
+    assert ManagedRuntime(tmp_path).installed_versions() == ()

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -114,6 +114,37 @@ async def test_setup_refuses_config_changed_after_preview(tmp_path: Path) -> Non
 
 
 @pytest.mark.anyio
+async def test_setup_refuses_stale_plan_after_active_runtime_changes(
+    tmp_path: Path,
+) -> None:
+    service, runtime, home = make_service(tmp_path)
+    competing = SetupService(
+        home=home,
+        data_root=service.data_root,
+        runtime=runtime,
+    )
+    first = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE,),
+        version="0.1.0",
+    )
+    stale = competing.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.GEMINI,),
+        version="0.2.0",
+    )
+
+    await service.apply(first)
+    with pytest.raises(DomainError) as caught:
+        await competing.apply(stale)
+
+    assert caught.value.code is ErrorCode.REVISION_CONFLICT
+    assert service.inspect().active_version == "0.1.0"
+    assert "0.2.0" not in runtime.versions
+    assert not (home / ".gemini" / "settings.json").exists()
+
+
+@pytest.mark.anyio
 async def test_setup_recovers_interrupted_config_transaction(tmp_path: Path) -> None:
     service, _, home = make_service(tmp_path)
     config = home / ".claude.json"

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -150,6 +150,53 @@ async def test_setup_recovers_interrupted_config_transaction(tmp_path: Path) -> 
     assert not service.journal_path.exists()
 
 
+def test_setup_recovers_interrupted_transaction_before_planning(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    config = home / ".claude.json"
+    original = b'{"mcpServers": {}}\n'
+    staged = (
+        json.dumps(
+            {
+                "mcpServers": {
+                    "flamo": {
+                        "command": str(runtime.executable("0.1.0")),
+                        "args": ["mcp", "serve", "--project-root", "."],
+                    }
+                }
+            }
+        )
+        + "\n"
+    ).encode()
+    config.write_bytes(staged)
+    service.data_root.mkdir(parents=True)
+    atomic_write_json(
+        service.journal_path,
+        {
+            "schema_version": 1,
+            "mutations": [
+                {
+                    "path": str(config),
+                    "original": base64.b64encode(original).decode(),
+                    "original_sha256": hashlib.sha256(original).hexdigest(),
+                    "updated_sha256": hashlib.sha256(staged).hexdigest(),
+                    "mode": 0o600,
+                }
+            ],
+        },
+    )
+
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE,),
+        version="0.1.0",
+    )
+
+    assert plan.edits[0].action.value == "update"
+    assert plan.edits[0].original == original
+    assert config.read_bytes() == original
+    assert not service.journal_path.exists()
+
+
 def test_codex_toml_edit_preserves_comments(tmp_path: Path) -> None:
     service, _, home = make_service(tmp_path)
     config = home / ".codex" / "config.toml"
@@ -330,8 +377,7 @@ async def test_rollback_repoints_clients_to_an_installed_runtime(tmp_path: Path)
     assert service.inspect().active_version == "0.0.9"
 
 
-@pytest.mark.anyio
-async def test_recovery_refuses_to_overwrite_a_post_crash_user_edit(
+def test_recovery_refuses_to_overwrite_a_post_crash_user_edit(
     tmp_path: Path,
 ) -> None:
     service, _, home = make_service(tmp_path)
@@ -356,14 +402,12 @@ async def test_recovery_refuses_to_overwrite_a_post_crash_user_edit(
             ],
         },
     )
-    plan = service.plan(
-        operation=SetupOperation.VERIFY,
-        clients=(),
-        version=None,
-    )
-
     with pytest.raises(DomainError) as caught:
-        await service.apply(plan)
+        service.plan(
+            operation=SetupOperation.VERIFY,
+            clients=(),
+            version=None,
+        )
 
     assert caught.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
     assert config.read_bytes() == user_edit

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -408,6 +408,29 @@ async def test_rollback_repoints_clients_to_an_installed_runtime(tmp_path: Path)
     assert service.inspect().active_version == "0.0.9"
 
 
+@pytest.mark.anyio
+async def test_rollback_refuses_target_removed_after_preview(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    runtime.versions.add("0.0.9")
+    config = home / ".claude.json"
+    config.write_text('{"mcpServers":{"flamo":{"command":"old"}}}\n')
+    plan = service.plan(
+        operation=SetupOperation.ROLLBACK,
+        clients=(SetupClient.CLAUDE,),
+        version="0.0.9",
+    )
+    runtime.versions.remove("0.0.9")
+
+    with pytest.raises(DomainError) as caught:
+        await service.apply(plan)
+
+    assert caught.value.code is ErrorCode.REVISION_CONFLICT
+    assert runtime.versions == set()
+    assert json.loads(config.read_text())["mcpServers"]["flamo"] == {
+        "command": "old"
+    }
+
+
 def test_recovery_refuses_to_overwrite_a_post_crash_user_edit(
     tmp_path: Path,
 ) -> None:

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -213,6 +213,30 @@ def test_direct_python_setup_refuses_to_overwrite_jsonc_without_helper(
     assert config.read_text().startswith("{\n  // user note")
 
 
+def test_jsonc_helper_does_not_relax_standard_json_clients(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+    home.mkdir()
+    config = home / ".claude.json"
+    config.write_text('{\n  // invalid for Claude\n  "mcpServers": {}\n}\n')
+    service = SetupService(
+        home=home,
+        data_root=data,
+        jsonc_helper=tmp_path / "helper-that-must-not-run.cjs",
+        runtime=FakeRuntime(data),
+    )
+
+    with pytest.raises(DomainError) as caught:
+        service.plan(
+            operation=SetupOperation.CONFIGURE,
+            clients=(SetupClient.CLAUDE,),
+            version="0.1.0",
+        )
+
+    assert caught.value.code is ErrorCode.EXECUTION_REFUSED
+    assert config.read_text().startswith("{\n  // invalid for Claude")
+
+
 @pytest.mark.anyio
 async def test_setup_restores_every_config_after_partial_write(
     tmp_path: Path,

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from flamo.adapters import RuntimeInstallation, SetupClient
+from flamo.application import SetupOperation, SetupService
+from flamo.domain import DomainError, ErrorCode
+from flamo.storage.atomic import atomic_write_bytes, atomic_write_json
+
+
+class FakeRuntime:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.versions: set[str] = set()
+        self.verified: list[Path] = []
+
+    def executable(self, version: str) -> Path:
+        return self.root / "runtimes" / version / "bin" / "flamo"
+
+    def installed_versions(self) -> tuple[str, ...]:
+        return tuple(sorted(self.versions, reverse=True))
+
+    async def install(self, version: str) -> RuntimeInstallation:
+        executable = self.executable(version)
+        installed = version not in self.versions
+        self.versions.add(version)
+        self.verified.append(executable)
+        return RuntimeInstallation(version, executable, installed)
+
+    async def verify(self, executable: Path, version: str) -> None:
+        assert executable == self.executable(version)
+        self.verified.append(executable)
+
+
+def make_service(tmp_path: Path) -> tuple[SetupService, FakeRuntime, Path]:
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+    home.mkdir()
+    runtime = FakeRuntime(data)
+    return SetupService(home=home, data_root=data, runtime=runtime), runtime, home
+
+
+@pytest.mark.anyio
+async def test_setup_connects_only_explicitly_selected_clients(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    (home / ".claude").mkdir()
+    (home / ".cursor").mkdir()
+
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE,),
+        version="0.1.0",
+    )
+    report = await service.apply(plan)
+
+    configured = json.loads((home / ".claude.json").read_text())
+    assert configured["mcpServers"]["flamo"] == {
+        "command": str(runtime.executable("0.1.0")),
+        "args": ["mcp", "serve", "--project-root", "."],
+    }
+    assert not (home / ".cursor" / "mcp.json").exists()
+    assert report.changed_clients == (SetupClient.CLAUDE,)
+
+
+@pytest.mark.anyio
+async def test_setup_is_idempotent_and_preserves_unrelated_json(tmp_path: Path) -> None:
+    service, _, home = make_service(tmp_path)
+    config = home / ".gemini" / "settings.json"
+    config.parent.mkdir()
+    config.write_text('{"theme": "dark", "mcpServers": {"other": {"command": "x"}}}\n')
+
+    first = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.GEMINI,),
+        version="0.1.0",
+    )
+    await service.apply(first)
+    second = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.GEMINI,),
+        version="0.1.0",
+    )
+    report = await service.apply(second)
+
+    configured = json.loads(config.read_text())
+    assert configured["theme"] == "dark"
+    assert configured["mcpServers"]["other"] == {"command": "x"}
+    assert report.changed_clients == ()
+    assert report.unchanged_clients == (SetupClient.GEMINI,)
+
+
+@pytest.mark.anyio
+async def test_setup_refuses_config_changed_after_preview(tmp_path: Path) -> None:
+    service, _, home = make_service(tmp_path)
+    config = home / ".claude.json"
+    config.write_text("{}\n")
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE,),
+        version="0.1.0",
+    )
+    config.write_text('{"new": true}\n')
+
+    with pytest.raises(DomainError) as caught:
+        await service.apply(plan)
+
+    assert caught.value.code is ErrorCode.REVISION_CONFLICT
+    assert json.loads(config.read_text()) == {"new": True}
+
+
+@pytest.mark.anyio
+async def test_setup_recovers_interrupted_config_transaction(tmp_path: Path) -> None:
+    service, _, home = make_service(tmp_path)
+    config = home / ".claude.json"
+    config.write_text('{"before": true}\n')
+    original = config.read_bytes()
+    config.write_text('{"partial": true}\n')
+    service.data_root.mkdir(parents=True)
+    atomic_write_json(
+        service.journal_path,
+        {
+            "schema_version": 1,
+            "mutations": [
+                {
+                    "path": str(config),
+                    "original": "eyJiZWZvcmUiOiB0cnVlfQo=",
+                    "original_sha256": hashlib.sha256(original).hexdigest(),
+                    "updated_sha256": hashlib.sha256(config.read_bytes()).hexdigest(),
+                    "mode": 0o600,
+                }
+            ],
+        },
+    )
+
+    plan = service.plan(
+        operation=SetupOperation.VERIFY,
+        clients=(),
+        version=None,
+    )
+    with pytest.raises(DomainError) as caught:
+        await service.apply(plan)
+
+    assert caught.value.code is ErrorCode.CAPABILITY_UNAVAILABLE
+    assert config.read_bytes() == original
+    assert not service.journal_path.exists()
+
+
+def test_codex_toml_edit_preserves_comments(tmp_path: Path) -> None:
+    service, _, home = make_service(tmp_path)
+    config = home / ".codex" / "config.toml"
+    config.parent.mkdir()
+    config.write_text('# keep this note\nmodel = "gpt-5"\n')
+
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CODEX,),
+        version="0.1.0",
+    )
+
+    assert plan.edits[0].updated is not None
+    updated = plan.edits[0].updated.decode()
+    assert "# keep this note" in updated
+    assert "[mcp_servers.flamo]" in updated
+
+
+def test_opencode_uses_its_native_local_server_shape(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    (home / ".config" / "opencode").mkdir(parents=True)
+
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.OPENCODE,),
+        version="0.1.0",
+    )
+
+    assert plan.edits[0].updated is not None
+    configured = json.loads(plan.edits[0].updated)
+    assert configured["mcp"]["flamo"] == {
+        "type": "local",
+        "command": [
+            str(runtime.executable("0.1.0")),
+            "mcp",
+            "serve",
+            "--project-root",
+            ".",
+        ],
+        "cwd": ".",
+        "enabled": True,
+    }
+
+
+def test_direct_python_setup_refuses_to_overwrite_jsonc_without_helper(
+    tmp_path: Path,
+) -> None:
+    service, _, home = make_service(tmp_path)
+    config = home / ".config" / "opencode" / "opencode.jsonc"
+    config.parent.mkdir(parents=True)
+    config.write_text("{\n  // user note\n  \"mcp\": {}\n}\n")
+
+    with pytest.raises(DomainError) as caught:
+        service.plan(
+            operation=SetupOperation.CONFIGURE,
+            clients=(SetupClient.OPENCODE,),
+            version="0.1.0",
+        )
+
+    assert caught.value.code is ErrorCode.CAPABILITY_UNAVAILABLE
+    assert config.read_text().startswith("{\n  // user note")
+
+
+@pytest.mark.anyio
+async def test_setup_restores_every_config_after_partial_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, _, home = make_service(tmp_path)
+    claude = home / ".claude.json"
+    gemini = home / ".gemini" / "settings.json"
+    claude.write_text('{"before": "claude"}\n')
+    gemini.parent.mkdir()
+    gemini.write_text('{"before": "gemini"}\n')
+    originals = {claude: claude.read_bytes(), gemini: gemini.read_bytes()}
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE, SetupClient.GEMINI),
+        version="0.1.0",
+    )
+    real_atomic_write = atomic_write_bytes
+    calls = 0
+
+    def fail_second_write(path: Path, payload: bytes, *, mode: int = 0o600) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("injected write failure")
+        real_atomic_write(path, payload, mode=mode)
+
+    monkeypatch.setattr("flamo.application.setup.atomic_write_bytes", fail_second_write)
+
+    with pytest.raises(OSError, match="injected write failure"):
+        await service.apply(plan)
+
+    assert claude.read_bytes() == originals[claude]
+    assert gemini.read_bytes() == originals[gemini]
+    assert not service.install_manifest.exists()
+    assert not service.journal_path.exists()
+
+
+@pytest.mark.anyio
+async def test_remove_preserves_other_mcp_servers(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    config = home / ".claude.json"
+    config.write_text(
+        '{"mcpServers":{"other":{"command":"other"},"flamo":{"command":"old"}}}\n'
+    )
+    plan = service.plan(
+        operation=SetupOperation.REMOVE,
+        clients=(SetupClient.CLAUDE,),
+        version=None,
+    )
+
+    report = await service.apply(plan)
+
+    assert json.loads(config.read_text()) == {
+        "mcpServers": {"other": {"command": "other"}}
+    }
+    assert report.changed_clients == (SetupClient.CLAUDE,)
+    assert runtime.verified == []
+    assert not service.install_manifest.exists()
+
+
+@pytest.mark.anyio
+async def test_rollback_repoints_clients_to_an_installed_runtime(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    runtime.versions.add("0.0.9")
+    config = home / ".claude.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "flamo": {
+                        "command": str(runtime.executable("0.1.0")),
+                        "args": ["mcp", "serve", "--project-root", "."],
+                    }
+                }
+            }
+        )
+    )
+    plan = service.plan(
+        operation=SetupOperation.ROLLBACK,
+        clients=(SetupClient.CLAUDE,),
+        version="0.0.9",
+    )
+
+    await service.apply(plan)
+
+    configured = json.loads(config.read_text())
+    assert configured["mcpServers"]["flamo"]["command"] == str(
+        runtime.executable("0.0.9")
+    )
+    assert service.inspect().active_version == "0.0.9"
+
+
+@pytest.mark.anyio
+async def test_recovery_refuses_to_overwrite_a_post_crash_user_edit(
+    tmp_path: Path,
+) -> None:
+    service, _, home = make_service(tmp_path)
+    config = home / ".claude.json"
+    original = b'{"state": "original"}\n'
+    staged = b'{"state": "staged"}\n'
+    user_edit = b'{"state": "user-edit"}\n'
+    config.write_bytes(user_edit)
+    service.data_root.mkdir(parents=True)
+    atomic_write_json(
+        service.journal_path,
+        {
+            "schema_version": 1,
+            "mutations": [
+                {
+                    "path": str(config),
+                    "original": base64.b64encode(original).decode(),
+                    "original_sha256": hashlib.sha256(original).hexdigest(),
+                    "updated_sha256": hashlib.sha256(staged).hexdigest(),
+                    "mode": 0o600,
+                }
+            ],
+        },
+    )
+    plan = service.plan(
+        operation=SetupOperation.VERIFY,
+        clients=(),
+        version=None,
+    )
+
+    with pytest.raises(DomainError) as caught:
+        await service.apply(plan)
+
+    assert caught.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+    assert config.read_bytes() == user_edit
+    assert service.journal_path.exists()

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -36,3 +36,21 @@ def test_setup_yes_requires_an_explicit_target(
 
     assert result.exit_code == 9
     assert "--yes requires explicit clients" in result.output
+
+
+def test_setup_reports_corrupt_install_metadata_as_a_domain_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "install.json").write_text("{broken")
+    monkeypatch.setenv("FLAMO_SETUP_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("FLAMO_SETUP_DATA_ROOT", str(data))
+
+    result = CliRunner().invoke(app, ["setup", "--verify", "--yes"])
+
+    assert result.exit_code == 5
+    assert "ARTIFACT_INTEGRITY_FAILED" in result.output
+    assert "Traceback" not in result.output
+    assert result.exception is not None

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from flamo.cli import app
+
+
+def test_setup_dry_run_emits_machine_readable_exact_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FLAMO_SETUP_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("FLAMO_SETUP_DATA_ROOT", str(tmp_path / "data"))
+
+    result = CliRunner().invoke(app, ["setup", "--claude", "--dry-run", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["operation"] == "configure"
+    assert payload["clients"][0]["client"] == "claude"
+    assert payload["clients"][0]["action"] == "create"
+    assert not (tmp_path / "home" / ".claude.json").exists()
+
+
+def test_setup_yes_requires_an_explicit_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FLAMO_SETUP_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("FLAMO_SETUP_DATA_ROOT", str(tmp_path / "data"))
+
+    result = CliRunner().invoke(app, ["setup", "--yes"])
+
+    assert result.exit_code == 9
+    assert "--yes requires explicit clients" in result.output

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from flamo import __version__
+
+
+def test_npm_bootstrap_matches_python_release_version() -> None:
+    package = json.loads(
+        (Path(__file__).parents[1] / "npm" / "package.json").read_text()
+    )
+
+    assert package["version"] == __version__

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 ]
 
 [[package]]
-name = "flamo"
+name = "flamo-diagnostics"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
@@ -443,12 +443,15 @@ dependencies = [
     { name = "mcp-types" },
     { name = "numpy" },
     { name = "packaging" },
+    { name = "platformdirs" },
     { name = "portalocker" },
     { name = "pyarrow" },
     { name = "pydantic" },
+    { name = "questionary" },
     { name = "scipy" },
     { name = "statsmodels" },
     { name = "tomli-w" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -505,6 +508,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=24,<27" },
     { name = "perfetto", marker = "extra == 'all'", specifier = ">=0.57,<0.58" },
     { name = "perfetto", marker = "extra == 'trace'", specifier = ">=0.57,<0.58" },
+    { name = "platformdirs", specifier = ">=4.3,<5" },
     { name = "portalocker", specifier = ">=3.2,<4" },
     { name = "py-spy", marker = "extra == 'all'", specifier = ">=0.4.2,<0.5" },
     { name = "py-spy", marker = "extra == 'cpu'", specifier = ">=0.4.2,<0.5" },
@@ -515,11 +519,13 @@ requires-dist = [
     { name = "pyperf", marker = "extra == 'python'", specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1" },
+    { name = "questionary", specifier = ">=2.1,<3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
     { name = "scipy", specifier = ">=1.15,<2" },
     { name = "scipy-stubs", marker = "extra == 'dev'", specifier = ">=1.18.0.1,<1.19" },
     { name = "statsmodels", specifier = ">=0.14,<1" },
     { name = "tomli-w", specifier = ">=1.2,<2" },
+    { name = "tomlkit", specifier = ">=0.13,<1" },
     { name = "torch", marker = "extra == 'all'", specifier = ">=2.7" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.7" },
     { name = "typer", specifier = ">=0.16,<1" },
@@ -1370,6 +1376,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1700,6 +1718,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
     { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
     { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -2047,6 +2077,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2174,4 +2213,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]


### PR DESCRIPTION
## Summary

Add a guided `npx flamo setup` flow that installs a verified, versioned local runtime and connects explicitly selected MCP clients.

The npm package acts only as a bootstrap:

```text
npx flamo setup
  -> uvx flamo-diagnostics==<matching version>
  -> install and verify a managed runtime
  -> atomically update selected client configs
  -> launch that managed executable directly from each client
```

The wizard supports Claude Code, Cursor, OpenCode, Codex, Gemini CLI, and Antigravity. Detection is informational rather than consent: the initial selection is empty, and setup changes only the clients the user selects. Repeated runs support updates, disconnection, verification, and rollback without initializing a Flamo project or `.diagnostics` workspace.

## Safety and compatibility

- Stage the exact CLI version and complete an MCP stdio handshake before activating a runtime.
- Preserve unrelated JSON, JSONC, and TOML configuration; malformed standard JSON is rejected rather than rewritten permissively.
- Serialize setup operations, snapshot config and install-manifest bytes and modes, journal mutations, and recover interrupted transactions before planning another change.
- Preserve edits made after a crash, reject stale activation plans, and refuse rollback when the target runtime is no longer installed locally.
- Rename the Python distribution from `flamo` to `flamo-diagnostics`. The import package and `flamo` console command remain unchanged.
- Publish `flamo-diagnostics` before publishing the npm package at the matching version. Registry publication is intentionally outside this PR.

## Suggested review order

1. `src/flamo/application/setup.py` for transaction, recovery, and stale-plan invariants.
2. `src/flamo/adapters/client_setup.py` and `setup_runtime.py` for client configuration contracts and runtime verification.
3. `src/flamo/setup_ui.py` and `src/flamo/cli.py` for interaction and noninteractive controls.
4. `npm/` for the exact-version bootstrap, JSONC bridge, and signal handling.
5. Tests and documentation.

## Validation

- `uv run ruff check src tests`
- `uv run mypy src tests` — 116 source files checked
- `uv run pytest -q` — 172 passed, 2 skipped (optional PyTorch integration and opt-in 100k performance test)
- `npm ci --prefix npm --ignore-scripts` — 0 vulnerabilities
- `npm --prefix npm test` — 4 passed
- `uv build`
