### PR TITLE
fix(setup): preselect detected MCP clients

### DIFF
--- a/src/flameox/setup_ui.py
+++ b/src/flameox/setup_ui.py
@@ -51,7 +51,7 @@ def choose_clients(
     *,
     remove: bool,
 ) -> tuple[SetupClient, ...]:
-    selected = set(inspection.configured_clients if remove else ())
+    selected = set(inspection.configured_clients if remove else inspection.detected_clients)
     detected = set(inspection.detected_clients)
     choices = [
         Choice(

--- a/tests/test_setup_ui.py
+++ b/tests/test_setup_ui.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from questionary import Choice
+
+from flameox import setup_ui
+from flameox.adapters.client_setup import SetupClient
+from flameox.application.setup import SetupInspection
+
+
+class _CheckboxQuestion:
+    def __init__(self, choices: list[Choice]) -> None:
+        self.choices = choices
+
+    def ask(self) -> list[SetupClient]:
+        return [cast(SetupClient, choice.value) for choice in self.choices if choice.checked]
+
+
+def test_connect_preselects_detected_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+    def checkbox(message: str, *, choices: list[Choice]) -> _CheckboxQuestion:
+        assert message == "Select MCP clients to connect:"
+        return _CheckboxQuestion(choices)
+
+    monkeypatch.setattr("flameox.setup_ui.questionary.checkbox", checkbox)
+    inspection = SetupInspection(
+        active_version=None,
+        active_executable=None,
+        configured_clients=(),
+        detected_clients=(SetupClient.CLAUDE, SetupClient.GEMINI),
+        installed_versions=(),
+    )
+
+    selected = setup_ui.choose_clients(inspection, remove=False)
+
+    assert selected == (SetupClient.CLAUDE, SetupClient.GEMINI)


### PR DESCRIPTION
## Description

The interactive connect prompt labeled available clients as detected but left every checkbox unchecked. Accepting the displayed defaults therefore produced `EXECUTION_REFUSED: Select at least one MCP client.`

Detected clients are now selected by default, so pressing Enter connects the clients flameox already found. Users can still uncheck any client before continuing.

## Approach

Initialize connect-mode checkbox state from `inspection.detected_clients`. Disconnect mode keeps its existing behavior and initializes from `inspection.configured_clients`.

A UI-level regression test simulates accepting the checkbox defaults and verifies that the detected clients are returned.

## Commands run

```console
uv run ruff format --check src tests
uv run ruff check src tests
uv run mypy src tests
uv run pytest tests/test_setup_ui.py tests/application/test_setup.py tests/test_cli_setup.py -q
```

The focused setup suite passed with 23 tests.

## Compatibility

Non-interactive client flags and removal behavior are unchanged. This only changes the initial checkbox state in the interactive connect flow.
