### PR TITLE
fix(mcp): make first-use workspace initialization explicit and safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,20 @@ npx flameox setup
 ```
 
 The wizard detects Claude Code, Cursor, OpenCode, Codex, Gemini CLI, and
-Antigravity. It selects nothing by default and previews every configuration file
-it will change. After you approve the plan, it installs and verifies a versioned
-local runtime and activates the clients you chose.
+Antigravity. It preselects detected clients for connection and previews every
+configuration file it will change; you can adjust the selection before applying
+it. After you approve the plan, it installs and verifies a versioned local
+runtime and activates the clients you chose.
 
 Restart the configured client, open a project, and ask:
 
 > Initialize flameox in this project and show me which profiling capabilities are
 > available.
+
+Client setup and project initialization are separate steps. Setup registers the
+MCP server, while the initialization request creates `.diagnostics/` in the
+checkout after you confirm that the client opened the intended project. The
+server does not initialize arbitrary launch directories automatically.
 
 flameox can initialize its `.diagnostics/` workspace through MCP. Before an agent
 can run your code, you must declare the command as a named workload in

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -10,11 +10,12 @@ verification, locking, activation, rollback, and structured results. The same
 setup service is available from `flameox setup` for standard JSON and TOML
 clients.
 
-The first run requires an explicit multi-select. Detection annotates choices
-but does not preselect them. Every mutation has a complete preview and a
-confirmation whose default is no. Non-interactive application requires both an
-explicit target (`--codex`, another client flag, `--all`, `--refresh`,
-`--rollback`, or `--verify`) and `--yes`; `--dry-run --json` returns the plan
+The first run requires an explicit multi-select. Detection preselects detected
+clients for connection, while the user can adjust the selection before applying
+it. Every mutation has a complete preview and a confirmation whose default is
+no. Non-interactive application requires both an explicit target (`--codex`,
+another client flag, `--all`, `--refresh`, `--rollback`, or `--verify`) and
+`--yes`; `--dry-run --json` returns the plan
 without mutation.
 
 Interactive setup is also the lifecycle entry point for connecting or
@@ -27,8 +28,11 @@ fails on configuration drift instead of repairing it implicitly.
 Client launchers contain the absolute path of a verified managed runtime and
 the fixed arguments `mcp serve --project-root .`. Setup never passes `--init`.
 Each MCP client therefore binds flameox's project root to the client's launch
-directory and encounters an ordinary `WORKSPACE_NOT_FOUND` until the user
-initializes that repository deliberately.
+directory. Client setup is complete when the launcher is verified; each checkout
+still requires deliberate project initialization through `flameox init`,
+`flameox mcp serve --init`, or the MCP `initialize_workspace` tool after the
+client's launch directory has been verified. A fresh server reports
+`WORKSPACE_NOT_FOUND` until that project step is complete.
 
 Setup serializes mutations with a user-local lock. Before applying, it compares
 every config with the exact bytes used for the preview. It writes a recovery
@@ -307,8 +311,10 @@ The supported tools are grouped as follows:
 #### `initialize_workspace`
 
 Additive and idempotent. Initializes only the MCP server's fixed project root.
-It cannot select an external path or approve workloads. Hosts may instead start
-the server using `flameox mcp serve --init`.
+If the server already owns an initialized workspace, the call returns its current
+status without replacing the detached-capture manager. It cannot select an
+external path or approve workloads. Hosts may instead start the server using
+`flameox mcp serve --init`.
 
 #### `workspace_status`
 
@@ -563,8 +569,11 @@ Structured error codes include:
 - `EVIDENCE_SCHEMA_MISMATCH`;
 - `COMPARISON_INVALID`;
 - `QUERY_BUDGET_EXCEEDED`;
+- `STORAGE_QUOTA_EXCEEDED`;
 - `WRITE_LOCK_TIMEOUT`;
 - `SENSITIVE_ARTIFACT_REFUSED`;
+- `REVISION_CONFLICT`;
+- `STALE_CURSOR`;
 - `INTERNAL_ERROR`.
 
 Tracebacks are logged locally but not returned by default.

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -319,7 +319,10 @@ class AppContext:
             raise DomainError(
                 code=ErrorCode.WORKSPACE_NOT_FOUND,
                 message="No .diagnostics workspace was found.",
-                remediation=("Call initialize_workspace first.",),
+                remediation=(
+                    "Verify the server's fixed project root is the intended checkout, "
+                    "then call initialize_workspace.",
+                ),
             )
         return self.workspace
 
@@ -529,8 +532,12 @@ def create_server(
             "when source, environment, command, and artifact provenance must be reproducible. "
             "Do not use it to provision hosts, install dependencies, mutate source or GitHub, "
             "or prove static claims without runtime evidence. "
-            "For a new capture: workspace_status -> list_declared_workflows -> "
-            "list_capabilities -> plan_capture -> execute_capture_plan for short work, or "
+            "For a new project, call workspace_status first. If it returns "
+            "WORKSPACE_NOT_FOUND, verify that the server's fixed project root is the intended "
+            "checkout and, only when authorized, call initialize_workspace; then repeat "
+            "workspace_status. Initialization writes .diagnostics. After initialization, use "
+            "list_declared_workflows -> list_capabilities -> plan_capture -> "
+            "execute_capture_plan for short work, or "
             "start_detached_capture for long work -> get_detached_capture -> get_run -> analyze. "
             "For existing evidence: list_runs and list_artifacts expose artifact_kinds; use "
             "extract_pyperf and query_measurements for benchmark_samples, "
@@ -549,20 +556,27 @@ def create_server(
     async def initialize_workspace(
         ctx: Context[AppContext],
     ) -> Annotated[CallToolResult, ToolPayload[WorkspaceStatus]]:
-        """Initialize flameox in the server's fixed project root."""
+        """Initialize Flameox in the fixed project root after it has been verified."""
         try:
             state = ctx.request_context.lifespan_context
-            state.workspace = Workspace.initialize(state.project_root)
-            state.capabilities = CapabilityService(state.workspace)
-            state.capture_plans = CapturePlanRegistry(
-                max_parallel_captures=(state.workspace.config.capture.max_parallel_captures)
+            if state.workspace is not None:
+                result = workspace_status(state.workspace)
+                return _success(result, f"Workspace is already initialized: {result.workspace_id}.")
+
+            workspace = Workspace.initialize(state.project_root)
+            capture_plans = CapturePlanRegistry(
+                max_parallel_captures=workspace.config.capture.max_parallel_captures
             )
+            detached_captures = DetachedCaptureManager(
+                workspace,
+                CaptureService(workspace, plans=capture_plans),
+            )
+            state.workspace = workspace
+            state.capabilities = CapabilityService(workspace)
+            state.capture_plans = capture_plans
             state.experiment_plans = ExperimentPlanRegistry()
-            state.detached_captures = DetachedCaptureManager(
-                state.workspace,
-                state.capture_service(),
-            )
-            result = workspace_status(state.workspace)
+            state.detached_captures = detached_captures
+            result = workspace_status(workspace)
             return _success(result, f"Initialized workspace {result.workspace_id}.")
         except DomainError as error:
             return _failure(error)
@@ -571,7 +585,7 @@ def create_server(
     async def workspace_status_tool(
         ctx: Context[AppContext],
     ) -> Annotated[CallToolResult, ToolPayload[WorkspaceStatus]]:
-        """Return the current workspace and corpus status."""
+        """Return workspace status; on first use, follow WORKSPACE_NOT_FOUND recovery."""
         try:
             result = workspace_status(ctx.request_context.lifespan_context.require_workspace())
             return _success(result, f"Workspace is at {result.corpus_commit_id}.")

--- a/src/flameox/storage/workspace.py
+++ b/src/flameox/storage/workspace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import os
 from collections.abc import Iterator
@@ -28,6 +29,41 @@ class WorkspaceIdentity(ContractModel):
     created_at: datetime
     project_root: str
     flameox_version: str
+
+
+def _workspace_initialization_error(error: OSError) -> DomainError:
+    details = {"operation": "workspace_initialization"}
+    if error.errno is not None:
+        details["errno"] = error.errno
+
+    quota_errors = {errno.ENOSPC}
+    if hasattr(errno, "EDQUOT"):
+        quota_errors.add(errno.EDQUOT)
+    if error.errno in quota_errors:
+        return DomainError(
+            ErrorCode.STORAGE_QUOTA_EXCEEDED,
+            "Workspace initialization needs more local storage.",
+            details=details,
+            remediation=(
+                "Free local storage or increase the filesystem quota, then retry initialization.",
+            ),
+        )
+    if error.errno in {errno.EACCES, errno.EPERM, errno.EROFS}:
+        return DomainError(
+            ErrorCode.WORKSPACE_INVALID,
+            "The selected project root is not writable for workspace initialization.",
+            details=details,
+            remediation=(
+                "Choose a writable project root or repair its permissions, then retry "
+                "initialization.",
+            ),
+        )
+    return DomainError(
+        ErrorCode.INTERNAL_ERROR,
+        "Workspace initialization failed because the local filesystem rejected a write.",
+        details=details,
+        remediation=("Check filesystem health and permissions, then retry initialization.",),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,6 +184,18 @@ class Workspace:
 
     @classmethod
     def initialize(
+        cls,
+        project_root: Path,
+        *,
+        workspace_root: Path | None = None,
+    ) -> Workspace:
+        try:
+            return cls._initialize(project_root, workspace_root=workspace_root)
+        except OSError as error:
+            raise _workspace_initialization_error(error) from error
+
+    @classmethod
+    def _initialize(
         cls,
         project_root: Path,
         *,

--- a/src/flameox/storage/workspace.py
+++ b/src/flameox/storage/workspace.py
@@ -32,7 +32,7 @@ class WorkspaceIdentity(ContractModel):
 
 
 def _workspace_initialization_error(error: OSError) -> DomainError:
-    details = {"operation": "workspace_initialization"}
+    details: dict[str, int | str] = {"operation": "workspace_initialization"}
     if error.errno is not None:
         details["errno"] = error.errno
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
@@ -13,7 +15,7 @@ from mcp.client.stdio import stdio_client
 from mcp_types import TextContent, TextResourceContents
 from typer.testing import CliRunner
 
-from flameox.application import WorkloadService, workspace_status
+from flameox.application import DetachedCaptureManager, WorkloadService, workspace_status
 from flameox.catalog import Catalog
 from flameox.cli import app
 from flameox.mcp import create_server
@@ -45,6 +47,8 @@ async def test_mcp_tools_use_explicit_envelopes_and_annotations(
     assert instructions is not None
     assert "list_declared_workflows" in instructions
     assert "consumed capture plan" in instructions
+    assert "WORKSPACE_NOT_FOUND" in instructions
+    assert "verify that the server's fixed project root is the intended checkout" in instructions
 
 
 @pytest.mark.anyio
@@ -89,12 +93,60 @@ async def test_mcp_domain_errors_remain_structured(tmp_path: Path) -> None:
     assert result.structured_content is not None
     assert result.structured_content["ok"] is False
     assert result.structured_content["error"]["code"] == "WORKSPACE_NOT_FOUND"
+    assert result.structured_content["error"]["remediation"] == [
+        "Verify the server's fixed project root is the intended checkout, then call "
+        "initialize_workspace."
+    ]
     assert result.structured_content["error"]["recovery"] == {
         "kind": "initialize_workspace",
         "safe_to_repeat_same_call": False,
         "retry_after_ms": None,
         "next_tool": "initialize_workspace",
     }
+
+
+@pytest.mark.anyio
+async def test_mcp_workspace_initialization_failures_remain_structured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_write(*args: object, **kwargs: object) -> None:
+        raise OSError(errno.ENOSPC, "simulated quota exhaustion")
+
+    monkeypatch.setattr("flameox.storage.workspace.atomic_write_json", fail_write)
+
+    async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        result = await client.call_tool("initialize_workspace", {})
+
+    assert result.is_error is True
+    assert result.structured_content is not None
+    assert result.structured_content["error"]["code"] == "STORAGE_QUOTA_EXCEEDED"
+    assert result.structured_content["error"]["remediation"] == [
+        "Free local storage or increase the filesystem quota, then retry initialization."
+    ]
+
+
+@pytest.mark.anyio
+async def test_mcp_initialize_is_idempotent_without_replacing_capture_manager(
+    tmp_path: Path,
+) -> None:
+    with patch(
+        "flameox.mcp.server.DetachedCaptureManager",
+        wraps=DetachedCaptureManager,
+    ) as constructor:
+        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+            first = await client.call_tool("initialize_workspace", {})
+            second = await client.call_tool("initialize_workspace", {})
+
+    assert first.is_error is False
+    assert second.is_error is False
+    assert constructor.call_count == 1
+    assert first.structured_content is not None
+    assert second.structured_content is not None
+    assert (
+        first.structured_content["result"]["workspace_id"]
+        == second.structured_content["result"]["workspace_id"]
+    )
 
 
 @pytest.mark.anyio

--- a/tests/storage/test_workspace.py
+++ b/tests/storage/test_workspace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 
@@ -22,6 +23,28 @@ def test_initialize_creates_static_identity_and_empty_corpus(tmp_path: Path) -> 
     assert head.generation_manifests == ()
     assert workspace.paths.config.is_file()
     assert WorkspaceConfig.from_path(workspace.paths.config) == WorkspaceConfig()
+
+
+def test_initialize_maps_filesystem_quota_failures_to_domain_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_write(*args: object, **kwargs: object) -> None:
+        raise OSError(errno.ENOSPC, "simulated quota exhaustion")
+
+    monkeypatch.setattr("flameox.storage.workspace.atomic_write_json", fail_write)
+
+    with pytest.raises(DomainError) as error:
+        Workspace.initialize(tmp_path)
+
+    assert error.value.code is ErrorCode.STORAGE_QUOTA_EXCEEDED
+    assert error.value.details == {
+        "operation": "workspace_initialization",
+        "errno": errno.ENOSPC,
+    }
+    assert error.value.remediation == (
+        "Free local storage or increase the filesystem quota, then retry initialization.",
+    )
 
 
 def test_discovery_selects_nearest_workspace(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Fresh MCP clients currently enter a project with no `.diagnostics/` workspace. The first `workspace_status` call therefore returns `WORKSPACE_NOT_FOUND`, but the recovery path did not tell an agent to verify the server's fixed project root before initializing. Filesystem failures during initialization could also escape as generic transport errors, and repeated initialization replaced the detached-capture manager.

The setup and interface documentation also disagreed with the current client-selection behavior and did not clearly separate client registration from deliberate project initialization.

## Approach

- Make the MCP server instructions and `WORKSPACE_NOT_FOUND` remediation describe the safe first-use sequence.
- Normalize quota, permission, read-only, and other filesystem failures into structured domain errors with actionable remediation.
- Make `initialize_workspace` idempotent so an existing detached-capture manager is not replaced.
- Align README and interface documentation with current setup and initialization behavior.
- Add regression coverage for structured initialization failures, first-use guidance, and manager reuse.

## Commands run

```console
uv run --extra dev ruff check src/flameox/mcp/server.py src/flameox/storage/workspace.py tests/mcp/test_server.py tests/storage/test_workspace.py
# All checks passed

uv run --extra dev mypy src/flameox/mcp/server.py src/flameox/storage/workspace.py tests/mcp/test_server.py tests/storage/test_workspace.py
# Success: no issues found in 4 source files

uv run --extra dev pytest tests/storage/test_workspace.py tests/mcp/test_server.py tests/test_setup_ui.py tests/test_cli_setup.py -q
# 35 passed, 1 rerun

git diff --check origin/main...HEAD
# passed
```

The documented full suite was also attempted with all repository extras, but the local filesystem quota was exhausted during workspace-heavy tests: `239 failed, 55 passed, 7 skipped`, with failures dominated by `[Errno 122] Disk quota exceeded`. This is not reported as a passing full-suite result.

## Compatibility

- No new external path or automatic workspace initialization is introduced.
- Existing clients still need deliberate project initialization after setup.
- Repeated `initialize_workspace` calls now return the existing workspace status without replacing capture state.
- MCP result envelopes and trust boundaries remain unchanged.
