### PR TITLE
feat(setup): verify configured client launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,11 @@ flameox reports the workload as `uncontained`.
 
 ## Setup and installation details
 
-Run setup again to connect or disconnect clients, verify the active runtime,
-update to the npm package's matching version, or roll back to a previously
-installed version. `npx flameox@latest setup` resolves the newest setup release.
-Automation can select clients and inspect the plan explicitly:
+Run setup again to connect or disconnect clients, verify that connected clients
+launch the active runtime, update to the npm package's matching version, or roll
+back to a previously installed version. `npx flameox@latest setup` resolves the
+newest setup release. Automation can select clients and inspect the plan
+explicitly:
 
 ```console
 npx flameox setup --codex --claude --yes

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -17,6 +17,13 @@ explicit target (`--codex`, another client flag, `--all`, `--refresh`,
 `--rollback`, or `--verify`) and `--yes`; `--dry-run --json` returns the plan
 without mutation.
 
+Interactive setup is also the lifecycle entry point for connecting or
+disconnecting clients, updating the active runtime, rolling back to an installed
+version, and verification. Verification checks the managed runtime version and
+real MCP handshake, then confirms that every configured client still contains
+the exact active executable and fixed launcher arguments. It is read-only and
+fails on configuration drift instead of repairing it implicitly.
+
 Client launchers contain the absolute path of a verified managed runtime and
 the fixed arguments `mcp serve --project-root .`. Setup never passes `--init`.
 Each MCP client therefore binds flameox's project root to the client's launch

--- a/src/flameox/adapters/client_setup.py
+++ b/src/flameox/adapters/client_setup.py
@@ -124,7 +124,7 @@ class ClientConfigRegistry:
     def detected_clients(self) -> tuple[SetupClient, ...]:
         return tuple(client for client in ALL_SETUP_CLIENTS if self.definition(client).detected)
 
-    def configured_clients(self) -> tuple[SetupClient, ...]:
+    def configured_clients(self, *, strict: bool = False) -> tuple[SetupClient, ...]:
         configured: list[SetupClient] = []
         for client in ALL_SETUP_CLIENTS:
             definition = self.definition(client)
@@ -133,6 +133,8 @@ class ClientConfigRegistry:
             try:
                 value = self._read_entry(definition)
             except DomainError:
+                if strict:
+                    raise
                 continue
             if value is not None:
                 configured.append(client)

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -1290,7 +1290,6 @@ class RecipeService:
                     p_value=p_value,
                     adjusted_p_value=p_value,
                     multiplicity_method="benjamini-hochberg-fdr",
-
                     independent_trial_count=len(samples),
                     supported_min=float(np.min(x)),
                     supported_max=float(np.max(x)),

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -1186,7 +1186,7 @@ class CaptureService:
                 os.close(stat_fd)
             stat_text = stat_raw.decode("utf-8", errors="replace")
             comm_end = stat_text.rindex(")")
-            stat_fields = stat_text[comm_end + 1:].split()
+            stat_fields = stat_text[comm_end + 1 :].split()
 
             process_start_identity = stat_fields[19]
         except FileNotFoundError:

--- a/src/flameox/application/integrity.py
+++ b/src/flameox/application/integrity.py
@@ -119,9 +119,7 @@ class IntegrityService:
     def validate(self, *, full: bool = False) -> IntegrityResult:
         issues: list[IntegrityIssue] = []
         head = self.workspace.corpus.read_head()
-        checked_generations, checked_parquet, manifest_issues = self._check_manifests(
-            head, full
-        )
+        checked_generations, checked_parquet, manifest_issues = self._check_manifests(head, full)
         issues.extend(manifest_issues)
 
         checked_artifacts = 0

--- a/src/flameox/application/recoverable_move.py
+++ b/src/flameox/application/recoverable_move.py
@@ -8,13 +8,7 @@ from flameox.storage.atomic import fsync_directory
 
 
 def validate_manifest_id(value: str, *, kind: str) -> None:
-    if (
-        value in {"", ".", ".."}
-        or "/" in value
-        or "\\" in value
-        or ":" in value
-        or "\x00" in value
-    ):
+    if value in {"", ".", ".."} or "/" in value or "\\" in value or ":" in value or "\x00" in value:
         raise DomainError(ErrorCode.EXECUTION_REFUSED, f"Invalid {kind} ID.")
 
 

--- a/src/flameox/application/setup.py
+++ b/src/flameox/application/setup.py
@@ -169,16 +169,35 @@ class SetupService:
         manifest_original, manifest_mode = self._snapshot_file(self.install_manifest)
         if operation is SetupOperation.VERIFY:
             manifest = self._read_install_manifest()
+            edits: tuple[ClientConfigEdit, ...] = ()
+            if manifest is not None:
+                launcher = Launcher(
+                    command=str(manifest.executable),
+                    args=("mcp", "serve", "--project-root", "."),
+                )
+                edits = tuple(
+                    self.registry.plan(client, launcher, remove=False)
+                    for client in self.registry.configured_clients(strict=True)
+                )
             public = SetupPlan(
                 operation=operation,
                 version=manifest.active_version if manifest else None,
                 runtime_action=RuntimeAction.NOT_REQUIRED,
                 runtime_executable=manifest.executable if manifest else None,
-                clients=(),
+                clients=tuple(
+                    ClientSetupPlan(
+                        client=edit.client,
+                        display_name=edit.client.display_name,
+                        path=edit.path,
+                        action=edit.action,
+                        detected=edit.detected,
+                    )
+                    for edit in edits
+                ),
             )
             return ResolvedSetupPlan(
                 public,
-                (),
+                edits,
                 manifest_original,
                 manifest_mode,
             )
@@ -292,13 +311,28 @@ class SetupService:
                     ErrorCode.INTERNAL_ERROR,
                     "Resolved runtime has no version after installation.",
                 )
+            mismatched = tuple(
+                edit.client
+                for edit in plan.edits
+                if edit.action is not ClientPlanAction.ALREADY_CURRENT
+            )
+            if mismatched:
+                names = ", ".join(client.display_name for client in mismatched)
+                raise DomainError(
+                    ErrorCode.REVISION_CONFLICT,
+                    f"Configured MCP launchers do not match the active runtime: {names}.",
+                    details={"clients": [client.value for client in mismatched]},
+                    remediation=(
+                        "Run `npx flameox setup` and choose Connect or update MCP clients.",
+                    ),
+                )
             await self.runtime.verify(executable, public.version)
             return SetupReport(
                 operation=public.operation,
                 version=public.version,
                 runtime_installed=False,
                 changed_clients=(),
-                unchanged_clients=(),
+                unchanged_clients=tuple(edit.client for edit in plan.edits),
                 verified=True,
             )
 

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -337,7 +337,10 @@ def setup(
     ] = None,
     verify: Annotated[
         bool,
-        typer.Option("--verify", help="Verify the active MCP runtime without changing configs."),
+        typer.Option(
+            "--verify",
+            help="Verify connected client launchers and the active MCP runtime.",
+        ),
     ] = False,
     yes: Annotated[
         bool,

--- a/src/flameox/setup_ui.py
+++ b/src/flameox/setup_ui.py
@@ -36,7 +36,7 @@ def choose_action(inspection: SetupInspection, target_version: str) -> str:
         (
             Choice("Connect or update MCP clients", "configure"),
             Choice("Disconnect MCP clients", "remove"),
-            Choice("Verify the active MCP runtime", "verify"),
+            Choice("Verify connected clients and the active runtime", "verify"),
         )
     )
     if len(inspection.installed_versions) > 1 and inspection.configured_clients:
@@ -86,7 +86,15 @@ def print_plan(plan: SetupPlan) -> None:
         typer.echo(f"  Launcher: {plan.runtime_executable}")
     for client in plan.clients:
         detected = "" if client.detected else " (not detected)"
-        typer.echo(f"  {client.display_name}: {client.action.value} {client.path}{detected}")
+        if plan.operation.value == "verify":
+            status = (
+                "matches active runtime"
+                if client.action.value == "already_current"
+                else "does not match active runtime"
+            )
+            typer.echo(f"  {client.display_name}: {status} {client.path}{detected}")
+        else:
+            typer.echo(f"  {client.display_name}: {client.action.value} {client.path}{detected}")
     for warning in plan.warnings:
         typer.secho(f"  Warning: {warning}", fg=typer.colors.YELLOW)
     typer.echo()
@@ -101,6 +109,11 @@ def print_report(report: SetupReport) -> None:
     typer.echo()
     if report.operation.value == "verify":
         typer.secho("flameox MCP runtime verified.", fg=typer.colors.GREEN)
+        clients = ", ".join(client.display_name for client in report.unchanged_clients)
+        if clients:
+            typer.echo(f"Configured launchers verified: {clients}")
+        else:
+            typer.echo("No MCP clients are currently connected.")
         return
     changed = ", ".join(client.display_name for client in report.changed_clients)
     if changed:

--- a/tests/application/test_comparison_samples.py
+++ b/tests/application/test_comparison_samples.py
@@ -11,45 +11,61 @@ multi-member unblocked path unreachable, so these tests construct the
 minimal single-member scenario where a collision is still possible (a single
 run emitting two measurements with the same worker/worker_run/value_index).
 """
+
 from __future__ import annotations
+
+from typing import cast
 
 import pytest
 
-from flameox.application.comparisons import ComparisonService
+from flameox.application.comparisons import ComparisonService, _SampleSet
+from flameox.catalog import Snapshot
 from flameox.domain import DomainError, ErrorCode
 from flameox.domain.models import RunSet, RunSetMember
 
+type Row = tuple[object, ...]
+
 
 class _FakeSnapshot:
-    def __init__(self, measurements_by_run: dict[str, list[tuple]]) -> None:
+    def __init__(self, measurements_by_run: dict[str, list[Row]]) -> None:
         self._measurements = measurements_by_run
 
-    def execute(self, sql: str, params: tuple) -> object:
+    def execute(self, sql: str, params: tuple[object, ...]) -> _Rows:
         if "FROM measurements" in sql:
-            return _Rows(self._measurements.get(params[0], []))
+            run_id = params[0]
+            assert isinstance(run_id, str)
+            return _Rows(self._measurements.get(run_id, []))
         if "FROM trials" in sql:
             return _Rows([])
         return _Rows([])
 
 
 class _Rows:
-    def __init__(self, rows: list[tuple]) -> None:
+    def __init__(self, rows: list[Row]) -> None:
         self._rows = rows
 
-    def fetchall(self) -> list[tuple]:
+    def fetchall(self) -> list[Row]:
         return self._rows
 
-    def fetchone(self) -> tuple | None:
+    def fetchone(self) -> Row | None:
         return self._rows[0] if self._rows else None
 
 
-def _row(value_int, value_index, worker_id="0", worker_run_index=0,
-         block_id=None) -> tuple:
+def _row(
+    value_int: int,
+    value_index: int,
+    worker_id: str = "0",
+    worker_run_index: int = 0,
+    block_id: str | None = None,
+) -> Row:
     return (value_int, None, block_id, worker_id, worker_run_index, value_index)
 
 
-def _samples(measurements, members):
-    snapshot = _FakeSnapshot(measurements)
+def _samples(
+    measurements: dict[str, list[Row]],
+    members: tuple[RunSetMember, ...],
+) -> _SampleSet:
+    snapshot = cast(Snapshot, _FakeSnapshot(measurements))
     run_set = RunSet(
         run_set_id="sha256:" + "0" * 64,
         corpus_commit_id="sha256:" + "a" * 64,
@@ -57,9 +73,7 @@ def _samples(measurements, members):
         members=members,
         membership_digest="sha256:" + "b" * 64,
     )
-    return ComparisonService.__new__(ComparisonService)._samples(
-        snapshot, run_set, "m", "ns"
-    )
+    return ComparisonService.__new__(ComparisonService)._samples(snapshot, run_set, "m", "ns")
 
 
 def test_unblocked_path_raises_on_duplicate_key() -> None:

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -95,6 +95,92 @@ async def test_setup_is_idempotent_and_preserves_unrelated_json(tmp_path: Path) 
 
 
 @pytest.mark.anyio
+async def test_verify_checks_the_runtime_and_every_configured_launcher(tmp_path: Path) -> None:
+    service, runtime, _ = make_service(tmp_path)
+    configured = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE, SetupClient.GEMINI),
+        version="0.1.0",
+    )
+    await service.apply(configured)
+
+    plan = service.plan(
+        operation=SetupOperation.VERIFY,
+        clients=(),
+        version=None,
+    )
+    report = await service.apply(plan)
+
+    assert tuple(client.client for client in plan.public.clients) == (
+        SetupClient.CLAUDE,
+        SetupClient.GEMINI,
+    )
+    assert all(client.action.value == "already_current" for client in plan.public.clients)
+    assert report.verified
+    assert report.unchanged_clients == (SetupClient.CLAUDE, SetupClient.GEMINI)
+    assert runtime.verified[-1] == runtime.executable("0.1.0")
+
+
+@pytest.mark.anyio
+async def test_verify_refuses_a_configured_launcher_that_drifted_from_active_runtime(
+    tmp_path: Path,
+) -> None:
+    service, runtime, home = make_service(tmp_path)
+    configured = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE,),
+        version="0.1.0",
+    )
+    await service.apply(configured)
+    config = home / ".claude.json"
+    content = json.loads(config.read_text())
+    content["mcpServers"]["flameox"]["command"] = "/tmp/not-the-active-runtime"
+    config.write_text(json.dumps(content) + "\n")
+    verifications_before = len(runtime.verified)
+
+    plan = service.plan(
+        operation=SetupOperation.VERIFY,
+        clients=(),
+        version=None,
+    )
+    with pytest.raises(DomainError) as caught:
+        await service.apply(plan)
+
+    assert caught.value.code is ErrorCode.REVISION_CONFLICT
+    assert caught.value.details == {"clients": ["claude"]}
+    assert len(runtime.verified) == verifications_before
+    assert json.loads(config.read_text())["mcpServers"]["flameox"]["command"] == (
+        "/tmp/not-the-active-runtime"
+    )
+
+
+def test_verify_refuses_a_malformed_client_configuration(tmp_path: Path) -> None:
+    service, runtime, home = make_service(tmp_path)
+    runtime.versions.add("0.1.0")
+    service.data_root.mkdir(parents=True)
+    atomic_write_json(
+        service.install_manifest,
+        {
+            "schema_version": 1,
+            "active_version": "0.1.0",
+            "executable": str(runtime.executable("0.1.0")),
+        },
+    )
+    config = home / ".claude.json"
+    config.write_text("{broken")
+
+    with pytest.raises(DomainError) as caught:
+        service.plan(
+            operation=SetupOperation.VERIFY,
+            clients=(),
+            version=None,
+        )
+
+    assert caught.value.code is ErrorCode.EXECUTION_REFUSED
+    assert "malformed client configuration" in caught.value.message
+
+
+@pytest.mark.anyio
 async def test_setup_refuses_config_changed_after_preview(tmp_path: Path) -> None:
     service, _, home = make_service(tmp_path)
     config = home / ".claude.json"

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -283,6 +283,12 @@ timeout_seconds = 5
 """
     )
     workspace = Workspace.initialize(tmp_path)
+    config = workspace.config.model_copy(
+        update={
+            "execution": workspace.config.execution.model_copy(update={"containment": "disabled"})
+        }
+    )
+    workspace.paths.config.write_text(config.to_toml())
     Catalog(workspace).rebuild()
 
     async with Client(create_server(tmp_path), raise_exceptions=True) as client:
@@ -292,7 +298,9 @@ timeout_seconds = 5
         )
     assert refused.is_error is True
     assert refused.structured_content is not None
-    assert refused.structured_content["error"]["code"] == "EXECUTION_REFUSED"
+    assert refused.structured_content["error"]["code"] == "EXECUTION_REFUSED", (
+        refused.structured_content
+    )
 
     WorkloadService(workspace).approve("echo")
     recorded_progress: list[tuple[float, float | None, str | None]] = []
@@ -309,6 +317,7 @@ timeout_seconds = 5
             "plan_capture",
             {"workload_name": "echo", "adapter": "command", "parameters": {}},
         )
+        assert planned.is_error is False, planned.structured_content
         assert planned.structured_content is not None
         plan_id = planned.structured_content["result"]["plan_id"]
         executed = await client.call_tool(

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -38,6 +38,57 @@ def test_setup_yes_requires_an_explicit_target(
     assert "--yes requires explicit clients" in result.output
 
 
+def test_setup_verify_dry_run_reports_configured_launcher_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+    home.mkdir()
+    data.mkdir()
+    executable = data / "runtimes" / "0.1.0" / "bin" / "flameox"
+    (home / ".claude.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "flameox": {
+                        "command": str(executable),
+                        "args": ["mcp", "serve", "--project-root", "."],
+                    }
+                }
+            }
+        )
+        + "\n"
+    )
+    (data / "install.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "active_version": "0.1.0",
+                "executable": str(executable),
+            }
+        )
+        + "\n"
+    )
+    monkeypatch.setenv("FLAMEOX_SETUP_HOME", str(home))
+    monkeypatch.setenv("FLAMEOX_SETUP_DATA_ROOT", str(data))
+
+    result = CliRunner().invoke(app, ["setup", "--verify", "--dry-run", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["operation"] == "verify"
+    assert payload["clients"] == [
+        {
+            "client": "claude",
+            "display_name": "Claude Code",
+            "path": str(home / ".claude.json"),
+            "action": "already_current",
+            "detected": True,
+        }
+    ]
+
+
 def test_setup_reports_corrupt_install_metadata_as_a_domain_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

`flameox setup --verify` now checks the complete managed setup instead of only launching the active runtime. It compares every connected client's flameox entry with the active executable and the fixed `mcp serve --project-root .` arguments before performing the runtime and MCP handshake.

Verification remains read-only. A malformed client configuration or launcher drift now produces a clear failure and remediation instead of silently skipping the client or repairing its configuration. Dry-run JSON and the interactive setup UI expose each connected launcher's status.

This branch also applies the repository's current Ruff formatting and adds explicit types to the comparison regression fixture so the repository-wide static checks pass. The MCP capture lifecycle test now declares containment disabled because it tests approval and single-use plan tokens, keeping that test independent of Bubblewrap and systemd availability on the CI host.

## Test plan

- `uv run ruff format --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest -q --cov --cov-report=xml --cov-report=term` — 201 passed, 2 skipped; 77.15% coverage

The skipped tests are the opt-in 100k catalog performance check and the PyTorch-dependent capture test.
