### PR TITLE
feat(adapters): add Python startup and pytest runtime evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@
 
 flameox helps coding agents investigate performance, memory, execution,
 concurrency, and reliability with evidence you can inspect and reproduce. It
-connects agents to maintained tools such as pyperf, py-spy, Perfetto Trace
-Processor, coverage.py, Memray, and torch.profiler, then keeps each original
-artifact alongside a record of how it was produced.
+connects agents to maintained tools such as Python import-time tracing, pytest,
+xdist, pyperf, py-spy, Perfetto Trace Processor, coverage.py, Memray, and
+torch.profiler, then keeps each original artifact alongside a record of how it
+was produced.
 
 flameox is not a profiler or an automatic bug finder. It coordinates existing
 tools, compares runs collected under compatible conditions, and ties findings
@@ -144,6 +145,7 @@ Optional Python extras are independent:
 - `trace`: Perfetto Python API; a local Trace Processor binary must also be
   configured
 - `execution`: coverage.py
+- `test`: pytest and pytest-xdist evidence capture
 - `memory`: Memray
 - `torch`: PyTorch capture
 - `all`: all runtime integrations

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -82,7 +82,7 @@ Conformance status uses three terms:
 | 8 | Proven | Frozen run sets preserve attempts and reject identity, environment, block, and oracle incompatibilities (`tests/application/test_records_and_comparisons.py`, `tests/application/test_experiments.py`). |
 | 9 | Proven | Comparisons and materialized analyses use one explicitly pinned `Snapshot`; persisted analyses and findings validate typed immutable references and record the exact source commit (`tests/application/test_records_and_comparisons.py`, `tests/application/test_analysis_records.py`, `tests/application/test_artifact_service.py`). |
 | 10 | Proven | All three fresh-workspace golden investigations produce investigation, hypothesis, analysis, comparison, validation, and finding evidence; reverse scan executes 32K–128K scaling and proves a normally exiting broken treatment is rejected by its oracle (`tests/golden/`). |
-| 11 | Proven | Results expose limitations and compatibility uncertainty; fixtures cover pyperf, Perfetto, Memray, coverage, synthetic torch evidence, empty/malformed/truncated inputs, recursive stacks, multi-process/thread traces, and newer producer versions (`tests/adapters/`, `tests/application/test_workloads_and_capture.py`). |
+| 11 | Proven | Results expose limitations and compatibility uncertainty; fixtures cover Python startup/import costs, pytest/xdist fixture and failure evidence, pyperf, Perfetto, Memray, coverage, synthetic torch evidence, empty/malformed/truncated inputs, recursive stacks, multi-process/thread traces, and newer producer versions (`tests/adapters/`, `tests/application/test_python_evidence_capture.py`, `tests/application/test_workloads_and_capture.py`). |
 | 12 | Proven | Every supported native artifact kind dispatches to an ecosystem viewer, and explicit launch runs through the bounded broker (`tests/application/test_viewers.py`, `tests/adapters/test_perfetto.py`). |
 | 13 | Proven | Full integrity verification detects altered artifact bytes (`tests/application/test_integrity.py`). |
 | 14 | Proven | Read-only recipes fail the test if they acquire the workspace write lock, comparisons leave HEAD unchanged, and both paths return their pinned commit (`tests/analysis/test_recipes.py`, `tests/application/test_records_and_comparisons.py`). |
@@ -132,6 +132,15 @@ validate extraction independently of collector availability. Fixtures cover:
 - multiple processes and threads;
 - recursive and inlined frames;
 - unknown producer versions.
+
+Python startup fixtures additionally preserve raw `-X importtime` lines, cache
+semantics, package grouping, repeated wall samples, and optional peak RSS.
+Pytest fixtures cover serial and two-worker xdist reports, repeated
+worker-scoped fixture setup, worker lifecycle, bounded fixture-sidecar recovery
+after a forced worker crash, first observed and controller-reported failure
+latency, malformed event streams, and a timed-out partial run with explicit
+unexecuted tests. Python startup integration also records whether peak RSS came
+from POSIX `wait4` resource usage or the portable polling fallback.
 
 ### Integration tests
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -118,6 +118,52 @@ pyperf owns calibration, warm-ups, workers, runs, and values within a benchmark
 trial; flameox's experiment blocks and treatment randomization sit above that
 hierarchy and do not duplicate it.
 
+#### `python-startup`
+
+Use for repeated startup of a declared Python script or module. Each sample
+uses a fresh interpreter. Repeated wall/RSS samples run without import
+instrumentation; one separate `-X importtime` process preserves the raw trace
+and package-grouped module counts and costs in the native JSON artifact. The
+first wall sample is labeled
+`uncontrolled_initial`, not cold: flameox does not drop operating-system
+caches. Later samples are warm process restarts with a fresh interpreter and a
+potentially populated filesystem cache.
+
+On POSIX systems with `wait4`, peak RSS comes from the terminated child's
+`ru_maxrss`; the extractor records `wait4_ru_maxrss` as the measurement
+backend. Other platforms use bounded psutil polling and record
+`psutil_polling`, which may miss a very short-lived peak.
+
+Package summaries add module self time and retain the maximum cumulative time
+reported for a module in that top-level package. Summing cumulative import
+times would double-count nested imports. Experiments publish
+`python_startup.wall_time`, `python_startup.peak_rss`, and package dimensions
+through ordinary measurements, so existing identity and compatibility rules
+govern base/candidate comparisons.
+
+#### `pytest`
+
+Use for declared `pytest` or `python -m pytest` workloads. A small plugin writes
+an append-only JSONL event stream while the suite runs. Public pytest hooks
+provide collection, setup/call/teardown reports, fixture setup timing, outcomes,
+and interruption events. With local xdist, fixture and test-start events are
+flushed immediately to bounded per-worker sidecars. After each clean shutdown
+or crash, the controller validates the event schema, type, and worker identity,
+then appends accepted events to the authoritative primary JSONL artifact.
+Controller hooks also record scheduler strategy, worker creation, readiness,
+collection, clean shutdown, and crashes.
+
+`pytest.time_to_first_failure.observed` uses the worker report stop time;
+`pytest.time_to_first_failure.reported` uses controller receipt time and better
+approximates when a parallel failure becomes actionable. Stable xdist hooks do
+not expose an exact per-test controller queue timestamp, so the adapter records
+execution start and reports that limitation instead of inferring queue delay.
+If a run times out after the event stream exists, flameox registers the partial
+artifact and marks the run timed out; collected tests without a phase report
+remain explicitly unexecuted. A forcefully terminated controller can still lose
+sidecar events it had not recovered; the primary artifact never treats an
+unregistered sidecar as authoritative evidence.
+
 #### `py-spy`
 
 Use for out-of-process Python CPU sampling and attach workflows. Prefer a

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -292,7 +292,7 @@ The supported tools are grouped as follows:
 | Family | Tools |
 | --- | --- |
 | Workspace | `initialize_workspace`, `workspace_status`, `list_capabilities`, `validate_workspace` |
-| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_pyperf`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_observations` |
+| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_observations` |
 | Detached capture | `start_detached_capture`, `get_detached_capture`, `cancel_detached_capture` |
 | Discovery | `list_declared_workflows`, `get_declared_workflow`, `list_runs`, `list_findings` |
 | Investigations | `create_investigation`, `list_investigations`, `get_investigation`, `record_hypothesis`, `get_hypothesis` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ python = ["pyperf>=2.9"]
 memory = ["memray>=1.17"]
 torch = ["torch>=2.7"]
 execution = ["coverage>=7.14,<8"]
+test = ["pytest>=8.3", "pytest-xdist>=3.6"]
 trace = ["perfetto>=0.57,<0.58"]
 cpu = ["py-spy>=0.4.2,<0.5"]
 all = [
@@ -49,6 +50,8 @@ all = [
     "perfetto>=0.57,<0.58",
     "py-spy>=0.4.2,<0.5",
     "pyperf>=2.9",
+    "pytest>=8.3",
+    "pytest-xdist>=3.6",
     "torch>=2.7",
 ]
 dev = [

--- a/src/flameox/adapters/__init__.py
+++ b/src/flameox/adapters/__init__.py
@@ -19,6 +19,11 @@ from flameox.adapters.perfetto import (
     TraceWindowResult,
 )
 from flameox.adapters.pyperf import PyPerfExtractionResult, PyPerfExtractor
+from flameox.adapters.pytest import PytestExtractionResult, PytestExtractor
+from flameox.adapters.python_startup import (
+    PythonStartupExtractionResult,
+    PythonStartupExtractor,
+)
 from flameox.adapters.registry import (
     AdapterApproval,
     AdapterDescriptor,
@@ -48,6 +53,10 @@ __all__ = [
     "PerfettoExtractor",
     "PyPerfExtractionResult",
     "PyPerfExtractor",
+    "PytestExtractionResult",
+    "PytestExtractor",
+    "PythonStartupExtractionResult",
+    "PythonStartupExtractor",
     "RuntimeInstallation",
     "SetupClient",
     "TraceEvent",

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -113,6 +114,50 @@ BUILTIN_ADAPTERS = {
             capture_limitations=(
                 "Experiment-level treatment randomization is separate from "
                 "pyperf's worker hierarchy.",
+            ),
+        ),
+        BuiltinAdapter(
+            name="python-startup",
+            dependency_kind="internal",
+            dependency=None,
+            supported_modes=("repeated_process",),
+            supported_formats=("flameox-python-startup-json", "python-importtime"),
+            features=("wall_time", "import_cost", "module_count", "peak_rss"),
+            output_filename="python-startup.json",
+            artifact_kinds=(ArtifactKind.PYTHON_STARTUP,),
+            expected_overhead=(
+                "Fresh interpreter launches with import timing enabled; target output is "
+                "captured by the launcher and replayed after each sample."
+            ),
+            capture_limitations=(
+                "The initial OS file-cache state is observed but not controlled; flameox does "
+                "not drop caches.",
+                "Import timing instruments imports and therefore adds measurement overhead.",
+            ),
+        ),
+        BuiltinAdapter(
+            name="pytest",
+            dependency_kind="package",
+            dependency="pytest",
+            supported_modes=("serial", "xdist"),
+            supported_formats=("flameox-pytest-events-jsonl",),
+            features=(
+                "test_phases",
+                "fixture_setup",
+                "failure_latency",
+                "worker_lifecycle",
+            ),
+            output_filename="pytest-events.jsonl",
+            artifact_kinds=(ArtifactKind.TEST_EXECUTION,),
+            expected_overhead=(
+                "Pytest hook timestamps and JSONL event recording; fixture setup events are "
+                "written to bounded per-worker sidecars under xdist."
+            ),
+            capture_limitations=(
+                "Public xdist hooks expose scheduler strategy, worker lifecycle, and execution "
+                "start, but not an exact per-test controller queue timestamp.",
+                "If the entire pytest controller is forcibly terminated, sidecars not yet "
+                "recovered into the primary artifact may be unavailable.",
             ),
         ),
         BuiltinAdapter(
@@ -271,6 +316,29 @@ def build_capture_invocation(
             "--",
             *workload_argv,
         )
+    elif adapter_name == "python-startup":
+        python, _ = _python_target(workload_argv)
+        argv = (
+            python,
+            "-m",
+            "flameox.collectors.python_startup",
+            "--output",
+            output,
+            "--samples",
+            "5",
+            "--",
+            *workload_argv,
+        )
+    elif adapter_name == "pytest":
+        argv = (
+            _python_executable_for_launcher(workload_argv),
+            "-m",
+            "flameox.collectors.pytest_launcher",
+            "--output",
+            output,
+            "--",
+            *workload_argv,
+        )
     else:
         raise DomainError(
             ErrorCode.CAPABILITY_UNAVAILABLE,
@@ -310,3 +378,10 @@ def _require_executable(adapter: str, executable: str | None) -> str:
             f"Adapter {adapter!r} has no resolved executable.",
         )
     return executable
+
+
+def _python_executable_for_launcher(workload_argv: tuple[str, ...]) -> str:
+    executable = Path(workload_argv[0]).name
+    if executable.startswith("python"):
+        return workload_argv[0]
+    return sys.executable

--- a/src/flameox/adapters/pytest.py
+++ b/src/flameox/adapters/pytest.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from typing import Any
+
+from flameox.domain.errors import DomainError, ErrorCode
+from flameox.domain.identity import digest_model
+from flameox.domain.models import ArtifactKind, RunManifest
+from flameox.evidence import GenerationPublisher
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+
+class PytestExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    complete: bool
+    execution_status: str
+    collected_count: int
+    executed_count: int
+    passed_count: int
+    failed_count: int
+    skipped_count: int
+    errored_count: int
+    unexecuted_count: int
+    fixture_setup_count: int
+    fixture_setup_ns: int
+    collection_duration_ns: int | None
+    workers: tuple[str, ...]
+    interrupted: bool
+    recovered_sidecar_events: int
+    sidecar_recovery_failures: int
+    first_failure_observed_ns: int | None
+    first_failure_reported_ns: int | None
+    measurement_count: int
+    corpus_commit_id: str
+    limitations: tuple[str, ...] = ()
+
+
+class PytestExtractor:
+    name = "pytest"
+    version = "1"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.publisher = GenerationPublisher(workspace)
+
+    def extract(self, run_id: str) -> PytestExtractionResult:
+        run = RunStore(self.workspace).read(run_id)
+        registration = self._registration(run)
+        artifact = ArtifactStore(self.workspace).get(registration.artifact_id)
+        events, truncated_stream = self._events(artifact.payload_path, run_id)
+        maximum = self.workspace.config.storage.max_rows_per_generation
+        if len(events) > maximum:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                f"Pytest extraction exceeded the {maximum}-event generation limit.",
+            )
+
+        run_started = next(
+            (event for event in events if event.get("event") == "run_started"),
+            None,
+        )
+        if run_started is None:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The pytest event stream has no run_started event.",
+                run_id=run_id,
+            )
+        run_started_ns = _integer(run_started, "run_started_at_ns")
+        rows: list[dict[str, Any]] = []
+        collected: set[str] = set()
+        phases: dict[str, dict[str, str]] = defaultdict(dict)
+        workers: set[str] = set()
+        fixture_setup_count = 0
+        fixture_setup_ns = 0
+        failure_observed: list[int] = []
+        failure_reported: list[int] = []
+        limitations: list[str] = []
+        crashed = False
+        crashed_workers: set[str] = set()
+        sidecar_events = [
+            event for event in events if event.get("event") == "worker_sidecar_recovered"
+        ]
+        recovered_sidecar_events = sum(
+            _integer(event, "recovered_count") for event in sidecar_events
+        )
+        recovered_sidecars = {
+            _text(event, "worker_id")
+            for event in sidecar_events
+            if event.get("outcome") == "complete"
+        }
+        failed_sidecars = {
+            _text(event, "worker_id")
+            for event in sidecar_events
+            if event.get("outcome") != "complete"
+        }
+        interrupted = any(
+            event.get("event") in {"interrupted", "internal_error"} for event in events
+        )
+
+        for index, event in enumerate(events):
+            event_name = event.get("event")
+            if event_name == "test_collected":
+                collected.add(_text(event, "nodeid"))
+            elif event_name == "fixture_setup":
+                duration = _integer(event, "duration_ns")
+                worker_id = _text(event, "worker_id")
+                workers.add(worker_id)
+                fixture_setup_count += 1
+                fixture_setup_ns += duration
+                rows.append(
+                    self._row(
+                        run_id,
+                        registration.artifact_id,
+                        "pytest.fixture_setup",
+                        duration,
+                        "ns",
+                        index,
+                        worker_id,
+                        "setup",
+                        {
+                            "fixture": _text(event, "fixture"),
+                            "scope": _text(event, "scope"),
+                            "nodeid": str(event.get("nodeid", "")),
+                            "outcome": _text(event, "outcome"),
+                        },
+                    )
+                )
+            elif event_name == "test_phase":
+                nodeid = _text(event, "nodeid")
+                phase = _text(event, "phase")
+                outcome = _text(event, "outcome")
+                worker_id = _text(event, "worker_id")
+                workers.add(worker_id)
+                phases[nodeid][phase] = outcome
+                rows.append(
+                    self._row(
+                        run_id,
+                        registration.artifact_id,
+                        f"pytest.phase.{phase}",
+                        _integer(event, "duration_ns"),
+                        "ns",
+                        index,
+                        worker_id,
+                        phase,
+                        {"nodeid": nodeid, "outcome": outcome},
+                    )
+                )
+                if outcome == "failed":
+                    failure_observed.append(
+                        max(0, _integer(event, "stopped_at_ns") - run_started_ns)
+                    )
+                    failure_reported.append(
+                        max(
+                            0,
+                            _integer(event, "controller_received_at_ns") - run_started_ns,
+                        )
+                    )
+            elif event_name in {"worker_created", "worker_ready", "worker_down"}:
+                worker_id = _text(event, "worker_id")
+                workers.add(worker_id)
+                if event_name == "worker_down" and event.get("outcome") == "crashed":
+                    crashed = True
+                    crashed_workers.add(worker_id)
+        outcome_counts = _test_outcomes(phases)
+        executed = set(phases)
+        unexecuted = collected - executed
+        first_observed = min(failure_observed, default=None)
+        first_reported = min(failure_reported, default=None)
+        collection_started = [
+            _integer(event, "observed_at_ns")
+            for event in events
+            if event.get("event") == "collection_started"
+        ]
+        collection_finished = [
+            _integer(event, "observed_at_ns")
+            for event in events
+            if event.get("event") == "collection_finished"
+        ]
+        collection_duration = (
+            max(0, max(collection_finished) - min(collection_started))
+            if collection_started and collection_finished
+            else None
+        )
+        for name, value in (
+            ("pytest.tests.collected", len(collected)),
+            ("pytest.tests.executed", len(executed)),
+            ("pytest.tests.passed", outcome_counts["passed"]),
+            ("pytest.tests.failed", outcome_counts["failed"]),
+            ("pytest.tests.skipped", outcome_counts["skipped"]),
+            ("pytest.tests.errored", outcome_counts["errored"]),
+            ("pytest.tests.unexecuted", len(unexecuted)),
+            ("pytest.fixture_setup.total", fixture_setup_ns),
+        ):
+            rows.append(
+                self._row(
+                    run_id,
+                    registration.artifact_id,
+                    name,
+                    value,
+                    "ns" if name.endswith(".total") else "count",
+                    len(rows),
+                    None,
+                    "summary",
+                    {},
+                    aggregation="sum",
+                )
+            )
+        for name, failure_value in (
+            ("pytest.time_to_first_failure.observed", first_observed),
+            ("pytest.time_to_first_failure.reported", first_reported),
+        ):
+            if failure_value is not None:
+                rows.append(
+                    self._row(
+                        run_id,
+                        registration.artifact_id,
+                        name,
+                        failure_value,
+                        "ns",
+                        len(rows),
+                        None,
+                        "failure",
+                        {},
+                        aggregation="first",
+                    )
+                )
+
+        if collection_duration is not None:
+            rows.append(
+                self._row(
+                    run_id,
+                    registration.artifact_id,
+                    "pytest.collection",
+                    collection_duration,
+                    "ns",
+                    len(rows),
+                    None,
+                    "collection",
+                    {},
+                    aggregation="single",
+                )
+            )
+        complete, completion_limitations = _completion(
+            events,
+            interrupted=interrupted,
+            crashed=crashed,
+            failed_sidecars=failed_sidecars,
+            truncated_stream=truncated_stream,
+        )
+        limitations.extend(completion_limitations)
+        if crashed:
+            limitations.append(_crash_limitation(crashed_workers, recovered_sidecars))
+        if any(event.get("scheduler") not in {None, "no"} for event in events):
+            limitations.append(
+                "Stable xdist hooks do not expose exact per-test controller queue latency."
+            )
+        published = self.publisher.publish_rows(
+            {"measurements": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=(registration.artifact_id,),
+        )
+        return PytestExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            complete=complete,
+            execution_status=run.execution_status.value,
+            collected_count=len(collected),
+            executed_count=len(executed),
+            passed_count=outcome_counts["passed"],
+            failed_count=outcome_counts["failed"],
+            skipped_count=outcome_counts["skipped"],
+            errored_count=outcome_counts["errored"],
+            unexecuted_count=len(unexecuted),
+            fixture_setup_count=fixture_setup_count,
+            fixture_setup_ns=fixture_setup_ns,
+            collection_duration_ns=collection_duration,
+            workers=tuple(sorted(workers)),
+            interrupted=interrupted,
+            recovered_sidecar_events=recovered_sidecar_events,
+            sidecar_recovery_failures=len(failed_sidecars),
+            first_failure_observed_ns=first_observed,
+            first_failure_reported_ns=first_reported,
+            measurement_count=len(rows),
+            corpus_commit_id=published.commit.commit_id,
+            limitations=tuple(limitations),
+        )
+
+    def _registration(self, run: RunManifest) -> Any:
+        matches = [item for item in run.artifacts if item.kind is ArtifactKind.TEST_EXECUTION]
+        if len(matches) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one pytest event artifact.",
+                run_id=run.run_id,
+            )
+        return matches[0]
+
+    def _events(self, path: Any, run_id: str) -> tuple[list[dict[str, Any]], bool]:
+        events: list[dict[str, Any]] = []
+        truncated = False
+        try:
+            with path.open(encoding="utf-8") as stream:
+                for line in stream:
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        if not line.endswith("\n") and stream.read(1) == "":
+                            truncated = True
+                            break
+                        raise
+                    if (
+                        not isinstance(event, dict)
+                        or event.get("schema") != "flameox.pytest-event.v1"
+                    ):
+                        raise ValueError("unsupported event")
+                    events.append(event)
+        except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The artifact is not a supported pytest event stream.",
+                run_id=run_id,
+            ) from exc
+        return events, truncated
+
+    def _row(
+        self,
+        run_id: str,
+        artifact_id: str,
+        name: str,
+        value: int,
+        unit: str,
+        value_index: int,
+        worker_id: str | None,
+        phase: str,
+        dimensions: dict[str, str],
+        *,
+        aggregation: str = "sample",
+    ) -> dict[str, Any]:
+        identity = {
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "name": name,
+            "value_index": value_index,
+            "worker_id": worker_id,
+            "dimensions": dimensions,
+        }
+        return {
+            "measurement_id": digest_model(identity),
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "name": name,
+            "value_int": value,
+            "value_float": None,
+            "unit": unit,
+            "aggregation": aggregation,
+            "scope": "test_suite",
+            "trial_id": None,
+            "worker_id": worker_id,
+            "worker_run_index": None,
+            "value_index": value_index,
+            "loop_count": None,
+            "is_warmup": False,
+            "block_id": None,
+            "variant_id": None,
+            "order_in_block": None,
+            "phase": phase,
+            "dimensions": dimensions,
+            "evidence_level": "observed",
+        }
+
+
+def _test_outcomes(phases: dict[str, dict[str, str]]) -> dict[str, int]:
+    counts = {"passed": 0, "failed": 0, "skipped": 0, "errored": 0}
+    for reports in phases.values():
+        if reports.get("setup") == "failed" or reports.get("teardown") == "failed":
+            counts["errored"] += 1
+        elif reports.get("call") == "failed":
+            counts["failed"] += 1
+        elif "skipped" in reports.values():
+            counts["skipped"] += 1
+        elif reports.get("call") == "passed":
+            counts["passed"] += 1
+        else:
+            counts["errored"] += 1
+    return counts
+
+
+def _completion(
+    events: list[dict[str, Any]],
+    *,
+    interrupted: bool,
+    crashed: bool,
+    failed_sidecars: set[str],
+    truncated_stream: bool,
+) -> tuple[bool, list[str]]:
+    limitations: list[str] = []
+    has_terminal_event = any(event.get("event") == "session_finished" for event in events)
+    if not has_terminal_event:
+        limitations.append("The pytest session did not emit a terminal event; evidence is partial.")
+    if interrupted:
+        limitations.append("The pytest session was interrupted or ended with an internal error.")
+    if truncated_stream:
+        limitations.append(
+            "The pytest event stream ended with a truncated record; "
+            "the valid prefix was recovered."
+        )
+    if failed_sidecars:
+        limitations.append(
+            "One or more worker sidecars were unavailable, partial, or failed recovery."
+        )
+    complete = (
+        has_terminal_event
+        and not interrupted
+        and not crashed
+        and not failed_sidecars
+        and not truncated_stream
+    )
+    return complete, limitations
+
+
+def _crash_limitation(
+    crashed_workers: set[str],
+    recovered_sidecars: set[str],
+) -> str:
+    unrecovered_crashes = crashed_workers - recovered_sidecars
+    if unrecovered_crashes:
+        return (
+            "At least one crashed xdist worker had no complete recoverable fixture sidecar: "
+            + ", ".join(sorted(unrecovered_crashes))
+            + "."
+        )
+    return (
+        "Fixture and test-start events emitted before an xdist worker crash were "
+        "recovered from bounded sidecars."
+    )
+
+
+def _integer(value: dict[str, Any], field: str) -> int:
+    result = value.get(field)
+    if not isinstance(result, int) or isinstance(result, bool) or result < 0:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"Pytest event field {field!r} is invalid.",
+        )
+    return result
+
+
+def _text(value: dict[str, Any], field: str) -> str:
+    result = value.get(field)
+    if not isinstance(result, str) or not result:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"Pytest event field {field!r} is invalid.",
+        )
+    return result

--- a/src/flameox/adapters/pytest.py
+++ b/src/flameox/adapters/pytest.py
@@ -407,8 +407,7 @@ def _completion(
         limitations.append("The pytest session was interrupted or ended with an internal error.")
     if truncated_stream:
         limitations.append(
-            "The pytest event stream ended with a truncated record; "
-            "the valid prefix was recovered."
+            "The pytest event stream ended with a truncated record; the valid prefix was recovered."
         )
     if failed_sidecars:
         limitations.append(

--- a/src/flameox/adapters/python_startup.py
+++ b/src/flameox/adapters/python_startup.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from flameox.domain.errors import DomainError, ErrorCode
+from flameox.domain.identity import digest_model
+from flameox.domain.models import ArtifactKind, RunManifest
+from flameox.evidence import GenerationPublisher
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+
+class PythonStartupExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    sample_count: int
+    package_count: int
+    measurement_count: int
+    peak_rss_backends: tuple[str, ...]
+    corpus_commit_id: str
+    limitations: tuple[str, ...] = ()
+
+
+class PythonStartupExtractor:
+    name = "python-startup"
+    version = "1"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.publisher = GenerationPublisher(workspace)
+
+    def extract(self, run_id: str) -> PythonStartupExtractionResult:
+        run = RunStore(self.workspace).read(run_id)
+        registration = self._registration(run)
+        artifact = ArtifactStore(self.workspace).get(registration.artifact_id)
+        try:
+            payload = json.loads(artifact.payload_path.read_text())
+            if (
+                not isinstance(payload, dict)
+                or payload.get("schema") != "flameox.python-startup.v1"
+            ):
+                raise ValueError("unsupported schema")
+            samples = payload["samples"]
+            if not isinstance(samples, list) or not samples:
+                raise ValueError("samples are missing")
+        except (
+            OSError,
+            UnicodeError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The artifact is not a supported Python startup capture.",
+                run_id=run_id,
+            ) from exc
+
+        rows: list[dict[str, Any]] = []
+        packages: set[str] = set()
+        limitations = [
+            "The initial OS file-cache state was uncontrolled; no caches were dropped.",
+            "Import-time instrumentation affects the separate trace process, not wall samples.",
+        ]
+        missing_rss = False
+        peak_rss_backends: set[str] = set()
+        for sample in samples:
+            index = _integer(sample, "index")
+            cache_semantics = _text(sample, "cache_semantics")
+            dimensions = {"cache_semantics": cache_semantics}
+            rows.append(
+                self._row(
+                    run_id,
+                    registration.artifact_id,
+                    "python_startup.wall_time",
+                    _integer(sample, "duration_ns"),
+                    "ns",
+                    index,
+                    "startup",
+                    dimensions,
+                )
+            )
+            peak_rss = sample.get("peak_rss_bytes")
+            if isinstance(peak_rss, int):
+                peak_rss_backend = _text(sample, "peak_rss_backend")
+                peak_rss_backends.add(peak_rss_backend)
+                rows.append(
+                    self._row(
+                        run_id,
+                        registration.artifact_id,
+                        "python_startup.peak_rss",
+                        peak_rss,
+                        "bytes",
+                        index,
+                        "startup",
+                        {**dimensions, "rss_backend": peak_rss_backend},
+                    )
+                )
+            else:
+                missing_rss = True
+        import_trace = payload.get("import_trace")
+        if not isinstance(import_trace, dict):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The Python startup artifact has no import trace.",
+                run_id=run_id,
+            )
+        package_rows = import_trace.get("packages")
+        if not isinstance(package_rows, list):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The Python startup import package list is invalid.",
+                run_id=run_id,
+            )
+        for package in package_rows:
+            package_name = _text(package, "package")
+            packages.add(package_name)
+            package_dimensions = {"package": package_name}
+            for name, field, unit in (
+                ("python_startup.import.module_count", "module_count", "count"),
+                ("python_startup.import.self_time", "self_us", "us"),
+                (
+                    "python_startup.import.max_cumulative_time",
+                    "max_cumulative_us",
+                    "us",
+                ),
+            ):
+                rows.append(
+                    self._row(
+                        run_id,
+                        registration.artifact_id,
+                        name,
+                        _integer(package, field),
+                        unit,
+                        0,
+                        "import",
+                        package_dimensions,
+                    )
+                )
+        if missing_rss:
+            limitations.append("Peak RSS was unavailable for at least one short-lived sample.")
+        unparsed_lines = import_trace.get("unparsed_importtime_lines", 0)
+        if (
+            not isinstance(unparsed_lines, int)
+            or isinstance(unparsed_lines, bool)
+            or unparsed_lines < 0
+        ):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The Python startup unparsed-line count is invalid.",
+                run_id=run_id,
+            )
+        if unparsed_lines:
+            limitations.append(
+                f"{unparsed_lines} import-time data lines used an unsupported representation."
+            )
+        maximum = self.workspace.config.storage.max_rows_per_generation
+        if len(rows) > maximum:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                f"Python startup extraction exceeded the {maximum}-row generation limit.",
+            )
+        published = self.publisher.publish_rows(
+            {"measurements": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=(registration.artifact_id,),
+        )
+        return PythonStartupExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            sample_count=len(samples),
+            package_count=len(packages),
+            measurement_count=len(rows),
+            peak_rss_backends=tuple(sorted(peak_rss_backends)),
+            corpus_commit_id=published.commit.commit_id,
+            limitations=tuple(limitations),
+        )
+
+    def _registration(self, run: RunManifest) -> Any:
+        matches = [item for item in run.artifacts if item.kind is ArtifactKind.PYTHON_STARTUP]
+        if len(matches) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one Python startup artifact.",
+                run_id=run.run_id,
+            )
+        return matches[0]
+
+    def _row(
+        self,
+        run_id: str,
+        artifact_id: str,
+        name: str,
+        value: int,
+        unit: str,
+        value_index: int,
+        phase: str,
+        dimensions: dict[str, str],
+    ) -> dict[str, Any]:
+        identity = {
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "name": name,
+            "value_index": value_index,
+            "dimensions": dimensions,
+        }
+        return {
+            "measurement_id": digest_model(identity),
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "name": name,
+            "value_int": value,
+            "value_float": None,
+            "unit": unit,
+            "aggregation": "sample",
+            "scope": "workload",
+            "trial_id": None,
+            "worker_id": None,
+            "worker_run_index": None,
+            "value_index": value_index,
+            "loop_count": None,
+            "is_warmup": False,
+            "block_id": None,
+            "variant_id": None,
+            "order_in_block": None,
+            "phase": phase,
+            "dimensions": dimensions,
+            "evidence_level": "observed",
+        }
+
+
+def _integer(value: Any, field: str) -> int:
+    result = value.get(field) if isinstance(value, dict) else None
+    if not isinstance(result, int) or isinstance(result, bool) or result < 0:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"Python startup field {field!r} is invalid.",
+        )
+    return result
+
+
+def _text(value: Any, field: str) -> str:
+    result = value.get(field) if isinstance(value, dict) else None
+    if not isinstance(result, str) or not result:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"Python startup field {field!r} is invalid.",
+        )
+    return result

--- a/src/flameox/application/async_work.py
+++ b/src/flameox/application/async_work.py
@@ -4,6 +4,8 @@ import asyncio
 from collections.abc import Callable
 from contextlib import suppress
 
+import anyio
+
 
 def _consume_completion(task: asyncio.Task[object]) -> None:
     with suppress(asyncio.CancelledError):
@@ -21,10 +23,21 @@ async def run_atomic_thread[T](
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError as cancellation:
-        try:
-            async with asyncio.timeout(cleanup_timeout_seconds):
-                await asyncio.shield(asyncio.gather(task, return_exceptions=True))
-        except TimeoutError:
+        deadline = asyncio.get_running_loop().time() + cleanup_timeout_seconds
+        with anyio.CancelScope(shield=True):
+            while not task.done():
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    break
+                try:
+                    await asyncio.wait({task}, timeout=remaining)
+                except asyncio.CancelledError:
+                    # asyncio cancellation is edge-triggered and bypasses an
+                    # AnyIO shield. Keep the durability barrier intact when a
+                    # caller repeats cancellation while the thread settles.
+                    continue
+        if task.done():
+            _consume_completion(task)
+        else:
             task.add_done_callback(_consume_completion)
-        finally:
-            raise cancellation
+        raise cancellation

--- a/src/flameox/application/capabilities.py
+++ b/src/flameox/application/capabilities.py
@@ -43,18 +43,21 @@ class CapabilityService:
         system = platform.system().lower()
         architecture = platform.machine().lower()
         reports: list[CapabilityReport] = []
-        command = BUILTIN_ADAPTERS["command"]
-        reports.append(
-            CapabilityReport(
-                adapter=command.name,
-                status=CapabilityStatus.AVAILABLE,
-                supported_modes=command.supported_modes,
-                supported_formats=command.supported_formats,
-                platform=system,
-                architecture=architecture,
-                limitations=command.capture_limitations,
+        for adapter in BUILTIN_ADAPTERS.values():
+            if adapter.dependency_kind != "internal":
+                continue
+            reports.append(
+                CapabilityReport(
+                    adapter=adapter.name,
+                    status=CapabilityStatus.AVAILABLE,
+                    supported_modes=adapter.supported_modes,
+                    supported_formats=adapter.supported_formats,
+                    platform=system,
+                    architecture=architecture,
+                    features=adapter.features,
+                    limitations=adapter.capture_limitations,
+                )
             )
-        )
         executable_adapters = (
             adapter
             for adapter in BUILTIN_ADAPTERS.values()

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -67,11 +67,13 @@ from flameox.domain import (
 )
 from flameox.domain.models import utc_now
 from flameox.evidence import GenerationPublisher
-from flameox.execution import ExecutionRequest, ResourcePolicy, SubprocessBroker
+from flameox.execution import ExecutionOutcome, ExecutionRequest, ResourcePolicy, SubprocessBroker
 from flameox.models import ContractModel
 from flameox.observability import OperationLogger, elapsed_ms
 from flameox.storage import ArtifactStore, RunStore, StorageQuota, Workspace
 from flameox.storage.atomic import atomic_write_bytes
+
+_MAX_PYTEST_SIDECAR_BYTES = 16 * 1024 * 1024
 
 
 class CaptureResult(ContractModel):
@@ -651,19 +653,35 @@ class CaptureService:
                 if error.code is ErrorCode.PROCESS_TIMEOUT
                 else ExecutionStatus.FAILED
             )
-            terminal = await capture.terminate(
-                execution=status,
-                message=error.message,
-                phase="collector execution failed",
-                error_code=error.code.value,
-                process=(
-                    ProcessResult.model_validate(error.details["process"])
-                    if "process" in error.details
-                    else None
-                ),
+            partial_process = (
+                ProcessResult.model_validate(error.details["process"])
+                if "process" in error.details
+                else None
             )
-            error.run_id = terminal.run_id
-            raise
+            native = output_root / self._native_filename(plan.adapter)
+            if (
+                status is ExecutionStatus.TIMED_OUT
+                and partial_process is not None
+                and native.is_file()
+            ):
+                outcome = ExecutionOutcome(
+                    process=partial_process,
+                    stdout=b"",
+                    stderr=b"",
+                    resolved_executable=Path(plan.collector_argv[0]).resolve(),
+                    containment=plan.containment,
+                )
+                await capture.report(5, "Collector timed out; preserving partial evidence")
+            else:
+                terminal = await capture.terminate(
+                    execution=status,
+                    message=error.message,
+                    phase="collector execution failed",
+                    error_code=error.code.value,
+                    process=partial_process,
+                )
+                error.run_id = terminal.run_id
+                raise
         finally:
             if acquired_slot:
                 self.plans.release_capture_slot()
@@ -873,14 +891,21 @@ class CaptureService:
             error.run_id = terminal.run_id
             raise
         succeeded = outcome.process.exit_code == 0
+        timed_out = outcome.process.timed_out
         terminal = running.model_copy(
             update={
                 "revision": running.revision + 1,
                 "finished_at": utc_now(),
                 "execution_status": (
-                    ExecutionStatus.SUCCEEDED if succeeded else ExecutionStatus.FAILED
+                    ExecutionStatus.TIMED_OUT
+                    if timed_out
+                    else (ExecutionStatus.SUCCEEDED if succeeded else ExecutionStatus.FAILED)
                 ),
-                "capture_status": (CaptureStatus.REGISTERED if succeeded else CaptureStatus.FAILED),
+                "capture_status": (
+                    CaptureStatus.REGISTERED
+                    if succeeded or (timed_out and registrations)
+                    else CaptureStatus.FAILED
+                ),
                 "validation_status": validation_status,
                 "process": outcome.process,
                 "artifacts": tuple(registration for registration, _ in registrations),
@@ -889,7 +914,11 @@ class CaptureService:
                     + (
                         []
                         if succeeded
-                        else [f"Collector exited with status {outcome.process.exit_code}."]
+                        else (
+                            ["Collector timed out; registered artifacts may be partial."]
+                            if timed_out
+                            else [f"Collector exited with status {outcome.process.exit_code}."]
+                        )
                     )
                     + validation_limitations
                 ),
@@ -1520,7 +1549,56 @@ class CaptureService:
                     "limitations": list(extraction.limitations),
                 }
             )
+        if plan.adapter == "pytest":
+            sidecars, sidecar_limitations = await self._preserve_pytest_sidecars(
+                plan,
+                output_root,
+                execution_plan,
+            )
+            registrations.extend(sidecars)
+            limitations.extend(sidecar_limitations)
         return registrations, extractions, limitations
+
+    async def _preserve_pytest_sidecars(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+        execution_plan: AdapterExecutionPlan,
+    ) -> tuple[list[tuple[ArtifactRegistration, int]], list[str]]:
+        registrations: list[tuple[ArtifactRegistration, int]] = []
+        limitations: list[str] = []
+        for declaration in execution_plan.artifacts:
+            if declaration.kind is not ArtifactKind.TEST_EXECUTION:
+                continue
+            primary = output_root / declaration.relative_path
+            for sidecar in sorted(primary.parent.glob(f"{primary.name}.*.worker")):
+                if sidecar.is_symlink() or not sidecar.is_file():
+                    limitations.append(
+                        "An unrecovered pytest worker sidecar was not a regular file."
+                    )
+                    continue
+                if sidecar.stat().st_size > _MAX_PYTEST_SIDECAR_BYTES:
+                    limitations.append(
+                        "An unrecovered pytest worker sidecar exceeded the preservation limit."
+                    )
+                    continue
+                registrations.append(
+                    await self._register_path_async(
+                        plan.run_id,
+                        sidecar,
+                        kind=ArtifactKind.PROCESS_OUTPUT,
+                        role="pytest_worker_sidecar_unrecovered",
+                        media_type="application/x-ndjson",
+                        producer=plan.adapter,
+                        producer_version=plan.adapter_version,
+                        sensitivity=declaration.sensitivity,
+                    )
+                )
+        if registrations:
+            limitations.append(
+                "Unrecovered pytest worker sidecars were preserved as native artifacts."
+            )
+        return registrations, limitations
 
     def _register_path(
         self,

--- a/src/flameox/application/experiments.py
+++ b/src/flameox/application/experiments.py
@@ -15,7 +15,7 @@ from typing import Literal, cast
 
 from pydantic import Field, JsonValue
 
-from flameox.adapters import PyPerfExtractor
+from flameox.adapters import PyPerfExtractor, PytestExtractor, PythonStartupExtractor
 from flameox.application.async_work import run_atomic_thread
 from flameox.application.capture import CaptureService
 from flameox.application.comparisons import (
@@ -29,6 +29,7 @@ from flameox.application.comparisons import (
 from flameox.application.execution_policy import ExecutionPolicy
 from flameox.application.workloads import ExperimentConfig, Scalar, WorkloadService
 from flameox.domain import (
+    ArtifactKind,
     DomainError,
     ErrorCode,
     Experiment,
@@ -49,6 +50,24 @@ from flameox.domain.models import utc_now
 from flameox.evidence import GenerationPublisher, PublishedGeneration
 from flameox.models import ContractModel
 from flameox.storage import JsonRecordStore, RunStore, Workspace
+
+
+def _extract_adapter_measurements(workspace: Workspace, adapter: str, run_id: str) -> None:
+    if adapter == "pyperf":
+        PyPerfExtractor(workspace).extract(run_id)
+    elif adapter == "python-startup":
+        PythonStartupExtractor(workspace).extract(run_id)
+    elif adapter == "pytest":
+        PytestExtractor(workspace).extract(run_id)
+
+
+def _has_extractable_artifact(run: RunManifest, adapter: str) -> bool:
+    expected = {
+        "pyperf": ArtifactKind.BENCHMARK_SAMPLES,
+        "python-startup": ArtifactKind.PYTHON_STARTUP,
+        "pytest": ArtifactKind.TEST_EXECUTION,
+    }.get(adapter)
+    return expected is not None and any(item.kind is expected for item in run.artifacts)
 
 
 class ExperimentCell(ContractModel):
@@ -481,10 +500,12 @@ class ExperimentService:
                 captured = await self.captures.execute(capture_plan.plan_id)
                 run = captured.run
                 outcome, failure_class = self._classify_run(run)
-                if outcome is TrialOutcome.SUCCEEDED and plan.adapter == "pyperf":
+                if _has_extractable_artifact(run, plan.adapter):
                     await run_atomic_thread(
                         partial(
-                            PyPerfExtractor(self.workspace).extract,
+                            _extract_adapter_measurements,
+                            self.workspace,
+                            plan.adapter,
                             run.run_id,
                         )
                     )

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -23,6 +23,8 @@ from flameox.adapters import (
     ObservationExtractor,
     PerfettoExtractor,
     PyPerfExtractor,
+    PytestExtractor,
+    PythonStartupExtractor,
     SetupClient,
 )
 from flameox.analysis import RecipeService
@@ -1705,6 +1707,34 @@ def extract_pyperf(
     """Extract pyperf workers, warmups, loops, and raw values."""
     try:
         result = PyPerfExtractor(_workspace(workspace)).extract(run_id)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@extract_app.command("python-startup")
+def extract_python_startup(
+    run_id: Annotated[str, typer.Argument(help="Run containing Python startup JSON.")],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract startup samples, peak RSS, and package-grouped import costs."""
+    try:
+        result = PythonStartupExtractor(_workspace(workspace)).extract(run_id)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@extract_app.command("pytest")
+def extract_pytest(
+    run_id: Annotated[str, typer.Argument(help="Run containing pytest event JSONL.")],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract test phases, fixture cost, worker lifecycle, and failure latency."""
+    try:
+        result = PytestExtractor(_workspace(workspace)).extract(run_id)
     except DomainError as error:
         _fail(error)
     _emit(result, as_json=json_output)

--- a/src/flameox/collectors/pytest_launcher.py
+++ b/src/flameox/collectors/pytest_launcher.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("workload", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    workload = arguments.workload[1:] if arguments.workload[:1] == ["--"] else arguments.workload
+    if not workload:
+        parser.error("a pytest workload is required")
+
+    executable = Path(workload[0]).name
+    if executable.startswith("python"):
+        if len(workload) < 3 or workload[1:3] != ["-m", "pytest"]:
+            parser.error("Python workloads must invoke `python -m pytest`")
+        command = [*workload[:3], "-p", "flameox.collectors.pytest_plugin", *workload[3:]]
+    elif executable.startswith("pytest"):
+        command = [workload[0], "-p", "flameox.collectors.pytest_plugin", *workload[1:]]
+    else:
+        parser.error("the pytest adapter requires `pytest` or `python -m pytest`")
+
+    environment = os.environ.copy()
+    environment["FLAMEOX_PYTEST_EVIDENCE_PATH"] = str(arguments.output)
+    environment["FLAMEOX_PYTEST_RUN_STARTED_NS"] = str(time.time_ns())
+    os.execvpe(command[0], command, environment)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flameox/collectors/pytest_plugin.py
+++ b/src/flameox/collectors/pytest_plugin.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_MAX_SIDECAR_BYTES = 16 * 1024 * 1024
+_SIDECAR_MARKER_RESERVE = 512
+_SIDECAR_INPUT = "flameox_evidence_sidecar"
+_SIDECAR_EVENTS = {"fixture_setup", "test_started", "sidecar_truncated"}
+_output: Path | None = None
+_worker_id = "master"
+_wrote_collection = False
+_sidecar_truncated = False
+
+
+def _append_payload(payload: dict[str, Any]) -> None:
+    global _sidecar_truncated
+    if _output is None:
+        return
+    encoded = json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True) + "\n"
+    if _worker_id != "master":
+        if _sidecar_truncated:
+            return
+        current_size = _output.stat().st_size if _output.exists() else 0
+        if current_size + len(encoded.encode()) + _SIDECAR_MARKER_RESERVE > _MAX_SIDECAR_BYTES:
+            _sidecar_truncated = True
+            encoded = (
+                json.dumps(
+                    {
+                        "schema": "flameox.pytest-event.v1",
+                        "event": "sidecar_truncated",
+                        "observed_at_ns": time.time_ns(),
+                        "worker_id": _worker_id,
+                    },
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+                + "\n"
+            )
+    with _output.open("a", encoding="utf-8") as stream:
+        stream.write(encoded)
+        stream.flush()
+
+
+def _write(event: str, **fields: Any) -> None:
+    _append_payload(
+        {
+            "schema": "flameox.pytest-event.v1",
+            "event": event,
+            "observed_at_ns": time.time_ns(),
+            **fields,
+        }
+    )
+
+
+def _sidecar_path(primary: Path, worker_id: str) -> Path:
+    worker_digest = hashlib.sha256(worker_id.encode()).hexdigest()[:16]
+    return primary.with_name(f"{primary.name}.{worker_digest}.worker")
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    global _output, _worker_id
+    configured = os.environ.get("FLAMEOX_PYTEST_EVIDENCE_PATH")
+    if configured is None:
+        return
+    worker_input = getattr(config, "workerinput", None)
+    _worker_id = str(worker_input.get("workerid", "worker")) if worker_input else "master"
+    if worker_input:
+        sidecar = worker_input.get(_SIDECAR_INPUT)
+        if isinstance(sidecar, str):
+            _output = Path(sidecar)
+        return
+    _output = Path(configured)
+    _output.parent.mkdir(parents=True, exist_ok=True)
+    _output.write_text("")
+    _write(
+        "run_started",
+        run_started_at_ns=int(os.environ["FLAMEOX_PYTEST_RUN_STARTED_NS"]),
+        pytest_version=pytest.__version__,
+        python_version=platform.python_version(),
+        platform=platform.platform(),
+        scheduler=str(getattr(config.option, "dist", "no")),
+        requested_workers=str(getattr(config.option, "numprocesses", 0) or 0),
+    )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    if _worker_id == "master":
+        _write("session_started")
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_collection(session: pytest.Session) -> Any:
+    if _worker_id == "master":
+        _write("collection_started")
+    return (yield)
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    global _wrote_collection
+    if _worker_id != "master" or getattr(session.config.option, "numprocesses", None):
+        return
+    for item in session.items:
+        _write("test_collected", nodeid=item.nodeid)
+    _wrote_collection = True
+    _write("collection_finished", test_count=len(session.items), worker_id="master")
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_fixture_setup(fixturedef: Any, request: pytest.FixtureRequest) -> Any:
+    start_ns = time.time_ns()
+    start = time.perf_counter_ns()
+    outcome = "passed"
+    try:
+        result = yield
+    except BaseException:
+        outcome = "failed"
+        raise
+    finally:
+        _append_payload(
+            {
+                "schema": "flameox.pytest-event.v1",
+                "event": "fixture_setup",
+                "observed_at_ns": start_ns,
+                "duration_ns": time.perf_counter_ns() - start,
+                "fixture": str(fixturedef.argname),
+                "scope": str(fixturedef.scope),
+                "nodeid": getattr(request.node, "nodeid", ""),
+                "worker_id": _worker_id,
+                "outcome": outcome,
+            }
+        )
+    return result
+
+
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    if _worker_id != "master":
+        _append_payload(
+            {
+                "schema": "flameox.pytest-event.v1",
+                "event": "test_started",
+                "observed_at_ns": time.time_ns(),
+                "nodeid": nodeid,
+                "worker_id": _worker_id,
+            }
+        )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if _output is None or _worker_id != "master":
+        return
+    worker_id = str(getattr(report, "worker_id", _worker_id))
+    _write(
+        "test_phase",
+        nodeid=report.nodeid,
+        worker_id=worker_id,
+        phase=report.when,
+        outcome=report.outcome,
+        duration_ns=round(report.duration * 1_000_000_000),
+        started_at_ns=round(report.start * 1_000_000_000),
+        stopped_at_ns=round(report.stop * 1_000_000_000),
+        controller_received_at_ns=time.time_ns(),
+        wasxfail=bool(getattr(report, "wasxfail", False)),
+    )
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int | pytest.ExitCode) -> None:
+    if _worker_id == "master":
+        _write("session_finished", exit_status=int(exitstatus))
+
+
+def pytest_keyboard_interrupt(excinfo: pytest.ExceptionInfo[BaseException]) -> None:
+    if _worker_id == "master":
+        _write("interrupted", exception_type=excinfo.typename)
+
+
+def pytest_internalerror(
+    excrepr: Any,
+    excinfo: pytest.ExceptionInfo[BaseException],
+) -> None:
+    if _worker_id == "master":
+        _write("internal_error", exception_type=excinfo.typename)
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_configure_node(node: Any) -> None:
+    worker_id = str(node.gateway.id)
+    if _output is not None:
+        sidecar = _sidecar_path(_output, worker_id)
+        sidecar.write_text("")
+        node.workerinput[_SIDECAR_INPUT] = str(sidecar)
+    _write("worker_created", worker_id=worker_id)
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodeready(node: Any) -> None:
+    _write("worker_ready", worker_id=str(node.gateway.id))
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_xdist_node_collection_finished(node: Any, ids: list[str]) -> None:
+    global _wrote_collection
+    worker_id = str(node.gateway.id)
+    if not _wrote_collection:
+        for nodeid in ids:
+            _write("test_collected", nodeid=nodeid)
+        _wrote_collection = True
+    _write("collection_finished", test_count=len(ids), worker_id=worker_id)
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node: Any, error: object | None) -> None:
+    _recover_sidecar(node)
+    _write(
+        "worker_down",
+        worker_id=str(node.gateway.id),
+        outcome="crashed" if error is not None else "clean",
+        error_type=type(error).__name__ if error is not None else None,
+    )
+
+
+def _recover_sidecar(node: Any) -> None:
+    configured = node.workerinput.get(_SIDECAR_INPUT)
+    worker_id = str(node.gateway.id)
+    if not isinstance(configured, str):
+        _write(
+            "worker_sidecar_recovered",
+            worker_id=worker_id,
+            recovered_count=0,
+            rejected_count=0,
+            outcome="unavailable",
+        )
+        return
+    sidecar = Path(configured)
+    recovered = 0
+    rejected = 0
+    truncated = False
+    outcome = "failed"
+    try:
+        if _output is None or sidecar != _sidecar_path(_output, worker_id):
+            raise ValueError("sidecar path differs from controller allocation")
+        if sidecar.is_symlink() or not sidecar.is_file():
+            raise FileNotFoundError(sidecar)
+        remaining = _MAX_SIDECAR_BYTES
+        with sidecar.open("rb") as stream:
+            while line := stream.readline(remaining + 1):
+                if len(line) > remaining:
+                    raise ValueError("sidecar exceeds recovery budget")
+                remaining -= len(line)
+                try:
+                    payload = json.loads(line.decode())
+                    if (
+                        not isinstance(payload, dict)
+                        or payload.get("schema") != "flameox.pytest-event.v1"
+                        or payload.get("event") not in _SIDECAR_EVENTS
+                        or payload.get("worker_id") != worker_id
+                    ):
+                        raise ValueError("invalid sidecar event")
+                    _append_payload(payload)
+                    if payload["event"] == "sidecar_truncated":
+                        truncated = True
+                    else:
+                        recovered += 1
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    rejected += 1
+        outcome = "complete" if rejected == 0 and not truncated else "partial"
+    except (OSError, UnicodeError, ValueError):
+        outcome = "failed"
+    if outcome == "complete":
+        try:
+            sidecar.unlink(missing_ok=True)
+        except OSError:
+            if outcome == "complete":
+                outcome = "partial"
+    _write(
+        "worker_sidecar_recovered",
+        worker_id=worker_id,
+        recovered_count=recovered,
+        rejected_count=rejected,
+        outcome=outcome,
+        truncated=truncated,
+    )

--- a/src/flameox/collectors/pytest_plugin.py
+++ b/src/flameox/collectors/pytest_plugin.py
@@ -141,6 +141,7 @@ def pytest_fixture_setup(fixturedef: Any, request: pytest.FixtureRequest) -> Any
 
 
 def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
+    del location
     if _worker_id != "master":
         _append_payload(
             {
@@ -186,6 +187,7 @@ def pytest_internalerror(
     excrepr: Any,
     excinfo: pytest.ExceptionInfo[BaseException],
 ) -> None:
+    del excrepr
     if _worker_id == "master":
         _write("internal_error", exception_type=excinfo.typename)
 

--- a/src/flameox/collectors/python_startup.py
+++ b/src/flameox/collectors/python_startup.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+_IMPORT_TIME = re.compile(
+    r"^import time:\s+(?P<self>\d+)\s+\|\s+(?P<cumulative>\d+)\s+\|\s+(?P<module>.+)$"
+)
+
+
+def _handle_termination(signum: int, _frame: object) -> None:
+    raise SystemExit(128 + signum)
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--samples", type=int, default=5)
+    parser.add_argument("workload", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if arguments.workload[:1] == ["--"]:
+        arguments.workload = arguments.workload[1:]
+    if not arguments.workload or arguments.samples < 1:
+        parser.error("a workload and at least one sample are required")
+    return arguments
+
+
+def _poll_peak_rss(process: subprocess.Popen[bytes]) -> int | None:
+    peak = 0
+    ps_process = psutil.Process(process.pid)
+    while process.poll() is None:
+        try:
+            processes = (ps_process, *ps_process.children(recursive=True))
+            peak = max(
+                peak,
+                sum(item.memory_info().rss for item in processes if item.is_running()),
+            )
+        except (psutil.Error, OSError):
+            pass
+        time.sleep(0.005)
+    return peak or None
+
+
+def _wait4_peak_rss(process: subprocess.Popen[bytes]) -> int:
+    _, status, usage = os.wait4(process.pid, 0)
+    process.returncode = os.waitstatus_to_exitcode(status)
+    peak_rss = int(usage.ru_maxrss)
+    if sys.platform != "darwin":
+        peak_rss *= 1024
+    return peak_rss
+
+
+def _terminate_process_group(pid: int) -> None:
+    if os.name != "posix":
+        return
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    time.sleep(0.05)
+    with suppress(ProcessLookupError):
+        os.killpg(pid, signal.SIGKILL)
+
+
+def _execute(
+    command: tuple[str, ...],
+) -> tuple[bytes, bytes, int | None, str, int, int]:
+    before_ns = time.perf_counter_ns()
+    with tempfile.TemporaryFile() as stdout_stream, tempfile.TemporaryFile() as stderr_stream:
+        process = subprocess.Popen(
+            command,
+            stdout=stdout_stream,
+            stderr=stderr_stream,
+            start_new_session=os.name == "posix",
+        )
+        try:
+            peak_rss: int | None
+            if hasattr(os, "wait4"):
+                peak_rss = _wait4_peak_rss(process)
+                rss_backend = "wait4_ru_maxrss"
+            else:
+                peak_rss = _poll_peak_rss(process)
+                rss_backend = "psutil_polling"
+        finally:
+            _terminate_process_group(process.pid)
+        stdout_stream.seek(0)
+        stderr_stream.seek(0)
+        stdout = stdout_stream.read()
+        stderr = stderr_stream.read()
+    if process.returncode is None:
+        raise RuntimeError("child process did not report an exit status")
+    return (
+        stdout,
+        stderr,
+        peak_rss,
+        rss_backend,
+        time.perf_counter_ns() - before_ns,
+        process.returncode,
+    )
+
+
+def _group_imports(stderr: str) -> tuple[str, list[dict[str, Any]], int]:
+    raw_lines: list[str] = []
+    modules: dict[str, tuple[int, int]] = {}
+    ignored_lines = 0
+    for line in stderr.splitlines():
+        if not line.startswith("import time:"):
+            continue
+        raw_lines.append(line)
+        match = _IMPORT_TIME.match(line)
+        if match is None:
+            if "self [us]" not in line:
+                ignored_lines += 1
+            continue
+        module = match.group("module").strip()
+        self_us = int(match.group("self"))
+        cumulative_us = int(match.group("cumulative"))
+        previous_self, previous_cumulative = modules.get(module, (0, 0))
+        modules[module] = (
+            previous_self + self_us,
+            max(previous_cumulative, cumulative_us),
+        )
+
+    grouped: dict[str, dict[str, int]] = {}
+    for module, (self_us, cumulative_us) in modules.items():
+        normalized = module.lstrip(".")
+        package = normalized.split(".", 1)[0] or module
+        group = grouped.setdefault(
+            package,
+            {"module_count": 0, "self_us": 0, "max_cumulative_us": 0},
+        )
+        group["module_count"] += 1
+        group["self_us"] += self_us
+        group["max_cumulative_us"] = max(group["max_cumulative_us"], cumulative_us)
+    return (
+        "\n".join(raw_lines) + ("\n" if raw_lines else ""),
+        [{"package": package, **values} for package, values in sorted(grouped.items())],
+        ignored_lines,
+    )
+
+
+def main() -> int:
+    if os.name == "posix":
+        signal.signal(signal.SIGTERM, _handle_termination)
+    arguments = _arguments()
+    workload = tuple(str(item) for item in arguments.workload)
+    python_name = Path(workload[0]).name
+    if not python_name.startswith("python"):
+        raise SystemExit("python-startup requires a Python script or module workload")
+
+    started_at_ns = time.time_ns()
+    samples: list[dict[str, Any]] = []
+    exit_code = 0
+    for index in range(arguments.samples):
+        (
+            stdout,
+            stderr,
+            peak_rss,
+            peak_rss_backend,
+            duration_ns,
+            sample_exit_code,
+        ) = _execute(workload)
+        if stdout:
+            sys.stdout.buffer.write(stdout)
+        if stderr:
+            sys.stderr.buffer.write(stderr)
+        samples.append(
+            {
+                "index": index,
+                "cache_semantics": (
+                    "uncontrolled_initial" if index == 0 else "warm_process_restart"
+                ),
+                "fresh_interpreter": True,
+                "duration_ns": duration_ns,
+                "peak_rss_bytes": peak_rss,
+                "peak_rss_backend": peak_rss_backend,
+                "exit_code": sample_exit_code,
+            }
+        )
+        if sample_exit_code:
+            exit_code = sample_exit_code
+
+    import_command = (workload[0], "-X", "importtime", *workload[1:])
+    trace_stdout, trace_stderr_bytes, _, _, _, trace_exit_code = _execute(import_command)
+    trace_stderr = trace_stderr_bytes.decode("utf-8", errors="replace")
+    raw_importtime, packages, ignored_lines = _group_imports(trace_stderr)
+    non_import_stderr = "\n".join(
+        line for line in trace_stderr.splitlines() if not line.startswith("import time:")
+    )
+    if trace_stdout:
+        sys.stdout.buffer.write(trace_stdout)
+    if non_import_stderr:
+        sys.stderr.write(non_import_stderr + "\n")
+    if trace_exit_code:
+        exit_code = trace_exit_code
+
+    payload = {
+        "schema": "flameox.python-startup.v1",
+        "started_at_ns": started_at_ns,
+        "finished_at_ns": time.time_ns(),
+        "python_executable": workload[0],
+        "python_version": sys.version,
+        "workload_argv": list(workload),
+        "semantics": {
+            "interpreter": "fresh process per wall sample and import trace",
+            "initial_cache": "uncontrolled; no OS caches were dropped",
+            "later_cache": "warm process restart; filesystem cache may have been populated",
+            "wall_time": "uninstrumented workload execution",
+            "import_trace": "separate instrumented workload execution",
+        },
+        "samples": samples,
+        "import_trace": {
+            "exit_code": trace_exit_code,
+            "raw_importtime": raw_importtime,
+            "packages": packages,
+            "unparsed_importtime_lines": ignored_lines,
+        },
+    }
+    arguments.output.write_text(
+        json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True)
+    )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -58,6 +58,8 @@ def effective_sensitivity(
 
 class ArtifactKind(StrEnum):
     EXECUTION_TRACE = "execution_trace"
+    PYTHON_STARTUP = "python_startup"
+    TEST_EXECUTION = "test_execution"
     SAMPLE_PROFILE = "sample_profile"
     MEMORY_PROFILE = "memory_profile"
     BENCHMARK_SAMPLES = "benchmark_samples"

--- a/src/flameox/execution.py
+++ b/src/flameox/execution.py
@@ -165,9 +165,22 @@ class SubprocessBroker:
                 await asyncio.shield(on_cleanup(cleanup_complete))
             await self._settle_readers(stdout_task, stderr_task)
             await self._settle_resource(resource_task)
+            timeout_process = ProcessResult(
+                exit_code=None,
+                terminating_signal=(
+                    -process.returncode
+                    if process.returncode is not None and process.returncode < 0
+                    else None
+                ),
+                wall_time_ns=time.monotonic_ns() - started,
+                timed_out=True,
+                cancellation_cause=cancellation_cause,
+                cleanup_complete=cleanup_complete,
+            )
             raise DomainError(
                 ErrorCode.PROCESS_TIMEOUT,
                 f"Process exceeded {request.timeout_seconds} seconds.",
+                details={"process": timeout_process.model_dump(mode="json")},
                 retryable=True,
             ) from exc
         except _OutputLimitExceeded as exc:

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -31,6 +31,10 @@ from flameox.adapters import (
     PerfettoExtractor,
     PyPerfExtractionResult,
     PyPerfExtractor,
+    PytestExtractionResult,
+    PytestExtractor,
+    PythonStartupExtractionResult,
+    PythonStartupExtractor,
     TraceWindowResult,
 )
 from flameox.analysis import (
@@ -529,7 +533,9 @@ def create_server(
             "list_capabilities -> plan_capture -> execute_capture_plan for short work, or "
             "start_detached_capture for long work -> get_detached_capture -> get_run -> analyze. "
             "For existing evidence: list_runs and list_artifacts expose artifact_kinds; use "
-            "extract_pyperf and query_measurements for benchmark_samples, analyze_memory for "
+            "extract_pyperf and query_measurements for benchmark_samples, "
+            "extract_python_startup for Python startup/import evidence, extract_pytest for "
+            "test phases, fixtures, workers, and failure latency, analyze_memory for "
             "memory profiles, analyze_execution for coverage, and the other analyze_* tools "
             "only for their documented artifact kinds. Then use get_evidence, record_analysis, "
             "or record_finding. Initialize a missing workspace only when authorized. A "
@@ -1770,6 +1776,40 @@ def create_server(
             return _success(
                 result,
                 f"Extracted {result.measurement_count} measured values.",
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="extract_python_startup", annotations=ADDITIVE)
+    async def extract_python_startup_tool(
+        run_id: str,
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[PythonStartupExtractionResult]]:
+        """Extract repeated startup, peak RSS, and package-grouped import evidence."""
+        try:
+            result = PythonStartupExtractor(
+                ctx.request_context.lifespan_context.require_workspace()
+            ).extract(run_id)
+            return _success(
+                result,
+                f"Extracted {result.measurement_count} startup measurements.",
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="extract_pytest", annotations=ADDITIVE)
+    async def extract_pytest_tool(
+        run_id: str,
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[PytestExtractionResult]]:
+        """Extract pytest phase, fixture, worker, outcome, and failure-latency evidence."""
+        try:
+            result = PytestExtractor(
+                ctx.request_context.lifespan_context.require_workspace()
+            ).extract(run_id)
+            return _success(
+                result,
+                f"Extracted {result.measurement_count} pytest measurements.",
             )
         except DomainError as error:
             return _failure(error)

--- a/tests/adapters/test_pytest.py
+++ b/tests/adapters/test_pytest.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from flameox.adapters import PytestExtractor
+from flameox.application import ImportArtifactRequest, ImportService
+from flameox.catalog import Catalog
+from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.storage import Workspace
+
+
+def _event(event: str, **fields: Any) -> str:
+    return json.dumps(
+        {
+            "schema": "flameox.pytest-event.v1",
+            "event": event,
+            "observed_at_ns": fields.pop("observed_at_ns", 1_000),
+            **fields,
+        }
+    )
+
+
+def _write_events(path: Path) -> None:
+    events = [
+        _event(
+            "run_started",
+            run_started_at_ns=1_000,
+            pytest_version="9.0",
+            python_version="3.12",
+            platform="test",
+            scheduler="load",
+            requested_workers="2",
+        ),
+        _event("collection_started", observed_at_ns=1_010),
+        _event("worker_created", worker_id="gw0"),
+        _event("worker_ready", worker_id="gw0"),
+        _event("test_collected", nodeid="test_suite.py::test_passes"),
+        _event("test_collected", nodeid="test_suite.py::test_errors"),
+        _event("test_collected", nodeid="test_suite.py::test_unexecuted"),
+        _event(
+            "collection_finished",
+            observed_at_ns=1_060,
+            test_count=3,
+            worker_id="gw0",
+        ),
+        _event(
+            "fixture_setup",
+            observed_at_ns=1_100,
+            duration_ns=500,
+            fixture="database",
+            scope="session",
+            nodeid="",
+            worker_id="gw0",
+            outcome="passed",
+        ),
+        _event(
+            "test_phase",
+            nodeid="test_suite.py::test_passes",
+            worker_id="gw0",
+            phase="setup",
+            outcome="passed",
+            duration_ns=600,
+            started_at_ns=1_100,
+            stopped_at_ns=1_700,
+            controller_received_at_ns=1_800,
+            wasxfail=False,
+        ),
+        _event(
+            "test_phase",
+            nodeid="test_suite.py::test_passes",
+            worker_id="gw0",
+            phase="call",
+            outcome="passed",
+            duration_ns=200,
+            started_at_ns=1_800,
+            stopped_at_ns=2_000,
+            controller_received_at_ns=2_100,
+            wasxfail=False,
+        ),
+        _event(
+            "test_phase",
+            nodeid="test_suite.py::test_errors",
+            worker_id="gw0",
+            phase="setup",
+            outcome="failed",
+            duration_ns=300,
+            started_at_ns=2_100,
+            stopped_at_ns=2_400,
+            controller_received_at_ns=2_800,
+            wasxfail=False,
+        ),
+        _event("worker_down", worker_id="gw0", outcome="clean", error_type=None),
+        _event("session_finished", exit_status=1),
+    ]
+    path.write_text("\n".join(events) + "\n")
+
+
+def test_pytest_extracts_fixture_cost_outcomes_and_failure_latency(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    Catalog(workspace).rebuild()
+    source = tmp_path / "pytest-events.jsonl"
+    _write_events(source)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.TEST_EXECUTION)
+    )
+
+    result = PytestExtractor(workspace).extract(imported.run.run_id)
+
+    assert result.complete is True
+    assert result.collected_count == 3
+    assert result.executed_count == 2
+    assert result.passed_count == 1
+    assert result.errored_count == 1
+    assert result.unexecuted_count == 1
+    assert result.fixture_setup_count == 1
+    assert result.fixture_setup_ns == 500
+    assert result.collection_duration_ns == 50
+    assert result.first_failure_observed_ns == 1_400
+    assert result.first_failure_reported_ns == 1_800
+    assert result.workers == ("gw0",)
+    assert any("queue latency" in item for item in result.limitations)
+    with Catalog(workspace).open_snapshot() as snapshot:
+        rows = snapshot.execute(
+            "SELECT name, value_int, worker_id, dimensions['fixture'] "
+            "FROM measurements ORDER BY name"
+        ).fetchall()
+    assert ("pytest.fixture_setup", 500, "gw0", "database") in rows
+    assert ("pytest.collection", 50, None, None) in rows
+    assert ("pytest.tests.unexecuted", 1, None, None) in rows
+    assert ("pytest.time_to_first_failure.reported", 1_800, None, None) in rows
+
+
+@pytest.mark.parametrize("payload", ("", "{}\n", "{broken\n"))
+def test_pytest_rejects_malformed_event_streams(tmp_path: Path, payload: str) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "pytest-events.jsonl"
+    source.write_text(payload)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.TEST_EXECUTION)
+    )
+
+    with pytest.raises(DomainError) as error:
+        PytestExtractor(workspace).extract(imported.run.run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_pytest_interrupt_is_explicitly_non_complete(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    Catalog(workspace).rebuild()
+    source = tmp_path / "pytest-events.jsonl"
+    source.write_text(
+        "\n".join(
+            (
+                _event(
+                    "run_started",
+                    run_started_at_ns=1_000,
+                    pytest_version="9.0",
+                    python_version="3.12",
+                    platform="test",
+                    scheduler="no",
+                    requested_workers="0",
+                ),
+                _event("interrupted", exception_type="KeyboardInterrupt"),
+                _event("session_finished", exit_status=2),
+            )
+        )
+        + "\n"
+    )
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.TEST_EXECUTION)
+    )
+
+    result = PytestExtractor(workspace).extract(imported.run.run_id)
+
+    assert result.interrupted is True
+    assert result.complete is False
+    assert any("interrupted" in item for item in result.limitations)
+
+
+def test_pytest_recovers_valid_prefix_from_truncated_final_record(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    Catalog(workspace).rebuild()
+    source = tmp_path / "pytest-events.jsonl"
+    source.write_text(
+        "\n".join(
+            (
+                _event(
+                    "run_started",
+                    run_started_at_ns=1_000,
+                    pytest_version="9.0",
+                    python_version="3.12",
+                    platform="test",
+                    scheduler="no",
+                    requested_workers="0",
+                ),
+                _event("session_finished", exit_status=2),
+            )
+        )
+        + "\n{\"schema\":"
+    )
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.TEST_EXECUTION)
+    )
+
+    result = PytestExtractor(workspace).extract(imported.run.run_id)
+
+    assert result.complete is False
+    assert any("valid prefix" in item for item in result.limitations)

--- a/tests/adapters/test_pytest.py
+++ b/tests/adapters/test_pytest.py
@@ -201,7 +201,7 @@ def test_pytest_recovers_valid_prefix_from_truncated_final_record(tmp_path: Path
                 _event("session_finished", exit_status=2),
             )
         )
-        + "\n{\"schema\":"
+        + '\n{"schema":'
     )
     imported = ImportService(workspace).import_artifact(
         ImportArtifactRequest(path=source, kind=ArtifactKind.TEST_EXECUTION)

--- a/tests/adapters/test_python_startup.py
+++ b/tests/adapters/test_python_startup.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters import PythonStartupExtractor
+from flameox.application import ImportArtifactRequest, ImportService
+from flameox.catalog import Catalog
+from flameox.collectors.python_startup import _group_imports
+from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.storage import Workspace
+
+
+def _write_startup(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "flameox.python-startup.v1",
+                "started_at_ns": 100,
+                "finished_at_ns": 500,
+                "python_executable": "python",
+                "python_version": "3.12",
+                "workload_argv": ["python", "app.py"],
+                "semantics": {
+                    "interpreter": "fresh process per sample",
+                    "initial_cache": "uncontrolled; no OS caches were dropped",
+                    "later_cache": "warm process restart",
+                    "wall_time": "uninstrumented workload execution",
+                    "import_trace": "separate instrumented workload execution",
+                },
+                "samples": [
+                    {
+                        "index": 0,
+                        "cache_semantics": "uncontrolled_initial",
+                        "fresh_interpreter": True,
+                        "duration_ns": 20_000_000,
+                        "peak_rss_bytes": 12_000_000,
+                        "peak_rss_backend": "wait4_ru_maxrss",
+                        "exit_code": 0,
+                    },
+                    {
+                        "index": 1,
+                        "cache_semantics": "warm_process_restart",
+                        "fresh_interpreter": True,
+                        "duration_ns": 15_000_000,
+                        "peak_rss_bytes": 12_500_000,
+                        "peak_rss_backend": "wait4_ru_maxrss",
+                        "exit_code": 0,
+                    },
+                ],
+                "import_trace": {
+                    "exit_code": 0,
+                    "raw_importtime": "import time: 80 | 160 | json\n",
+                    "packages": [
+                        {
+                            "package": "json",
+                            "module_count": 4,
+                            "self_us": 80,
+                            "max_cumulative_us": 160,
+                        }
+                    ],
+                    "unparsed_importtime_lines": 0,
+                },
+            }
+        )
+    )
+
+
+def test_python_startup_extracts_samples_and_package_costs(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    Catalog(workspace).rebuild()
+    source = tmp_path / "startup.json"
+    _write_startup(source)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.PYTHON_STARTUP)
+    )
+
+    result = PythonStartupExtractor(workspace).extract(imported.run.run_id)
+
+    assert result.sample_count == 2
+    assert result.package_count == 1
+    assert result.measurement_count == 7
+    assert result.peak_rss_backends == ("wait4_ru_maxrss",)
+    assert "uncontrolled" in result.limitations[0]
+    with Catalog(workspace).open_snapshot() as snapshot:
+        rows = snapshot.execute(
+            "SELECT name, value_int, unit, dimensions['package'] "
+            "FROM measurements ORDER BY value_index, name"
+        ).fetchall()
+    assert ("python_startup.wall_time", 20_000_000, "ns", None) in rows
+    assert ("python_startup.import.module_count", 4, "count", "json") in rows
+    assert ("python_startup.import.max_cumulative_time", 160, "us", "json") in rows
+
+
+@pytest.mark.parametrize("payload", ("", "{}", "{broken", "[]", "null"))
+def test_python_startup_rejects_malformed_artifacts(tmp_path: Path, payload: str) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "startup.json"
+    source.write_text(payload)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.PYTHON_STARTUP)
+    )
+
+    with pytest.raises(DomainError) as error:
+        PythonStartupExtractor(workspace).extract(imported.run.run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_python_startup_rejects_malformed_package_container(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "startup.json"
+    _write_startup(source)
+    payload = json.loads(source.read_text())
+    payload["import_trace"]["packages"] = None
+    source.write_text(json.dumps(payload))
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(path=source, kind=ArtifactKind.PYTHON_STARTUP)
+    )
+
+    with pytest.raises(DomainError) as error:
+        PythonStartupExtractor(workspace).extract(imported.run.run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_import_grouping_accumulates_duplicate_self_time_and_keeps_maximum() -> None:
+    _, packages, ignored = _group_imports(
+        "import time: 10 | 100 | package.module\n"
+        "import time: 20 | 80 | package.module\n"
+    )
+
+    assert ignored == 0
+    assert packages == [
+        {
+            "package": "package",
+            "module_count": 1,
+            "self_us": 30,
+            "max_cumulative_us": 100,
+        }
+    ]

--- a/tests/adapters/test_python_startup.py
+++ b/tests/adapters/test_python_startup.py
@@ -128,8 +128,7 @@ def test_python_startup_rejects_malformed_package_container(tmp_path: Path) -> N
 
 def test_import_grouping_accumulates_duplicate_self_time_and_keeps_maximum() -> None:
     _, packages, ignored = _group_imports(
-        "import time: 10 | 100 | package.module\n"
-        "import time: 20 | 80 | package.module\n"
+        "import time: 10 | 100 | package.module\nimport time: 20 | 80 | package.module\n"
     )
 
     assert ignored == 0

--- a/tests/application/test_async_work.py
+++ b/tests/application/test_async_work.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from flameox.application.async_work import run_atomic_thread
+
+
+@pytest.mark.anyio
+async def test_atomic_thread_settles_before_repeated_cancellation_returns() -> None:
+    started = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    def mutation() -> None:
+        started.set()
+        release.wait()
+        completed.set()
+
+    task = asyncio.create_task(run_atomic_thread(mutation))
+    assert await asyncio.to_thread(started.wait, 1)
+
+    task.cancel()
+    await asyncio.sleep(0)
+    task.cancel()
+
+    done, _ = await asyncio.wait({task}, timeout=0.1)
+    try:
+        assert not done
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert completed.is_set()

--- a/tests/application/test_python_evidence_capture.py
+++ b/tests/application/test_python_evidence_capture.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters import PytestExtractor, PythonStartupExtractor
+from flameox.application import CaptureService, ExecutionPolicy
+from flameox.catalog import Catalog
+from flameox.domain import ArtifactKind, ExecutionStatus
+from flameox.storage import ArtifactStore, Workspace
+
+
+def _workspace_without_containment(tmp_path: Path) -> Workspace:
+    workspace = Workspace.initialize(tmp_path)
+    config = workspace.config.model_copy(
+        update={
+            "execution": workspace.config.execution.model_copy(update={"containment": "disabled"})
+        }
+    )
+    workspace.paths.config.write_text(config.to_toml())
+    Catalog(workspace).rebuild()
+    return workspace
+
+
+@pytest.mark.anyio
+async def test_python_startup_capture_preserves_raw_importtime_and_samples(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace_without_containment(tmp_path)
+    (tmp_path / "startup_target.py").write_text("import json\nassert json.dumps({'ok': True})\n")
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.startup]
+argv = [{json.dumps(sys.executable)}, "startup_target.py"]
+cwd = "."
+timeout_seconds = 30
+"""
+    )
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="startup",
+        adapter="python-startup",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    captured = await service.execute(plan.plan_id)
+    extracted = PythonStartupExtractor(workspace).extract(captured.run.run_id)
+
+    assert captured.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert extracted.sample_count == 5
+    registration = next(
+        item for item in captured.run.artifacts if item.kind is ArtifactKind.PYTHON_STARTUP
+    )
+    artifact = ArtifactStore(workspace).get(registration.artifact_id)
+    payload = json.loads(artifact.payload_path.read_text())
+    assert payload["samples"][0]["cache_semantics"] == "uncontrolled_initial"
+    assert payload["samples"][1]["cache_semantics"] == "warm_process_restart"
+    expected_rss_backend = "wait4_ru_maxrss" if hasattr(os, "wait4") else "psutil_polling"
+    assert payload["samples"][0]["peak_rss_backend"] == expected_rss_backend
+    assert "import time:" in payload["import_trace"]["raw_importtime"]
+
+
+@pytest.mark.anyio
+async def test_pytest_xdist_capture_attributes_repeated_fixture_cost_and_failure_latency(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace_without_containment(tmp_path)
+    (tmp_path / "test_example.py").write_text(
+        "import time\n"
+        "import pytest\n"
+        "@pytest.fixture(scope='session', autouse=True)\n"
+        "def expensive_session_fixture():\n"
+        "    time.sleep(0.02)\n"
+        "def test_one(): pass\n"
+        "def test_two(): pass\n"
+        "def test_three(): pass\n"
+        "def test_failure(): assert False\n"
+    )
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.tests]
+argv = [{json.dumps(sys.executable)}, "-m", "pytest", "-q", "-n", "2", "test_example.py"]
+cwd = "."
+timeout_seconds = 30
+"""
+    )
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="tests",
+        adapter="pytest",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    captured = await service.execute(plan.plan_id)
+    extracted = PytestExtractor(workspace).extract(captured.run.run_id)
+
+    assert captured.run.execution_status is ExecutionStatus.FAILED
+    assert extracted.complete is True
+    assert extracted.failed_count == 1
+    assert extracted.fixture_setup_count >= 2
+    assert extracted.fixture_setup_ns >= 20_000_000
+    assert extracted.first_failure_observed_ns is not None
+    assert extracted.first_failure_reported_ns is not None
+    assert extracted.first_failure_reported_ns >= extracted.first_failure_observed_ns
+    assert len(extracted.workers) == 2
+    with Catalog(workspace).open_snapshot() as snapshot:
+        phase_workers = snapshot.execute(
+            "SELECT DISTINCT worker_id FROM measurements "
+            "WHERE name LIKE 'pytest.phase.%' ORDER BY worker_id"
+        ).fetchall()
+    assert phase_workers == [("gw0",), ("gw1",)]
+
+
+@pytest.mark.anyio
+async def test_pytest_timeout_preserves_partial_and_unexecuted_evidence(tmp_path: Path) -> None:
+    workspace = _workspace_without_containment(tmp_path)
+    (tmp_path / "test_timeout.py").write_text(
+        "import time\n"
+        "def test_slow(): time.sleep(5)\n"
+        "def test_never_started(): pass\n"
+    )
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.tests]
+argv = [{json.dumps(sys.executable)}, "-m", "pytest", "-q", "-p", "no:randomly", "test_timeout.py"]
+cwd = "."
+timeout_seconds = 2
+"""
+    )
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="tests",
+        adapter="pytest",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    captured = await service.execute(plan.plan_id)
+    extracted = PytestExtractor(workspace).extract(captured.run.run_id)
+
+    assert captured.run.execution_status is ExecutionStatus.TIMED_OUT
+    assert extracted.execution_status == "timed_out"
+    assert extracted.complete is False
+    assert extracted.collected_count == 2
+    assert extracted.unexecuted_count >= 1
+    assert any("partial" in item for item in extracted.limitations)
+
+
+@pytest.mark.anyio
+async def test_pytest_worker_crash_recovers_fixture_sidecar(tmp_path: Path) -> None:
+    workspace = _workspace_without_containment(tmp_path)
+    (tmp_path / "test_crash.py").write_text(
+        "import os\n"
+        "import pytest\n"
+        "@pytest.fixture(scope='session', autouse=True)\n"
+        "def expensive_session_fixture():\n"
+        "    return object()\n"
+        "def test_crash(): os._exit(7)\n"
+        "def test_unexecuted(): pass\n"
+    )
+    crash_argv = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-n",
+        "1",
+        "--max-worker-restart=0",
+        "-p",
+        "no:randomly",
+        "test_crash.py",
+    ]
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.tests]
+argv = {json.dumps(crash_argv)}
+cwd = "."
+timeout_seconds = 30
+"""
+    )
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="tests",
+        adapter="pytest",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    captured = await service.execute(plan.plan_id)
+    extracted = PytestExtractor(workspace).extract(captured.run.run_id)
+
+    assert captured.run.execution_status is ExecutionStatus.FAILED
+    assert extracted.recovered_sidecar_events >= 2
+    assert extracted.sidecar_recovery_failures == 0
+    assert extracted.fixture_setup_count >= 1
+    assert any("recovered from bounded sidecars" in item for item in extracted.limitations)

--- a/tests/application/test_python_evidence_capture.py
+++ b/tests/application/test_python_evidence_capture.py
@@ -121,9 +121,7 @@ timeout_seconds = 30
 async def test_pytest_timeout_preserves_partial_and_unexecuted_evidence(tmp_path: Path) -> None:
     workspace = _workspace_without_containment(tmp_path)
     (tmp_path / "test_timeout.py").write_text(
-        "import time\n"
-        "def test_slow(): time.sleep(5)\n"
-        "def test_never_started(): pass\n"
+        "import time\ndef test_slow(): time.sleep(5)\ndef test_never_started(): pass\n"
     )
     (tmp_path / "flameox.toml").write_text(
         f"""

--- a/uv.lock
+++ b/uv.lock
@@ -619,6 +619,8 @@ all = [
     { name = "perfetto" },
     { name = "py-spy" },
     { name = "pyperf" },
+    { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "torch" },
 ]
 cpu = [
@@ -648,6 +650,10 @@ memory = [
 ]
 python = [
     { name = "pyperf" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-xdist" },
 ]
 torch = [
     { name = "torch" },
@@ -691,11 +697,15 @@ requires-dist = [
     { name = "pyperf", specifier = ">=2.9" },
     { name = "pyperf", marker = "extra == 'all'", specifier = ">=2.9" },
     { name = "pyperf", marker = "extra == 'python'", specifier = ">=2.9" },
+    { name = "pytest", marker = "extra == 'all'", specifier = ">=8.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1" },
     { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.16" },
     { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=15" },
+    { name = "pytest-xdist", marker = "extra == 'all'", specifier = ">=3.6" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6" },
     { name = "pytz", specifier = ">=2024.2" },
     { name = "questionary", specifier = ">=2.1,<3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
@@ -709,7 +719,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.16,<1" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
 ]
-provides-extras = ["python", "memory", "torch", "execution", "trace", "cpu", "all", "dev"]
+provides-extras = ["python", "memory", "torch", "execution", "test", "trace", "cpu", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-psutil", specifier = ">=7.2,<8" }]


### PR DESCRIPTION
Closes #40.
Closes #41.

## Problem

Python startup investigations currently require separate wall-time, import-time, and memory commands whose cache semantics and provenance are easy to lose. Pytest/xdist runs have a similar gap: aggregate duration does not show repeated worker fixture cost, worker failure, incomplete execution, or when the first failure became visible to the controller.

Both cases need native, source-bound evidence that can flow through flameox's existing run, experiment, comparison, CLI, and MCP contracts.

## Change

This adds two maintained adapters:

- `python-startup` records five fresh-interpreter wall/RSS samples plus one separate `-X importtime` trace. The artifact states initial/warm cache semantics, preserves raw trace lines, groups module cost by top-level package, and records whether peak RSS came from POSIX `wait4` or psutil polling.
- `pytest` records collection, fixture setup, setup/call/teardown phases, outcomes, worker lifecycle, first observed and controller-reported failure latency, and unexecuted tests. xdist worker events use bounded per-worker sidecars that are validated before recovery; partial or failed sidecars remain non-complete and unrecovered native sidecars are preserved when possible.

Failed and timed-out runs with registered evidence remain extractable in experiment workflows. Timeout extraction accepts a valid JSONL prefix and reports a truncated final record instead of discarding the artifact.

The follow-up also fixes a shared cancellation race: `run_atomic_thread` now shields its bounded settlement wait from AnyIO level cancellation and repeated `asyncio.Task.cancel()` calls. Cancellation therefore does not return while the terminal run-manifest write is still in flight.

## Compatibility and limitations

The new `test` extra adds pytest and pytest-xdist; existing extras and stored artifact formats are unchanged. CLI and MCP gain additive extraction operations for the two artifact kinds.

Startup's first sample is explicitly `uncontrolled_initial`, not cold, because flameox does not drop OS caches. Import timing runs in a separate instrumented process. Stable xdist hooks do not expose exact per-test controller queue latency, and a force-killed controller can lose sidecar events it never recovered; results state those limits rather than inferring missing evidence.

## Suggested review order

1. `src/flameox/collectors/python_startup.py` and `src/flameox/adapters/python_startup.py` — sampling, process cleanup, import grouping, and extraction.
2. `src/flameox/collectors/pytest_plugin.py` and `src/flameox/adapters/pytest.py` — worker attribution, bounded sidecars, partial-stream handling, and completeness.
3. `src/flameox/application/capture.py`, `experiments.py`, and `async_work.py` — artifact preservation, failed-run extraction, and cancellation settlement.
4. CLI/MCP wiring, tests, and adapter/acceptance documentation.

## Validation

- `uv run ruff check src tests` — passed.
- `uv run mypy src tests` — passed; 144 source files checked.
- Focused adapter, capture, detached, and real-stdio MCP suite — 21 passed, 1 rerun.
- `uv run pytest -q` — 296 passed, 2 skipped, 2 rerun in 708.74s.
- `git diff --check origin/main...HEAD` — passed.

The skipped tests are the explicitly gated 100,000-run performance check and the optional PyTorch capture check.
