### PR TITLE
fix(storage): contain artifact and generation paths

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 morluto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "flameox",
       "version": "0.1.1",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"
       },

--- a/npm/package.json
+++ b/npm/package.json
@@ -6,7 +6,7 @@
   "bugs": {
     "url": "https://github.com/morluto/flameox/issues"
   },
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/morluto/flameox.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "flameox"
 version = "0.1.1"
 description = "Local runtime evidence CLI and MCP server for coding agents"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "anyio>=4.9,<5",

--- a/src/flameox/application/evidence_lookup.py
+++ b/src/flameox/application/evidence_lookup.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Literal, cast
 from pydantic import JsonValue
 
 from flameox.application.artifacts import ArtifactService
+from flameox.application.recoverable_move import validate_manifest_id
 from flameox.catalog import Catalog
 from flameox.domain import DomainError, ErrorCode
 from flameox.models import ContractModel
@@ -62,6 +63,7 @@ class EvidenceLookupService:
         elif ref_type == "artifact":
             data = ArtifactService(self.workspace).get(ref_id).model_dump(mode="json")
         elif ref_type == "generation":
+            validate_manifest_id(ref_id, kind="generation")
             path = self.workspace.paths.generations / ref_id / "manifest.json"
             try:
                 data = GenerationManifest.model_validate_json(path.read_text()).model_dump(

--- a/src/flameox/application/records.py
+++ b/src/flameox/application/records.py
@@ -5,6 +5,7 @@ from typing import ClassVar, Literal
 
 from pydantic import Field, JsonValue
 
+from flameox.application.recoverable_move import validate_manifest_id
 from flameox.catalog import Catalog
 from flameox.domain import (
     DomainError,
@@ -299,6 +300,7 @@ class FindingService:
             ArtifactStore(self.workspace).get(item.ref_id)
             return
         if item.ref_type == "generation":
+            validate_manifest_id(item.ref_id, kind="generation")
             path = self.workspace.paths.generations / item.ref_id / "manifest.json"
             if path.is_file():
                 return

--- a/src/flameox/application/recoverable_move.py
+++ b/src/flameox/application/recoverable_move.py
@@ -8,7 +8,13 @@ from flameox.storage.atomic import fsync_directory
 
 
 def validate_manifest_id(value: str, *, kind: str) -> None:
-    if not value or "/" in value or "\\" in value or "\x00" in value:
+    if (
+        value in {"", ".", ".."}
+        or "/" in value
+        or "\\" in value
+        or ":" in value
+        or "\x00" in value
+    ):
         raise DomainError(ErrorCode.EXECUTION_REFUSED, f"Invalid {kind} ID.")
 
 

--- a/src/flameox/storage/artifacts.py
+++ b/src/flameox/storage/artifacts.py
@@ -18,6 +18,7 @@ from flameox.storage.quotas import StorageQuota
 from flameox.storage.workspace import Workspace
 
 _SAFE_EXTENSION = re.compile(r"^\.[A-Za-z0-9][A-Za-z0-9._-]{0,15}$")
+_SAFE_PAYLOAD_NAME = re.compile(r"^payload(?:\.[A-Za-z0-9][A-Za-z0-9._-]{0,15})?$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -170,11 +171,38 @@ class ArtifactStore:
             character not in "0123456789abcdef" for character in hexadecimal
         ):
             raise DomainError(ErrorCode.WORKSPACE_INVALID, "Invalid artifact identifier.")
-        object_root = self.workspace.paths.artifacts / hexadecimal[:2] / hexadecimal
-        content = self._read_metadata(object_root / "artifact.json")
+        artifacts_root = self.workspace.paths.artifacts
+        shard_root = artifacts_root / hexadecimal[:2]
+        object_root = shard_root / hexadecimal
+        metadata_path = object_root / "artifact.json"
+        for path in (artifacts_root, shard_root, object_root, metadata_path):
+            if path.is_symlink():
+                raise DomainError(
+                    ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                    "Artifact storage paths must not contain symbolic links.",
+                )
+        try:
+            object_root.resolve().relative_to(artifacts_root.resolve())
+        except ValueError as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                "Artifact storage path escapes the artifact root.",
+            ) from exc
+        content = self._read_metadata(metadata_path)
+        if _SAFE_PAYLOAD_NAME.fullmatch(content.payload_name) is None:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                "Artifact metadata contains an invalid payload name.",
+            )
+        payload_path = object_root / content.payload_name
+        if payload_path.is_symlink():
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                "Artifact payload must not be a symbolic link.",
+            )
         return StoredArtifact(
             content=content,
-            payload_path=object_root / content.payload_name,
+            payload_path=payload_path,
         )
 
     def _read_metadata(self, path: Path) -> ArtifactContent:

--- a/tests/application/test_path_containment.py
+++ b/tests/application/test_path_containment.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flameox.application import (
+    EvidenceInput,
+    EvidenceLookupService,
+    FindingService,
+    RecordFindingRequest,
+)
+from flameox.application.recoverable_move import validate_manifest_id
+from flameox.domain import DomainError, ErrorCode, EvidenceLevel, FindingAssessment
+from flameox.storage import Workspace
+
+
+@pytest.mark.parametrize("value", [".", "..", "D:outside"])
+def test_manifest_ids_reject_current_and_parent_directory(value: str) -> None:
+    with pytest.raises(DomainError) as error:
+        validate_manifest_id(value, kind="manifest")
+
+    assert error.value.code is ErrorCode.EXECUTION_REFUSED
+
+
+@pytest.mark.parametrize("ref_id", [".", "..", "../outside", r"..\outside", "D:outside"])
+def test_generation_lookup_rejects_non_local_reference(tmp_path: Path, ref_id: str) -> None:
+    workspace = Workspace.initialize(tmp_path)
+
+    with pytest.raises(DomainError) as error:
+        EvidenceLookupService(workspace).get("generation", ref_id)
+
+    assert error.value.code is ErrorCode.EXECUTION_REFUSED
+
+
+def test_finding_rejects_non_local_generation_reference(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    request = RecordFindingRequest(
+        kind="performance",
+        title="Candidate is faster",
+        claim="The candidate is faster.",
+        evidence_level=EvidenceLevel.DERIVED,
+        confidence="high",
+        assessment=FindingAssessment.SUPPORTED,
+        evidence=(
+            EvidenceInput(
+                ref_type="generation",
+                ref_id="../outside",
+                relation="supports",
+            ),
+        ),
+    )
+
+    with pytest.raises(DomainError) as error:
+        FindingService(workspace).record(request)
+
+    assert error.value.code is ErrorCode.EXECUTION_REFUSED

--- a/tests/storage/test_artifacts_and_runs.py
+++ b/tests/storage/test_artifacts_and_runs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 
@@ -84,6 +85,78 @@ def test_artifact_import_enforces_size_and_root(tmp_path: Path) -> None:
     assert root_error.value.code is ErrorCode.EXECUTION_REFUSED
     assert size_error.value.code is ErrorCode.ARTIFACT_TOO_LARGE
     assert list(workspace.paths.staging.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "payload_name",
+    ["", "../outside", r"..\outside", "D:outside", ".", ".."],
+)
+def test_artifact_get_rejects_non_local_payload_name(
+    tmp_path: Path,
+    payload_name: str,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"evidence")
+    store = ArtifactStore(workspace)
+    stored = store.import_path(source, allowed_roots=(tmp_path,), max_bytes=100)
+    metadata_path = stored.payload_path.parent / "artifact.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["payload_name"] = payload_name
+    metadata_path.write_text(json.dumps(metadata))
+
+    with pytest.raises(DomainError) as error:
+        store.get(stored.content.artifact_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+
+
+def test_artifact_get_rejects_symlink_payload(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"evidence")
+    store = ArtifactStore(workspace)
+    stored = store.import_path(source, allowed_roots=(tmp_path,), max_bytes=100)
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"outside")
+    stored.payload_path.unlink()
+    stored.payload_path.symlink_to(outside)
+
+    with pytest.raises(DomainError) as error:
+        store.get(stored.content.artifact_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+
+
+@pytest.mark.parametrize("component", ["object", "metadata"])
+def test_artifact_get_rejects_symlink_storage_component(
+    tmp_path: Path,
+    component: str,
+) -> None:
+    workspace = Workspace.initialize(tmp_path / "workspace")
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"evidence")
+    store = ArtifactStore(workspace)
+    stored = store.import_path(source, allowed_roots=(tmp_path,), max_bytes=100)
+    object_root = stored.payload_path.parent
+    metadata_path = object_root / "artifact.json"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    if component == "metadata":
+        outside_metadata = outside / "artifact.json"
+        outside_metadata.write_bytes(metadata_path.read_bytes())
+        metadata_path.unlink()
+        metadata_path.symlink_to(outside_metadata)
+    else:
+        outside_object = outside / "object"
+        object_root.rename(outside_object)
+        object_root.symlink_to(outside_object, target_is_directory=True)
+
+    with pytest.raises(DomainError) as error:
+        store.get(stored.content.artifact_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
 
 
 def test_run_revisions_use_compare_and_swap(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Prevent generation and artifact references from escaping their workspace-owned directories, and add the MIT license required for public distribution.

Generation lookups and finding evidence references previously joined caller-provided IDs directly into filesystem paths. Artifact reads also trusted the metadata payload name and could follow symlinked storage components. These cases could resolve outside the intended generation or artifact roots.

## Approach

Generation IDs now pass through the shared manifest-ID validator, which rejects current-directory, parent-directory, separator-containing, NUL-containing, and drive-qualified values. Artifact reads enforce the store's canonical payload naming contract, reject symlinks in storage components and payloads, and verify that resolved object paths remain beneath the artifact root.

Regression tests cover POSIX and Windows-style traversal inputs, drive-relative paths, malformed payload metadata, and symlinked object, metadata, and payload paths.

The repository now includes an MIT license, and both Python and npm package metadata declare MIT consistently.

## Commands run

```console
uv run pytest tests/application/test_path_containment.py tests/storage/test_artifacts_and_runs.py -q
uv run ruff check src tests
uv run mypy src tests
uv run pytest -q
uv build
npm pack --dry-run
```

Focused containment tests passed (22 tests). The full suite passed with 191 tests and 2 environment-dependent skips. The wheel metadata reports `License-Expression: MIT` and includes `LICENSE`.

## Compatibility

Valid generated identifiers and artifact payloads are unchanged. Malformed or tampered references that use traversal syntax, drive-qualified names, or symlinked storage paths now fail with domain errors instead of resolving through the filesystem. The project license changes from npm's previous Apache-2.0 declaration to MIT across the repository and both package manifests.