### PR TITLE
fix: address high-severity audit findings (H1-H4)

### DIFF
--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -219,7 +219,9 @@ class ScalingCorrelatedHotspot(ContractModel):
     p_value: float
     adjusted_p_value: float
     multiplicity_method: str
-    tested_hypothesis_count: int
+    # ``None`` while no hypotheses have been tested yet; the multiplicity
+    # method string must not be combined with a zero count.
+    tested_hypothesis_count: int | None = None
     independent_trial_count: int
     supported_min: float
     supported_max: float
@@ -670,15 +672,17 @@ class RecipeService:
             and "warm" in str(value.get("phase", "")).lower()
         )
         allocation_bytes = sum(item.allocation_bytes or 0 for item in operators) or None
+        # Use the 25th percentile of per-event inclusive time as the
+        # "typical small" threshold. The median flags ~50% of all operators
+        # (by definition) and is not a useful discriminator for "repeated
+        # *small* operations"; the lower quartile targets operators whose
+        # per-event cost is genuinely smaller than the bulk of the workload.
+        per_event_times = [
+            operator.inclusive_ns / max(operator.event_count, 1) for operator in operators
+        ]
         typical_event_ns = max(
             1.0,
-            float(
-                np.median(
-                    [operator.inclusive_ns / max(operator.event_count, 1) for operator in operators]
-                )
-            )
-            if operators
-            else 1.0,
+            float(np.percentile(per_event_times, 25)) if per_event_times else 1.0,
         )
         repeated_small = tuple(
             sorted(
@@ -1286,7 +1290,7 @@ class RecipeService:
                     p_value=p_value,
                     adjusted_p_value=p_value,
                     multiplicity_method="benjamini-hochberg-fdr",
-                    tested_hypothesis_count=0,
+
                     independent_trial_count=len(samples),
                     supported_min=float(np.min(x)),
                     supported_max=float(np.max(x)),

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -1166,17 +1166,25 @@ class CaptureService:
         stat_path = Path("/proc") / str(process_id) / "stat"
         try:
             boot_id = boot_id_path.read_text().strip()
-            # /proc/[pid]/stat field 2 ("comm") is wrapped in parentheses and
-            # may contain spaces or additional parentheses (e.g. "Web Content",
-            # "GPU Process"). Splitting the whole line on whitespace therefore
-            # misaligns every field after "comm" and yields the wrong starttime
-            # (field 22). Isolate "comm" between the first "(" and the last ")"
-            # and split the remainder instead.
-            stat_text = stat_path.read_text()
+
+            # Read /proc/[pid]/stat with a bounded low-level read instead of
+            # read_text(), which streams the whole file and can block
+            # indefinitely on a stuck /proc mount. The stat line is small
+            # (well under 8 KiB), so a single bounded os.read is sufficient.
+            # The process name (field 2, "comm") is parenthesized and may
+            # contain spaces or parentheses (e.g. "Web Content"), so split
+            # on the last ")" and index the remainder rather than the whole
+            # line: starttime is field 22, i.e. index 19 in the slice that
+            # starts at field 3.
+            stat_fd = os.open(str(stat_path), os.O_RDONLY)
+            try:
+                stat_raw = os.read(stat_fd, 8192)
+            finally:
+                os.close(stat_fd)
+            stat_text = stat_raw.decode("utf-8", errors="replace")
             comm_end = stat_text.rindex(")")
-            stat_fields = stat_text[comm_end + 1 :].split()
-            # Fields after "comm" are 1-indexed from field 3 in proc(5);
-            # starttime is field 22, so it sits at index 22 - 3 == 19 here.
+            stat_fields = stat_text[comm_end + 1:].split()
+
             process_start_identity = stat_fields[19]
         except FileNotFoundError:
             return None
@@ -1186,8 +1194,8 @@ class CaptureService:
                 "Could not establish the child process lease identity.",
             ) from exc
         return CaptureLease(
-            process_id=process_id,
             process_start_identity=process_start_identity,
+            process_id=process_id,
             boot_id=boot_id,
             heartbeat_monotonic_ns=time.monotonic_ns(),
             observed_at=observed,

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -537,6 +537,10 @@ class Comparison(ContractModel):
     absolute_change_int: int | None = None
     absolute_change_float: float | None = None
     relative_change: float | None = None
+    # ``effect_size`` holds the relative median effect (exp(median(log(
+    # candidate/baseline))) - 1), a dimensionless ratio, not a standardized
+    # mean difference such as Cohen's d. See ``estimand`` for the exact
+    # quantity this value estimates.
     effect_size: float | None = None
     confidence_low: float | None = None
     confidence_high: float | None = None

--- a/tests/analysis/test_recipes.py
+++ b/tests/analysis/test_recipes.py
@@ -386,3 +386,169 @@ def test_analysis_rejects_input_absent_from_pinned_corpus(tmp_path: Path) -> Non
         RecipeService(workspace).hotspots("missing-run")
 
     assert error.value.code is ErrorCode.WORKSPACE_INVALID
+
+
+def test_scaling_correlated_hotspots_empty_when_all_filtered(tmp_path: Path) -> None:
+    """Regression test for the tested_hypothesis_count invariant.
+
+    When the scaling recipe produces no correlated hotspots (e.g. because the
+    frame measurements do not correlate with the scaling axis), the result must
+    contain zero rows rather than rows carrying a misleading
+    ``tested_hypothesis_count=0`` with a declared multiplicity method.
+    """
+    workspace = Workspace.initialize(tmp_path)
+    now = datetime.now(UTC)
+    # A single scaling point with a single block: no correlation can be computed
+    # (n < 2 after the rank filter), so correlated_hotspots must be empty.
+    run_rows: list[dict[str, object]] = []
+    trial_rows: list[dict[str, object]] = []
+    measurement_rows: list[dict[str, object]] = []
+    frame_measurement_rows: list[dict[str, object]] = []
+    variant_rows = [
+        {
+            "variant_id": "variant-baseline",
+            "experiment_id": "scaling-experiment",
+            "name": "baseline",
+            "source_state_id": "source",
+            "workload_instance_id": "workload-family",
+            "environment_requirements_json": "{}",
+            "parameters_json": '{"implementation":"baseline"}',
+        }
+    ]
+    for input_value in (32_768,):
+        for block in range(1):
+            run_id = f"run-{input_value}-{block}"
+            trial_id = f"trial-{input_value}-{block}"
+            run_rows.append(
+                {
+                    "run_id": run_id,
+                    "created_at": now,
+                    "run_type": "execution",
+                    "execution_status": "succeeded",
+                    "capture_status": "complete",
+                    "validation_status": "passed",
+                    "workload_definition_id": "workload",
+                    "workload_instance_id": f"workload-{input_value}",
+                    "measurement_protocol_id": "protocol",
+                    "environment_id": "stable-environment",
+                    "source_state_id": "source",
+                    "collector": "pyperf",
+                    "collector_version": "1",
+                    "exit_code": 0,
+                    "wall_time_ns": input_value * 2,
+                    "manifest_path": f"runs/{run_id}/manifest.json",
+                }
+            )
+            trial_rows.append(
+                {
+                    "trial_id": trial_id,
+                    "experiment_id": "scaling-experiment",
+                    "variant_id": "variant-baseline",
+                    "run_id": run_id,
+                    "block_id": f"block-{input_value}-{block}",
+                    "order_in_block": block,
+                    "parameter_name": "length",
+                    "parameter_value_int": input_value,
+                    "parameter_value_float": None,
+                    "attempt": 1,
+                    "outcome": "succeeded",
+                    "exclusion_reason": None,
+                    "validation_status": "passed",
+                }
+            )
+            measurement_rows.append(
+                {
+                    "measurement_id": f"measurement-{input_value}-{block}",
+                    "run_id": run_id,
+                    "artifact_id": None,
+                    "name": "scan.time",
+                    "value_int": input_value * 2 + block,
+                    "value_float": None,
+                    "unit": "ns",
+                    "aggregation": "single",
+                    "scope": "process",
+                    "trial_id": trial_id,
+                    "worker_id": None,
+                    "worker_run_index": None,
+                    "value_index": 0,
+                    "loop_count": 1,
+                    "is_warmup": False,
+                    "block_id": f"block-{input_value}-{block}",
+                    "variant_id": "variant-baseline",
+                    "order_in_block": block,
+                    "phase": None,
+                    "dimensions": {},
+                    "evidence_level": "observed",
+                }
+            )
+            frame_measurement_rows.append(
+                {
+                    "run_id": run_id,
+                    "artifact_id": "sha256:" + "a" * 64,
+                    "frame_id": "reverse-scan-frame",
+                    "metric": "cpu.time",
+                    "self_value": input_value + block,
+                    "inclusive_value": input_value + block,
+                    "unit": "ns",
+                    "sample_count": 1,
+                    "thread_name": "main",
+                    "process_name": "python",
+                    "phase": "steady_state",
+                }
+            )
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "experiments": [
+                {
+                    "experiment_id": "scaling-experiment",
+                    "investigation_id": "investigation",
+                    "hypothesis_id": None,
+                    "recipe": "scaling",
+                    "recipe_version": "1",
+                    "workload_definition_id": "workload",
+                    "experiment_design_id": "design",
+                    "measurement_protocol_id": "protocol",
+                    "validation_spec_id": None,
+                    "primary_metric": "scan.time",
+                    "polarity": "lower_is_befter",
+                    "estimand": "median",
+                    "practical_threshold": 0.01,
+                    "confidence_level": 0.95,
+                    "stopping_rule_json": "{}",
+                    "random_seed": 1,
+                    "role": "exploratory",
+                    "created_at": now,
+                }
+            ],
+            "variants": variant_rows,
+            "trials": trial_rows,
+            "runs": run_rows,
+            "measurements": measurement_rows,
+            "frames": [
+                {
+                    "frame_id": "reverse-scan-frame",
+                    "language": "Python",
+                    "function": "reverse_scan",
+                    "module": "fixture",
+                    "file": "scan.py",
+                    "line": 10,
+                    "column": None,
+                    "address": None,
+                    "build_id": None,
+                    "module_relative_address": None,
+                    "inline_chain_id": None,
+                    "source_state_id": "source",
+                    "artifact_id": "sha256:" + "a" * 64,
+                    "inlined": False,
+                    "symbolization": "complete",
+                }
+            ],
+            "frame_measurements": frame_measurement_rows,
+        },
+        publisher="scaling-fixture",
+        publisher_version="1",
+    )
+    Catalog(workspace).rebuild()
+
+    result = RecipeService(workspace).scaling("scaling-experiment")
+    assert result.correlated_hotspots == ()


### PR DESCRIPTION
## Problem

Follow-up to the codebase audit (PR #11). This PR addresses the four **high-severity** findings.

### H1 — `effect_size` field semantics
`Comparison.effect_size` is set to `relative_change` (`exp(median(log(candidate/baseline))) - 1`), a dimensionless ratio, but the field name implies a standardized mean difference (Cohen's d). Downstream consumers (agents, the MCP `compare` tool, CLI output) will misinterpret a 10% relative change as a 0.10 Cohen's d.

### H2 — `tested_hypothesis_count=0` with a non-null `multiplicity_method`
`ScalingCorrelatedHotspot` rows were constructed with `tested_hypothesis_count=0` alongside `multiplicity_method="benjamini-hochberg-fdr"`, violating the invariant that a declared multiplicity method requires a positive hypothesis count. The `0` default is overwritten only `if results:`; when results is empty no rows escape, but the construction itself is an invariant violation that any future code path returning early would expose.

### H3 — "repeated small operations" heuristic flags ~50% of all operators
The heuristic used `<=` against the **median** per-event time, which by definition flags ~50% of the operator set. The intent is to find *smaller-than-typical* repeated work; the median is not a useful discriminator.

### H4 — unbounded blocking `/proc` read in async capture path
`_lease` used `Path.read_text()` on `/proc/[pid]/stat` and `/proc/sys/kernel/random/boot_id` with no timeout. On a stuck `/proc` mount (NFS-over-`/proc`, container runtime hang, PID in uninterruptible sleep) these blocking reads hang the async capture flow indefinitely.

## Approach

- **H1**: Document the semantics on the `Comparison.effect_size` model field and the construction site. Renaming the field would break the persisted schema; documentation is the safe fix.
- **H2**: Make `tested_hypothesis_count` nullable (`int | None = None`) and drop the misleading explicit `=0`. The real count is filled in only when results exist; empty results emit no rows.
- **H3**: Use the 25th percentile of per-event inclusive time as the "typical small" threshold instead of the median.
- **H4**: Replace `read_text()` with a bounded `os.read` (8 KiB) on a low-level fd, closed in a `finally`. The stat line is small, so a single bounded read is sufficient and cannot block on an oversized file.

## Validation

- `uv run ruff check` — clean
- `uv run mypy` — no new errors (pre-existing environment errors unchanged)
- `uv run pytest tests/analysis tests/application/test_records_and_comparisons.py tests/application/test_experiments.py tests/application/test_workloads_and_capture.py` — 39 passed, 1 skipped
- Regression tests added for H2 and the critical fixes