### PR TITLE
fix(setup): prevent stale bootstrap downgrades

### DIFF
--- a/src/flameox/application/setup.py
+++ b/src/flameox/application/setup.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Literal, Protocol
 
 import portalocker
+from packaging.version import InvalidVersion, Version
 from platformdirs import user_data_path
 from pydantic import Field
 
@@ -207,6 +208,7 @@ class SetupService:
                 "Select at least one MCP client.",
             )
 
+        warnings: list[str] = []
         remove = operation is SetupOperation.REMOVE
         if remove:
             launcher = Launcher(command="", args=())
@@ -219,6 +221,17 @@ class SetupService:
                     ErrorCode.EXECUTION_REFUSED,
                     "A target runtime version is required.",
                 )
+            active_manifest = self._read_install_manifest()
+            if (
+                operation is SetupOperation.CONFIGURE
+                and active_manifest is not None
+                and _is_older_version(version, active_manifest.active_version)
+            ):
+                warnings.append(
+                    f"Requested flameox {version} is older than the active runtime "
+                    f"{active_manifest.active_version}; keeping the active runtime."
+                )
+                version = active_manifest.active_version
             installed_versions = self.runtime.installed_versions()
             if operation is SetupOperation.ROLLBACK and version not in installed_versions:
                 raise DomainError(
@@ -253,7 +266,8 @@ class SetupService:
                 )
                 for edit in edits
             ),
-            warnings=(
+            warnings=tuple(warnings)
+            + (
                 ("Client detection is informational; only selected clients will change.",)
                 if any(not edit.detected for edit in edits)
                 else ()
@@ -588,6 +602,13 @@ class SetupService:
 def _unique_clients(clients: tuple[SetupClient, ...]) -> tuple[SetupClient, ...]:
     selected = set(clients)
     return tuple(client for client in ALL_SETUP_CLIENTS if client in selected)
+
+
+def _is_older_version(candidate: str, current: str) -> bool:
+    try:
+        return Version(candidate) < Version(current)
+    except InvalidVersion:
+        return False
 
 
 def _digest(value: bytes | None) -> str | None:

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -473,7 +473,11 @@ def setup(
                     inspection,
                     remove=operation is SetupOperation.REMOVE,
                 )
-                version = None if operation is SetupOperation.REMOVE else __version__
+                version = (
+                    None
+                    if operation is SetupOperation.REMOVE
+                    else setup_ui.effective_runtime_version(inspection, __version__)
+                )
         elif operation is SetupOperation.ROLLBACK:
             clients = clients or inspection.configured_clients
 

--- a/src/flameox/setup_ui.py
+++ b/src/flameox/setup_ui.py
@@ -5,6 +5,7 @@ from typing import cast
 
 import questionary
 import typer
+from packaging.version import InvalidVersion, Version
 from questionary import Choice
 
 from flameox.adapters.client_setup import ALL_SETUP_CLIENTS, SetupClient
@@ -28,7 +29,7 @@ def choose_action(inspection: SetupInspection, target_version: str) -> str:
     choices: list[Choice] = []
     if (
         inspection.active_version is not None
-        and inspection.active_version != target_version
+        and _is_newer(target_version, inspection.active_version)
         and inspection.configured_clients
     ):
         choices.append(Choice(f"Update flameox to {target_version}", "update"))
@@ -44,6 +45,20 @@ def choose_action(inspection: SetupInspection, target_version: str) -> str:
     choices.append(Choice("Exit", "exit"))
     answer = questionary.select("What would you like to do?", choices=choices).ask()
     return cast(str, _answer(answer))
+
+
+def effective_runtime_version(inspection: SetupInspection, target_version: str) -> str:
+    """Keep a stale bootstrap from replacing a newer active runtime."""
+    if inspection.active_version is None or _is_newer(target_version, inspection.active_version):
+        return target_version
+    return inspection.active_version
+
+
+def _is_newer(candidate: str, current: str) -> bool:
+    try:
+        return Version(candidate) > Version(current)
+    except InvalidVersion:
+        return candidate != current
 
 
 def choose_clients(

--- a/tests/application/test_setup.py
+++ b/tests/application/test_setup.py
@@ -68,6 +68,37 @@ async def test_setup_connects_only_explicitly_selected_clients(tmp_path: Path) -
 
 
 @pytest.mark.anyio
+async def test_setup_does_not_downgrade_active_runtime_for_stale_bootstrap(
+    tmp_path: Path,
+) -> None:
+    service, runtime, home = make_service(tmp_path)
+    (home / ".claude").mkdir()
+
+    await service.apply(
+        service.plan(
+            operation=SetupOperation.CONFIGURE,
+            clients=(SetupClient.CLAUDE,),
+            version="0.1.5",
+        )
+    )
+    plan = service.plan(
+        operation=SetupOperation.CONFIGURE,
+        clients=(SetupClient.CLAUDE,),
+        version="0.1.1",
+    )
+
+    assert plan.public.version == "0.1.5"
+    assert plan.public.runtime_action.value == "reuse"
+    assert plan.public.warnings == (
+        "Requested flameox 0.1.1 is older than the active runtime 0.1.5; "
+        "keeping the active runtime.",
+    )
+    await service.apply(plan)
+    configured = json.loads((home / ".claude.json").read_text())
+    assert configured["mcpServers"]["flameox"]["command"] == str(runtime.executable("0.1.5"))
+
+
+@pytest.mark.anyio
 async def test_setup_is_idempotent_and_preserves_unrelated_json(tmp_path: Path) -> None:
     service, _, home = make_service(tmp_path)
     config = home / ".gemini" / "settings.json"

--- a/tests/cli/test_npx_upgrade.py
+++ b/tests/cli/test_npx_upgrade.py
@@ -19,7 +19,13 @@ def _next_patch_version(version: str) -> str:
 @pytest.mark.skipif(os.name != "posix", reason="npx e2e fixture uses POSIX executable scripts")
 @pytest.mark.process
 @pytest.mark.serial
-@pytest.mark.parametrize("active_version", ("0.1.3", _next_patch_version(__version__)))
+@pytest.mark.parametrize(
+    "active_version",
+    (
+        pytest.param("0.1.3", id="older-active-runtime"),
+        pytest.param(_next_patch_version(__version__), id="newer-active-runtime"),
+    ),
+)
 def test_npx_upgrade_activates_or_preserves_the_managed_runtime(
     tmp_path: Path,
     active_version: str,

--- a/tests/cli/test_npx_upgrade.py
+++ b/tests/cli/test_npx_upgrade.py
@@ -11,10 +11,19 @@ import pytest
 from flameox import __version__
 
 
+def _next_patch_version(version: str) -> str:
+    major, minor, patch = (int(part) for part in version.split("."))
+    return f"{major}.{minor}.{patch + 1}"
+
+
 @pytest.mark.skipif(os.name != "posix", reason="npx e2e fixture uses POSIX executable scripts")
 @pytest.mark.process
 @pytest.mark.serial
-def test_npx_upgrade_activates_the_matching_managed_runtime(tmp_path: Path) -> None:
+@pytest.mark.parametrize("active_version", ("0.1.3", _next_patch_version(__version__)))
+def test_npx_upgrade_activates_or_preserves_the_managed_runtime(
+    tmp_path: Path,
+    active_version: str,
+) -> None:
     home = tmp_path / "home"
     data = tmp_path / "data"
     project = tmp_path / "npx-project"
@@ -24,29 +33,29 @@ def test_npx_upgrade_activates_the_matching_managed_runtime(tmp_path: Path) -> N
     package_dist.mkdir()
     (home / ".claude").mkdir()
 
-    old_version = "0.1.3"
-    old_executable = data / "runtimes" / old_version / "bin" / "flameox"
-    old_executable.parent.mkdir(parents=True)
-    old_executable.write_text("#!/bin/sh\nprintf '%s\\n' '0.1.3'\n")
-    old_executable.chmod(0o700)
-    (old_executable.parent.parent / "runtime.json").write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "distribution": "flameox",
-                "version": old_version,
-                "executable": str(old_executable),
-            }
+    active_executable = data / "runtimes" / active_version / "bin" / "flameox"
+    if active_version == "0.1.3":
+        active_executable.parent.mkdir(parents=True)
+        active_executable.write_text("#!/bin/sh\nprintf '%s\\n' '0.1.3'\n")
+        active_executable.chmod(0o700)
+        (active_executable.parent.parent / "runtime.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "distribution": "flameox",
+                    "version": active_version,
+                    "executable": str(active_executable),
+                }
+            )
+            + "\n"
         )
-        + "\n"
-    )
     data.mkdir(exist_ok=True)
     (data / "install.json").write_text(
         json.dumps(
             {
                 "schema_version": 1,
-                "active_version": old_version,
-                "executable": str(old_executable),
+                "active_version": active_version,
+                "executable": str(active_executable),
             }
         )
         + "\n"
@@ -57,7 +66,7 @@ def test_npx_upgrade_activates_the_matching_managed_runtime(tmp_path: Path) -> N
             {
                 "mcpServers": {
                     "flameox": {
-                        "command": str(old_executable),
+                        "command": str(active_executable),
                         "args": ["mcp", "serve", "--project-root", "."],
                     }
                 }
@@ -149,18 +158,28 @@ os.execv({str(python_cli)!r}, [{str(python_cli)!r}, *arguments[handoff + 1:]])
     fake_uv = tmp_path / "uv"
     fake_uv.write_text(
         f"""#!{sys.executable}
+import json
 import os
 from pathlib import Path
 import sys
 
 if sys.argv[1:3] != ["tool", "install"]:
     raise SystemExit("unexpected uv invocation")
+version = next(
+    argument.split("==", 1)[1]
+    for argument in sys.argv
+    if argument.startswith("flameox==")
+)
+Path(os.environ["FLAMEOX_UV_CAPTURE"]).write_text(json.dumps(sys.argv[1:]))
 runtime = Path(os.environ["UV_TOOL_BIN_DIR"]) / "flameox"
 runtime.parent.mkdir(parents=True, exist_ok=True)
 runtime.write_text(
     "#!{sys.executable}\\n"
     "import os, sys\\n"
-    "os.execv({str(python_cli)!r}, [{str(python_cli)!r}, *sys.argv[1:]])\\n"
+    "if sys.argv[1:] == ['--version']:\\n"
+    "    print(" + repr(version) + ")\\n"
+    "else:\\n"
+    "    os.execv({str(python_cli)!r}, [{str(python_cli)!r}, *sys.argv[1:]])\\n"
 )
 runtime.chmod(0o700)
 """
@@ -176,6 +195,7 @@ runtime.chmod(0o700)
             "FLAMEOX_SETUP_DATA_ROOT": str(data),
             "FLAMEOX_SETUP_UV": str(fake_uv),
             "FLAMEOX_UV_EXECUTABLE": str(fake_uvx),
+            "FLAMEOX_UV_CAPTURE": str(tmp_path / "uv-arguments.json"),
         },
         capture_output=True,
         text=True,
@@ -187,9 +207,10 @@ runtime.chmod(0o700)
     assert "Managed runtime ready. Starting flameox setup..." in result.stderr
 
     manifest = json.loads((data / "install.json").read_text())
-    current_executable = data / "runtimes" / __version__ / "bin" / "flameox"
+    expected_version = __version__ if active_version == "0.1.3" else active_version
+    current_executable = data / "runtimes" / expected_version / "bin" / "flameox"
     assert manifest == {
-        "active_version": __version__,
+        "active_version": expected_version,
         "executable": str(current_executable),
         "schema_version": 1,
     }
@@ -204,5 +225,8 @@ runtime.chmod(0o700)
         check=False,
     )
     assert version.returncode == 0
-    assert version.stdout.strip() == __version__
+    assert version.stdout.strip() == expected_version
     assert "node_modules" not in json.loads(config.read_text())["mcpServers"]["flameox"]["command"]
+    assert json.loads((tmp_path / "uv-arguments.json").read_text())[-1] == (
+        f"flameox=={expected_version}"
+    )

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -90,7 +90,7 @@ expected_test_count = 349
 'tests/storage/test_artifacts_and_runs.py' = { count = 14, digest = '0f27557254a46c2635bf5cfd47766e05d84e3bb38becf8d8bf6271cd2ebbfc2e' }
 'tests/storage/test_workspace.py' = { count = 8, digest = 'e657cc3def63d14daa25687beba8a16a5fc95e61b3548e198dc90d0ced9781de' }
 'tests/test_cli_setup.py' = { count = 6, digest = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561' }
-'tests/cli/test_npx_upgrade.py' = { count = 2, digest = '4a8d96f2436be4bbb941aca4e6b46da694761f4ef38deef7adbd32cd67ef57fe' }
+'tests/cli/test_npx_upgrade.py' = { count = 2, digest = '4f9d9fc9b4d16d1c42d34bcb6e812036c7cdd12650fefee694ef5cfbef873bab' }
 'tests/test_cli_smoke.py' = { count = 6, digest = '651c7d2e6e4cc20a01957613755d81d2a44f7c3feac77d45d990c9651298df47' }
 'tests/test_release_metadata.py' = { count = 2, digest = '6235e23370243d1e45fa84e75a6b8f1699af1d5d8a01b59d783a1b882bd077a9' }
 'tests/test_setup_ui.py' = { count = 2, digest = '9b80453c3b4df6c3744f2d8e750d794bf6f0dc1d568ca987a39739a124a48e45' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 348
+expected_test_count = 349
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -90,7 +90,7 @@ expected_test_count = 348
 'tests/storage/test_artifacts_and_runs.py' = { count = 14, digest = '0f27557254a46c2635bf5cfd47766e05d84e3bb38becf8d8bf6271cd2ebbfc2e' }
 'tests/storage/test_workspace.py' = { count = 8, digest = 'e657cc3def63d14daa25687beba8a16a5fc95e61b3548e198dc90d0ced9781de' }
 'tests/test_cli_setup.py' = { count = 6, digest = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561' }
-'tests/cli/test_npx_upgrade.py' = { count = 1, digest = '10737afa18cdcf5261c2ee91adf930f36bf8147ecb984c38fa5be8fcf938274d' }
+'tests/cli/test_npx_upgrade.py' = { count = 2, digest = '4a8d96f2436be4bbb941aca4e6b46da694761f4ef38deef7adbd32cd67ef57fe' }
 'tests/test_cli_smoke.py' = { count = 6, digest = '651c7d2e6e4cc20a01957613755d81d2a44f7c3feac77d45d990c9651298df47' }
 'tests/test_release_metadata.py' = { count = 2, digest = '6235e23370243d1e45fa84e75a6b8f1699af1d5d8a01b59d783a1b882bd077a9' }
 'tests/test_setup_ui.py' = { count = 2, digest = '9b80453c3b4df6c3744f2d8e750d794bf6f0dc1d568ca987a39739a124a48e45' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 346
+expected_test_count = 348
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -68,7 +68,7 @@ expected_test_count = 346
 'tests/application/test_recovery.py' = { count = 1, digest = 'f91a604faeffcce55b436242fd99e0b72a6a45cea94c92ac7f2ef918adf5db06' }
 'tests/application/test_reductions.py' = { count = 6, digest = '994e0a9b37e71bc4760a519d1e8635a40731ee91616cdb9d1d79d7f6454e20b0' }
 'tests/application/test_repair.py' = { count = 9, digest = 'f1db8b3dfa7f151b02f4f6671db0fc62686df6fd83699b57ed6a9c04cdddee1b' }
-'tests/application/test_setup.py' = { count = 18, digest = '37bd26c693a7f435d38584d8c58ce184cfa7419627800b3f20e36ee39ed26248' }
+'tests/application/test_setup.py' = { count = 19, digest = '4ca5627f631a69bde5ecca086bc2ce4daa71fd2d90f5e2723d9ec40fa1b2201a' }
 'tests/application/test_source_identity.py' = { count = 1, digest = '9269cc3025cf0035a14da2b8c601d8ad36dd50f2dabfc1c7b87b6a74e15e1ea4' }
 'tests/application/test_status.py' = { count = 3, digest = '1ff4f1c315236e7e1207fc54890018db1c94071b8bc916e0b9fb75cd5d35f254' }
 'tests/application/test_summaries.py' = { count = 4, digest = '350d1cb8ae547c947cf6e5b492f01a2c75e832af5d239731a87d6b30daa04905' }
@@ -93,6 +93,6 @@ expected_test_count = 346
 'tests/cli/test_npx_upgrade.py' = { count = 1, digest = '10737afa18cdcf5261c2ee91adf930f36bf8147ecb984c38fa5be8fcf938274d' }
 'tests/test_cli_smoke.py' = { count = 6, digest = '651c7d2e6e4cc20a01957613755d81d2a44f7c3feac77d45d990c9651298df47' }
 'tests/test_release_metadata.py' = { count = 2, digest = '6235e23370243d1e45fa84e75a6b8f1699af1d5d8a01b59d783a1b882bd077a9' }
-'tests/test_setup_ui.py' = { count = 1, digest = '24035fdd0bc224d58c3df8944d9c16f2525cabc217c3682fe93ffea1ac2204ab' }
+'tests/test_setup_ui.py' = { count = 2, digest = '9b80453c3b4df6c3744f2d8e750d794bf6f0dc1d568ca987a39739a124a48e45' }
 'tests/golden/test_semantic_matrix.py' = { count = 1, digest = 'ad3ee0c218bcfa4a2badc24faed4b456b281234589cb6f05721ef14f8c4acee3' }
 'tests/test_external_receipt_fixture.py' = { count = 6, digest = 'e18dcfbc5d5ef8969250d06ec2ff54f04bcc01ad560e5526269e957fae38f782' }

--- a/tests/test_setup_ui.py
+++ b/tests/test_setup_ui.py
@@ -18,6 +18,43 @@ class _CheckboxQuestion:
         return [cast(SetupClient, choice.value) for choice in self.choices if choice.checked]
 
 
+class _SelectQuestion:
+    def __init__(self, choices: list[Choice]) -> None:
+        self.choices = choices
+
+    def ask(self) -> str:
+        return "configure"
+
+
+def test_stale_bootstrap_does_not_offer_or_select_a_runtime_downgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selected: list[Choice] = []
+
+    def select(message: str, *, choices: list[Choice]) -> _SelectQuestion:
+        assert message == "What would you like to do?"
+        selected.extend(choices)
+        return _SelectQuestion(choices)
+
+    monkeypatch.setattr("flameox.setup_ui.questionary.select", select)
+    inspection = SetupInspection(
+        active_version="0.1.5",
+        active_executable=None,
+        configured_clients=(SetupClient.CLAUDE,),
+        detected_clients=(),
+        installed_versions=("0.1.5",),
+    )
+
+    assert setup_ui.choose_action(inspection, "0.1.1") == "configure"
+    assert [choice.title for choice in selected] == [
+        "Connect or update MCP clients",
+        "Disconnect MCP clients",
+        "Verify connected clients and the active runtime",
+        "Exit",
+    ]
+    assert setup_ui.effective_runtime_version(inspection, "0.1.1") == "0.1.5"
+
+
 def test_connect_preselects_detected_clients(monkeypatch: pytest.MonkeyPatch) -> None:
     def checkbox(message: str, *, choices: list[Choice]) -> _CheckboxQuestion:
         assert message == "Select MCP clients to connect:"


### PR DESCRIPTION
## Description

Prevent an older cached `npx flameox` bootstrap from presenting or applying a runtime downgrade. A stale wrapper can report an older package version than the active managed runtime; setup must preserve the newer active runtime in both interactive and `--yes` flows.

## Root cause

The setup UI offered `Update flameox to <target>` whenever the target merely differed from the active version. It did not compare versions, and the application planner accepted the stale target unconditionally. A cached bootstrap such as `0.1.1` could therefore be mistaken for an upgrade while `0.1.5` was already active.

## Change

- Offer the interactive update action only when the target version is newer.
- Resolve stale configure targets to the active runtime and emit an explicit warning.
- Apply the same protection to non-interactive `upgrade --yes` flows.
- Add UI, application, and published-style real-`npx` E2E coverage for activation and stale-bootstrap preservation.

## Validation

```console
uv run pytest -q -m process tests/cli/test_npx_upgrade.py  # 2 passed
GITHUB_ACTIONS=true uv run pytest -q tests/test_setup_ui.py::test_stale_bootstrap_does_not_offer_or_select_a_runtime_downgrade
uv run pytest -q tests/test_setup_ui.py tests/application/test_setup.py tests/test_cli_smoke.py
uv run python tools/test.py cli  # 32 passed
uv run python tools/test.py collection  # 349 node IDs preserved
uv run python tools/test.py ownership
uv run ruff check src tests
uv run ruff format --check src tests tools
uv run mypy src tests
```

Unqualified `npx flameox` may reuse a cached 0.1.1 bootstrap; `npx flameox@latest` resolves the current published bootstrap. This change keeps the runtime layer safe even when a stale bootstrap is invoked.