### PR TITLE
feat(mcp): standardize lifecycle and evidence-aware workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ preview analyses, and record results. Capture and experiment plans are
 short-lived and single-use; restarting the server invalidates those plan tokens.
 Detached capture records persist across a manager restart: retry the same
 `idempotency_key` to reconnect to the original run rather than starting another
-capture.
+capture. Capability setup uses the same rule; after a retryable failure or
+cancellation, follow the returned recovery arguments with their fresh
+`idempotency_key` to start a new attempt.
 
 Inspect the protocol surface with a real stdio client:
 

--- a/README.md
+++ b/README.md
@@ -160,12 +160,13 @@ Optional Python extras are independent:
 
 When FlameOx is connected to an agent, the agent does not need to guess package
 names. `list_capabilities` reports the exact managed providers that are missing;
-the agent calls `prepare_capabilities`, or `prepare_adapter` for an installed
-third-party entry point. These actions verify their result and never run a
-workload. `prepare_workload_dependencies` installs only Python distributions
-declared by a named workload. Non-privileged user-space tools such as Trace
-Processor are staged automatically; host executables, permissions, and
-privileged collectors remain explicit limitations.
+the agent calls `start_capability_setup` with an idempotency key, then polls
+`get_capability_setup` (or calls `cancel_capability_setup` when needed).
+`prepare_capabilities` remains as a compatibility wrapper. These actions verify
+their result and never run a workload. `prepare_workload_dependencies` installs
+only Python distributions declared by a named workload. Non-privileged
+user-space tools such as Trace Processor are staged automatically; host
+executables, permissions, and privileged collectors remain explicit limitations.
 
 ## Local data model
 
@@ -222,10 +223,12 @@ An agent can create this declaration directly through MCP with
 `configure_workload`. That operation validates the complete project, preserves
 unrelated workloads and experiments, and makes the workload immediately
 available; it never runs the command. The agent then follows
-`list_declared_workflows → get_declared_workflow → list_capabilities →
-plan_capture → execute_capture_plan`. A valid manually authored workload is
-also immediately active. There is no separate workload approval or human-check
-step: the canonical definition in `flameox.toml` is the execution binding.
+`list_declared_workflows` (no arguments lists workloads) →
+`get_declared_workflow → list_capabilities → plan_capture → execute_capture_plan`.
+Pass `kind="experiment"` when discovering experiments. A valid manually authored
+workload is also immediately active. There is no separate workload approval or
+human-check step: the canonical definition in `flameox.toml` is the execution
+binding.
 
 The equivalent CLI capture commands are:
 
@@ -312,7 +315,10 @@ uv run flameox mcp serve --project-root .
 
 Through MCP, agents can configure workloads, plan captures and experiments, query evidence,
 preview analyses, and record results. Capture and experiment plans are
-short-lived and single-use; restarting the server invalidates them.
+short-lived and single-use; restarting the server invalidates those plan tokens.
+Detached capture records persist across a manager restart: retry the same
+`idempotency_key` to reconnect to the original run rather than starting another
+capture.
 
 Inspect the protocol surface with a real stdio client:
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -285,11 +285,13 @@ A capability may be:
 - `unknown`.
 
 For missing managed providers, the report also contains a typed setup action.
-Agents should pass its adapter name to `prepare_capabilities`, then refresh the
-capability list before planning. This covers the published `execution`,
-`memory`, `cpu`, `test`, and `torch` extras. It does not install host tools or
-change permissions. A fallback adapter must be chosen only after the agent has
-shown the requested capability's evidence limitation in its plan.
+Agents should pass its adapter name to `start_capability_setup` with a stable
+idempotency key, poll the durable result, and then refresh the capability list
+before planning. `prepare_capabilities` remains a compatibility wrapper. This
+covers the published `execution`, `memory`, `cpu`, `test`, and `torch` extras.
+It does not install host tools or change permissions. A fallback adapter must be
+chosen only after the agent has shown the requested capability's evidence
+limitation in its plan.
 
 Probe commands must be bounded and expected to be side-effect free, but active
 execution is still labeled as execution. An executable found only through a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -266,20 +266,22 @@ flameox[dev]          test, lint, type-check, and fixture tooling
 flameox[all]          all non-vendor optional integrations
 ```
 
-The MCP setup actions are the agent-facing installers. `prepare_capabilities`
-accepts an explicit managed adapter enum and resolves the matching published
-extra; `prepare_adapter` records an exact installed third-party identity; and
+The MCP setup actions are the agent-facing installers. `start_capability_setup`
+accepts an explicit managed adapter enum and idempotency key, returns a durable
+operation, and is followed by `get_capability_setup` or
+`cancel_capability_setup`; `prepare_capabilities` is the compatibility wrapper.
+`prepare_adapter` records an exact installed third-party identity, and
 `prepare_workload_dependencies` installs only Python distributions already
-declared by a named workload. Selected extras are recorded in the user-local
-managed-runtime manifest so a later runtime upgrade does not silently remove
-them. None of these actions runs a workload.
+declared by a named workload. Selected extras are recorded in the workspace
+capability manifest so a later runtime upgrade does not silently remove them.
+None of these actions runs a workload.
 
 System and privileged executables such as `perf`, `llvm-symbolizer`, Bubblewrap,
 GDB, or LLDB are detected at runtime and are not provisioned by FlameOx. The
-non-privileged Trace Processor is the exception: `prepare_capabilities` stages a
-pinned platform-specific binary under `.diagnostics/tools`, verifies its bounded
-version command, and records the configured path. Permission requirements such
-as `perf_event_open` remain explicit.
+non-privileged Trace Processor is the exception: `start_capability_setup` stages
+a pinned platform-specific binary under `.diagnostics/tools`, verifies its
+bounded version command, and records the configured path. Permission
+requirements such as `perf_event_open` remain explicit.
 
 ### Application services
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -102,9 +102,12 @@ flameox validate
 
 `init` creates only local files and never installs collectors. `capabilities`
 reports installed tools, versions, supported modes, permissions, and exact
-managed setup actions. MCP agents use `prepare_capabilities` for FlameOx-managed
-providers and the typed `prepare_adapter` action for an installed third-party
-entry point; neither action runs a workload.
+managed setup actions. MCP agents use `start_capability_setup` with an explicit
+idempotency key for FlameOx-managed providers, then poll
+`get_capability_setup` or cancel with `cancel_capability_setup`. The older
+`prepare_capabilities` entry point remains a compatibility wrapper. The typed
+`prepare_adapter` action handles an installed third-party entry point; none of
+these actions runs a workload.
 
 ### Capture commands
 
@@ -393,8 +396,8 @@ experiments, and comments are preserved, and `flameox.toml` is atomically
 updated under the workspace lock. The canonical workload is immediately active.
 This tool never runs
 the command; call `list_declared_workflows` next, then
-`get_declared_workflow`, `list_capabilities`, `prepare_capabilities` when
-needed, `list_capabilities` again, `plan_capture`, and finally
+`get_declared_workflow`, `list_capabilities`, `start_capability_setup` when
+needed, `get_capability_setup`, `list_capabilities` again, `plan_capture`, and finally
 `execute_capture_plan`.
 
 #### `workspace_status`

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -696,13 +696,17 @@ unknown-duration phases report a phase with `completed` and `total` omitted.
 Operations using the shared lifecycle record their exact request digest,
 workspace identity, idempotency digest, item-level outcomes, cancellation and
 cleanup state, and terminal receipt before they are reported complete.
+The original idempotency key always reconnects to the same operation, including
+after a restart. A retryable failure or cancellation therefore advertises a
+`retry_new_operation` recovery with a fresh key; reusing the original key never
+starts duplicate side effects.
 
 ### Lifecycle matrix
 
 | Operation family | Side effect | Expected duration | Recovery |
 | --- | --- | --- | --- |
 | Workspace/configuration reads | none | bounded | reread the pinned workspace on stale state |
-| Capability setup | package install or tool staging | long | poll status; retry the exact request or failed items |
+| Capability setup | package install or tool staging | long | poll status; reconnect with the same key, or use the receipt's fresh key for a new retry |
 | Workload dependency setup | declared package install | bounded to long | retry the exact workload name and inspect preflight |
 | Import and extraction | copy, external parser, or publication | bounded to long | identify the affected run and required extractor |
 | Capture and experiments | external process and/or multiple trials | long | use the durable operation/run identity and poll |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -319,7 +319,7 @@ The supported tools are grouped as follows:
 
 | Family | Tools |
 | --- | --- |
-| Workspace | `initialize_workspace`, `workspace_status`, `workload_configuration_status`, `configure_workload`, `list_capabilities`, `prepare_capabilities`, `prepare_adapter`, `prepare_workload_dependencies`, `validate_workspace` |
+| Workspace | `initialize_workspace`, `workspace_status`, `workload_configuration_status`, `configure_workload`, `list_capabilities`, `start_capability_setup`, `get_capability_setup`, `cancel_capability_setup`, `prepare_capabilities`, `prepare_adapter`, `prepare_workload_dependencies`, `validate_workspace` |
 | Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_observations` |
 | Detached capture | `start_detached_capture`, `get_detached_capture`, `cancel_detached_capture` |
 | Discovery | `list_declared_workflows`, `get_declared_workflow`, `list_runs`, `list_findings` |
@@ -338,10 +338,10 @@ The normal first-run sequence is:
 initialize_workspace
   → workload_configuration_status
   → configure_workload (when missing)
-  → list_declared_workflows
+  → list_declared_workflows (no arguments lists workloads; use kind='experiment' for experiments)
   → get_declared_workflow
   → list_capabilities
-  → prepare_capabilities (when setup_adapters is non-empty)
+  → start_capability_setup (when setup_adapters is non-empty)
   → prepare_adapter (when setup_third_party_adapters is non-empty)
   → prepare_workload_dependencies (when the workload declares missing Python distributions)
   → list_capabilities
@@ -427,18 +427,23 @@ decide whether to refresh discovery before planning.
 
 #### `prepare_capabilities`
 
-Mutating but non-executing. Accepts only adapter names reported by
+Mutating but non-executing. This compatibility entry point starts a durable
+operation and returns its operation ID instead of holding an MCP request open.
+Use `start_capability_setup` with an explicit idempotency key for new callers,
+`get_capability_setup` to reconnect and poll, and `cancel_capability_setup` to
+request cleanup. The operation accepts only adapter names reported by
 `list_capabilities` as managed setup actions: `coverage`, `memray`, `perfetto`,
 `py-spy`, `pytest`, and `torch.profiler`. It installs the published FlameOx
 extra into the active managed Python runtime and stages the pinned user-space
-Trace Processor under `.diagnostics/tools` for `perfetto`. It verifies
-availability, persists selected extras for the next FlameOx runtime upgrade,
-and returns `next_tool="list_capabilities"`. `list_capabilities` also reports the latest
-durable setup receipt, including the requested adapters, completed adapters, and phase after a
-cancelled or failed request. It never runs the declared
-workload, mutates source, installs arbitrary packages, changes host
-permissions, or provisions privileged collectors. A failed install returns a
-bounded installer diagnostic and a retryable recovery action.
+Trace Processor under `.diagnostics/tools` for `perfetto`. Its receipt includes
+the workspace identity, exact request digest, named phase, bounded progress,
+item outcomes, cancellation/cleanup state, and next recovery action. It never
+runs the declared workload, mutates source, installs arbitrary packages,
+changes host permissions, or provisions privileged collectors.
+
+`prepare_workload_dependencies` follows the same side-effect rule and remains a
+short compatibility entry point; its installer runs behind a worker boundary,
+and its preflight result names the exact missing distributions and next action.
 
 #### `prepare_adapter`
 
@@ -470,6 +475,10 @@ permission status, supported modes and formats, features, limitations, and
 remediation. Options that need a permission check are reported as
 `active_probe_required`; discovery remains passive until the caller requests
 `list_capabilities(mode="active_refresh")`.
+
+`list_declared_workflows` accepts an argument-free call. It defaults to
+`kind="workload"`; pass `kind="experiment"` when the experiment namespace is
+needed.
 
 #### `plan_capture`
 
@@ -633,7 +642,8 @@ flameox://run-sets/{run_set_id}
 ```
 
 Resources return JSON or text summaries. Large native artifacts are represented
-by metadata and local handles, not injected into model context. Template
+by metadata and opaque resource references, never host storage paths and never
+injected into model context. Template
 resources declare `mime_type="application/json"`, percent-encode identifiers,
 and resolve services through a server-local lifespan closure. In the exact
 `2.0.0b2` wheel, template-handler `Context` is reconstructed by Pydantic and
@@ -676,6 +686,30 @@ phase boundary. A default operation uses fixed phase work units, for example
 interval. Unknown-duration work reports phase transitions and uses MCP logging
 for elapsed time rather than inventing percentages. Reporting is best-effort:
 `ctx.report_progress()` is a no-op when the client supplied no progress token.
+
+Detached operations persist the same phase transitions and retain only a bounded
+progress history. Percentage values are monotonic when work units are known;
+unknown-duration phases report a phase with `completed` and `total` omitted.
+Operations using the shared lifecycle record their exact request digest,
+workspace identity, idempotency digest, item-level outcomes, cancellation and
+cleanup state, and terminal receipt before they are reported complete.
+
+### Lifecycle matrix
+
+| Operation family | Side effect | Expected duration | Recovery |
+| --- | --- | --- | --- |
+| Workspace/configuration reads | none | bounded | reread the pinned workspace on stale state |
+| Capability setup | package install or tool staging | long | poll status; retry the exact request or failed items |
+| Workload dependency setup | declared package install | bounded to long | retry the exact workload name and inspect preflight |
+| Import and extraction | copy, external parser, or publication | bounded to long | identify the affected run and required extractor |
+| Capture and experiments | external process and/or multiple trials | long | use the durable operation/run identity and poll |
+| Analysis and measurement queries | read-only catalog access | bounded | inspect the evidence status and next tool |
+| Full validation and reductions | large reads or generated evidence | long | poll the terminal receipt for the declared scope |
+
+An empty array is not evidence of a complete negative result. Analysis and
+query results carry an `evidence` object with status `available`, `empty`,
+`unavailable`, `partial`, or `unknown`, a stable reason, and exact next-tool
+arguments when recovery is possible.
 
 ### Cancellation
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -508,6 +508,10 @@ progress, observes cancellation, and returns a completed or failed run record.
 Every bound identity, capability, workload definition, and policy input is rechecked
 immediately before execution. It never accepts a shell string or replacement
 arguments.
+Python profiler adapters keep the declared workload interpreter and working
+directory, including for `python -m` workloads, while invoking FlameOx's
+standalone launcher directly. They do not require FlameOx to be importable from
+the workload virtualenv and do not enable `PYTHONPATH` overrides.
 
 #### `plan_experiment` and `run_experiment`
 

--- a/docs/runtime-safety.md
+++ b/docs/runtime-safety.md
@@ -217,10 +217,13 @@ disabled.
 ### Network behavior
 
 The flameox control process performs no network calls during capture or analysis.
-The explicit MCP `prepare_capabilities` operation may fetch and install only the
-allowlisted FlameOx optional providers into the managed runtime; it never
-executes a workload and records the selected extras for future runtime
-upgrades. Host executables and permissions remain manual limitations.
+The explicit MCP `start_capability_setup` operation may fetch and install only
+the allowlisted FlameOx optional providers into the managed runtime; poll
+`get_capability_setup` for its durable receipt or use `cancel_capability_setup`
+for cleanup. The compatibility `prepare_capabilities` wrapper follows the same
+policy. Setup never executes a workload and records the selected extras for
+future runtime upgrades. Host executables and permissions remain manual
+limitations.
 Symbol-server or debuginfod access is disabled unless explicitly enabled
 in local configuration and invoked through the CLI. Child workloads may use
 the network unless an active containment backend denies it; this is displayed

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -309,8 +309,7 @@ def build_capture_invocation(
                 launcher_target = ("--script", target[0], *target[1:])
             argv = (
                 python,
-                "-m",
-                "flameox.collectors.torch_launcher",
+                _launcher_path("torch_launcher.py"),
                 "--output",
                 output,
                 *launcher_target,
@@ -404,3 +403,8 @@ def _python_executable_for_launcher(workload_argv: tuple[str, ...]) -> str:
     if executable.startswith("python"):
         return workload_argv[0]
     return sys.executable
+
+
+def _launcher_path(name: str) -> str:
+    """Return a standalone launcher path usable by an unrelated workload venv."""
+    return str((Path(__file__).parent.parent / "collectors" / name).resolve())

--- a/src/flameox/adapters/perfetto.py
+++ b/src/flameox/adapters/perfetto.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from pydantic import JsonValue
+from pydantic import Field, JsonValue
 
 from flameox.atomic import atomic_write_json
 from flameox.domain import (
@@ -19,6 +19,7 @@ from flameox.domain import (
     digest_model,
 )
 from flameox.evidence import GenerationPublisher
+from flameox.evidence_status import EvidenceAvailability, available_availability, empty_availability
 from flameox.execution import ExecutionRequest, SubprocessBroker
 from flameox.models import ContractModel
 from flameox.storage import ArtifactStore, RunStore, Workspace
@@ -64,6 +65,7 @@ class TraceWindowResult(ContractModel):
     limitations: tuple[str, ...] = (
         "The window includes slices that overlap the requested interval.",
     )
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class PerfettoExtractor:
@@ -476,9 +478,14 @@ class PerfettoExtractor:
             total=total,
             returned=len(events),
             truncated=has_more,
-            coverage=(len(events) / total if total else 1.0),
+            coverage=(len(events) / total if total else 0.0),
             next_cursor=next_cursor,
             trace_processor_path=str(binary),
+            evidence=(
+                empty_availability("no_events_in_window")
+                if not events
+                else available_availability()
+            ),
         )
 
     async def _run_worker(

--- a/src/flameox/adapters/setup_runtime.py
+++ b/src/flameox/adapters/setup_runtime.py
@@ -6,6 +6,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -239,7 +241,11 @@ class ManagedRuntime:
 TRACE_PROCESSOR_VERSION = "v55.1"
 
 
-def install_trace_processor(workspace: Workspace) -> TraceProcessorInstallation:
+def install_trace_processor(
+    workspace: Workspace,
+    *,
+    cancel_event: threading.Event | None = None,
+) -> TraceProcessorInstallation:
     """Stage the pinned user-space Trace Processor without requiring host privileges."""
     platform_key = {
         ("linux", "x86_64"): "linux-amd64",
@@ -261,7 +267,8 @@ def install_trace_processor(workspace: Workspace) -> TraceProcessorInstallation:
 
     target = workspace.paths.root / "tools" / "trace_processor_shell"
     if target.is_file() and os.access(target, os.X_OK):
-        _verify_trace_processor(target)
+        _check_staging_cancelled(cancel_event)
+        _verify_trace_processor(target, cancel_event=cancel_event)
         return TraceProcessorInstallation(TRACE_PROCESSOR_VERSION, target, False)
 
     url = (
@@ -281,6 +288,7 @@ def install_trace_processor(workspace: Workspace) -> TraceProcessorInstallation:
             with urllib.request.urlopen(url, timeout=120) as response:
                 total = 0
                 while chunk := response.read(1024 * 1024):
+                    _check_staging_cancelled(cancel_event)
                     total += len(chunk)
                     if total > 512 * 1024 * 1024:
                         raise DomainError(
@@ -292,9 +300,11 @@ def install_trace_processor(workspace: Workspace) -> TraceProcessorInstallation:
             stream.flush()
             os.fsync(stream.fileno())
         temporary.chmod(0o755)
-        _verify_trace_processor(temporary)
+        _check_staging_cancelled(cancel_event)
+        _verify_trace_processor(temporary, cancel_event=cancel_event)
         target.parent.mkdir(parents=True, exist_ok=True)
         with workspace.write_locked():
+            _check_staging_cancelled(cancel_event)
             os.replace(temporary, target)
             config = workspace.config
             updated = config.model_copy(
@@ -325,7 +335,53 @@ def install_trace_processor(workspace: Workspace) -> TraceProcessorInstallation:
     return TraceProcessorInstallation(TRACE_PROCESSOR_VERSION, target, True)
 
 
-def _verify_trace_processor(executable: Path) -> None:
+def _verify_trace_processor(
+    executable: Path,
+    *,
+    cancel_event: threading.Event | None = None,
+) -> None:
+    if cancel_event is None:
+        _verify_trace_processor_with_run(executable)
+        return
+    process = subprocess.Popen(
+        [str(executable), "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 30
+    while process.poll() is None:
+        if cancel_event.wait(0.1):
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            raise DomainError(
+                ErrorCode.PROCESS_CANCELLED,
+                "Trace Processor staging was cancelled before publication.",
+                retryable=True,
+                details={"next_tool": "start_capability_setup", "adapter": "perfetto"},
+            )
+        if time.monotonic() >= deadline:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            raise DomainError(
+                ErrorCode.PROCESS_TIMEOUT,
+                "The staged Trace Processor exceeded its 30 second verification timeout.",
+                retryable=True,
+                details={"next_tool": "start_capability_setup", "adapter": "perfetto"},
+            )
+    stdout, stderr = process.communicate()
+    _validate_trace_processor_result(process.returncode, stdout, stderr)
+
+
+def _verify_trace_processor_with_run(executable: Path) -> None:
     try:
         completed = subprocess.run(
             [str(executable), "--version"],
@@ -340,13 +396,31 @@ def _verify_trace_processor(executable: Path) -> None:
             "The staged Trace Processor failed its bounded version check.",
             details={"next_tool": "prepare_capabilities", "adapter": "perfetto"},
         ) from exc
-    output = f"{completed.stdout}\n{completed.stderr}"
-    if completed.returncode != 0 or TRACE_PROCESSOR_VERSION.removeprefix("v") not in output:
+    _validate_trace_processor_result(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _validate_trace_processor_result(
+    returncode: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    output = f"{stdout}\n{stderr}"
+    if returncode != 0 or TRACE_PROCESSOR_VERSION.removeprefix("v") not in output:
         raise DomainError(
             ErrorCode.PROCESS_FAILED,
             "The staged Trace Processor failed its bounded version check.",
             details={"next_tool": "prepare_capabilities", "adapter": "perfetto"},
-            remediation=(completed.stderr.strip()[:500] or "Retry the managed setup.",),
+            remediation=(stderr.strip()[:500] or "Retry the managed setup.",),
+        )
+
+
+def _check_staging_cancelled(cancel_event: threading.Event | None) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise DomainError(
+            ErrorCode.PROCESS_CANCELLED,
+            "Trace Processor staging was cancelled before publication.",
+            retryable=True,
+            details={"next_tool": "start_capability_setup", "adapter": "perfetto"},
         )
 
 

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -1499,25 +1499,66 @@ class RecipeService:
         environment_stable = all(point.environment_count == 1 for point in points)
         if not environment_stable:
             warnings.append("Environment identity varies within at least one scaling point.")
+        attempted_trials = int(trial_row[0])
+        succeeded_trials = int(trial_row[1])
+        failed_trials = int(trial_row[2])
+        evidence, measurement_warning = self._scaling_evidence(
+            points,
+            attempted_trials=attempted_trials,
+            succeeded_trials=succeeded_trials,
+            measured_trials=len(trials),
+        )
+        if measurement_warning is not None:
+            warnings.append(measurement_warning)
         return ScalingAnalysisResult(
             corpus_commit_id=snapshot.commit.commit_id,
             experiment_id=experiment_id,
             metric=metric,
             points=points,
             trials=tuple(trials),
-            attempted_trials=int(trial_row[0]),
-            succeeded_trials=int(trial_row[1]),
-            failed_trials=int(trial_row[2]),
+            attempted_trials=attempted_trials,
+            succeeded_trials=succeeded_trials,
+            failed_trials=failed_trials,
             complete_blocks=int(complete_row[0]),
             fits=fits,
             correlated_hotspots=correlated_hotspots,
             conclusion=conclusion,
             environment_stable=environment_stable,
             warnings=tuple(warnings),
-            evidence=(
-                empty_availability("no_scaling_trials") if not points else available_availability()
-            ),
+            evidence=evidence,
         )
+
+    @staticmethod
+    def _scaling_evidence(
+        points: tuple[ScalingPoint, ...],
+        *,
+        attempted_trials: int,
+        succeeded_trials: int,
+        measured_trials: int,
+    ) -> tuple[EvidenceAvailability, str | None]:
+        if points and succeeded_trials > measured_trials:
+            return (
+                EvidenceAvailability(
+                    status="partial",
+                    reason="primary_metric_measurements_partial",
+                ),
+                "Some succeeded trials published no measurements matching the experiment's "
+                "primary metric.",
+            )
+        if points:
+            return available_availability(), None
+        if succeeded_trials:
+            return (
+                EvidenceAvailability(
+                    status="unavailable",
+                    reason="primary_metric_measurements_unavailable",
+                ),
+                "Succeeded trials published no measurements matching the experiment's "
+                "primary metric.",
+            )
+        if attempted_trials:
+            return empty_availability("no_succeeded_trials"), None
+        return empty_availability("no_scaling_trials"), None
 
     def _scaling_fits(
         self,

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -547,6 +547,15 @@ class RecipeService:
                 "Runtime resource summary was not published for this evidence generation."
             )
         memory_run_id = scope.run_ids[0] if len(scope.run_ids) == 1 else None
+        memory_hotspots = tuple(
+            item for item in hotspot_result.hotspots if item.metric.startswith("memory.")
+        )
+        has_runtime_evidence = bool(
+            resource_rows
+            or writable_rows
+            or policy_termination is not None
+            or (resource_total is not None and resource_total.run_count > 0)
+        )
         evidence = (
             EvidenceAvailability(
                 status="unavailable",
@@ -560,14 +569,32 @@ class RecipeService:
                     {"run_id": memory_run_id} if has_memory_profile and memory_run_id else None
                 ),
             )
-            if not rows and has_memory_profile
+            if (
+                not rows
+                and not memory_hotspots
+                and not phase_growth
+                and has_memory_profile
+                and not has_runtime_evidence
+            )
             else (
                 EvidenceAvailability(
-                    status="unavailable",
-                    reason="no_memory_profile_artifact",
+                    status="partial" if has_runtime_evidence else "unavailable",
+                    reason=(
+                        (
+                            "memory_profile_not_extracted_runtime_evidence_present"
+                            if has_memory_profile
+                            else "no_memory_profile_artifact_runtime_evidence_present"
+                        )
+                        if has_runtime_evidence
+                        else "no_memory_profile_artifact"
+                    ),
                 )
-                if not rows and hotspot_result.evidence_status == "unavailable"
-                else empty_availability("no_memory_measurements")
+                if not rows and not memory_hotspots and not phase_growth
+                else (
+                    available_availability()
+                    if memory_hotspots or phase_growth
+                    else empty_availability("no_memory_measurements")
+                )
                 if not rows
                 else available_availability()
             )
@@ -586,9 +613,7 @@ class RecipeService:
                 )
                 for row in rows
             ),
-            hotspots=tuple(
-                item for item in hotspot_result.hotspots if item.metric.startswith("memory.")
-            ),
+            hotspots=memory_hotspots,
             phase_growth=tuple(phase_growth),
             limitations=tuple(limitations),
             runtime_resources=resource_rows,
@@ -844,7 +869,7 @@ class RecipeService:
                 else:
                     run_ids = ()
                 details: dict[str, object] = {"next_tool": "extract_perfetto"}
-                if len(run_ids) == 1:
+                if run_ids:
                     details["run_id"] = run_ids[0]
                 raise DomainError(
                     ErrorCode.CAPABILITY_UNAVAILABLE,

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -1457,9 +1457,7 @@ class RecipeService:
             environment_stable=environment_stable,
             warnings=tuple(warnings),
             evidence=(
-                empty_availability("no_scaling_trials")
-                if not points
-                else available_availability()
+                empty_availability("no_scaling_trials") if not points else available_availability()
             ),
         )
 

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import Any, Literal, cast
 
 import numpy as np
+from pydantic import Field
 from scipy.stats import bootstrap, spearmanr
 from statsmodels.api import OLS
 from statsmodels.stats.multitest import multipletests
@@ -17,6 +18,11 @@ from statsmodels.stats.stattools import durbin_watson
 from flameox.catalog import Catalog, Snapshot
 from flameox.domain import DomainError, ErrorCode, digest_model
 from flameox.evidence_scope import EvidenceScope, resolve_evidence_scope
+from flameox.evidence_status import (
+    EvidenceAvailability,
+    available_availability,
+    empty_availability,
+)
 from flameox.models import ContractModel
 from flameox.storage import Workspace
 
@@ -43,8 +49,11 @@ class HotspotResult(ContractModel):
     truncated: bool
     coverage: dict[str, int]
     limitations: tuple[str, ...]
-    evidence_status: Literal["available", "unavailable"] = "available"
+    evidence_status: Literal["available", "empty", "unavailable", "partial", "unknown"] = (
+        "available"
+    )
     unavailable_reason: str | None = None
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class MeasurementSummary(ContractModel):
@@ -71,6 +80,7 @@ class MemoryAnalysisResult(ContractModel):
     writable_root_observations: tuple[WritableRootObservation, ...] = ()
     policy_termination: str | None = None
     unavailable_metrics: tuple[str, ...] = ()
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class RuntimeResourceObservation(ContractModel):
@@ -134,6 +144,7 @@ class ExecutionAnalysisResult(ContractModel):
     returned: int
     truncated: bool
     limitations: tuple[str, ...]
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class ExecutionObservationChange(ContractModel):
@@ -177,6 +188,7 @@ class PyTorchAnalysisResult(ContractModel):
     warmup_time_ns: int = 0
     allocation_bytes: int | None = None
     limitations: tuple[str, ...]
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class FailureCluster(ContractModel):
@@ -220,6 +232,7 @@ class FailureAnalysisResult(ContractModel):
         "Clusters use lifecycle status and exit code; native crash signatures "
         "require a specialized extractor.",
     )
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class ScalingPoint(ContractModel):
@@ -304,6 +317,7 @@ class ScalingAnalysisResult(ContractModel):
     limitations: tuple[str, ...] = (
         "Points are per-trial medians; statistical decisions belong to frozen run-set comparisons.",
     )
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class RecipeService:
@@ -352,6 +366,10 @@ class RecipeService:
                     ),
                     evidence_status="unavailable",
                     unavailable_reason="no_profile_artifact",
+                    evidence=EvidenceAvailability(
+                        status="unavailable",
+                        reason="no_profile_artifact",
+                    ),
                 )
             count_row = snapshot.execute(
                 "SELECT count(*) FROM frame_measurements fm WHERE " + where,
@@ -404,7 +422,12 @@ class RecipeService:
                 "Complete stacks remain in native artifacts; this result is a bounded "
                 "frame aggregate.",
             ),
-            evidence_status="available",
+            evidence_status="available" if hotspots else "empty",
+            evidence=(
+                empty_availability("no_matching_hotspots")
+                if not hotspots
+                else available_availability()
+            ),
         )
 
     @staticmethod
@@ -516,6 +539,7 @@ class RecipeService:
             limitations.append(
                 "Runtime resource summary was not published for this evidence generation."
             )
+        memory_run_id = scope.run_ids[0] if len(scope.run_ids) == 1 else None
         return MemoryAnalysisResult(
             corpus_commit_id=snapshot.commit.commit_id,
             input_id=input_id,
@@ -542,6 +566,22 @@ class RecipeService:
             writable_root_observations=writable_rows,
             policy_termination=policy_termination,
             unavailable_metrics=unavailable_metrics,
+            evidence=(
+                EvidenceAvailability(
+                    status="unavailable",
+                    reason=hotspot_result.unavailable_reason or "memory_facet_unavailable",
+                    next_tool="extract_memray" if memory_run_id is not None else None,
+                    next_arguments=(
+                        {"run_id": memory_run_id} if memory_run_id is not None else None
+                    ),
+                )
+                if hotspot_result.evidence_status == "unavailable"
+                else (
+                    empty_availability("no_memory_measurements")
+                    if not rows
+                    else available_availability()
+                )
+            ),
         )
 
     def _runtime_resources(
@@ -728,6 +768,11 @@ class RecipeService:
             returned=len(observations),
             truncated=total > len(observations),
             limitations=tuple(limitations),
+            evidence=(
+                empty_availability("no_execution_observations")
+                if total == 0
+                else available_availability()
+            ),
         )
 
     def pytorch(
@@ -753,13 +798,18 @@ class RecipeService:
             assert count_row is not None
             total = int(count_row[0])
             if total == 0:
-                run_rows = snapshot.execute(
-                    "SELECT DISTINCT run_id FROM artifact_registrations WHERE artifact_id IN ("
-                    + ", ".join("?" for _ in scope.artifact_ids)
-                    + ") ORDER BY run_id",
-                    scope.artifact_ids,
-                ).fetchall()
-                run_ids = tuple(str(row[0]) for row in run_rows)
+                if scope.run_ids:
+                    run_ids = scope.run_ids
+                elif scope.artifact_ids:
+                    run_rows = snapshot.execute(
+                        "SELECT DISTINCT run_id FROM artifact_registrations WHERE artifact_id IN ("
+                        + ", ".join("?" for _ in scope.artifact_ids)
+                        + ") ORDER BY run_id",
+                        scope.artifact_ids,
+                    ).fetchall()
+                    run_ids = tuple(str(row[0]) for row in run_rows)
+                else:
+                    run_ids = ()
                 details: dict[str, object] = {"next_tool": "extract_perfetto"}
                 if len(run_ids) == 1:
                     details["run_id"] = run_ids[0]
@@ -966,6 +1016,11 @@ class RecipeService:
             warmup_time_ns=warmup_time_ns,
             allocation_bytes=allocation_bytes,
             limitations=tuple(limitations),
+            evidence=(
+                empty_availability("no_normalized_torch_operators")
+                if total == 0
+                else available_availability()
+            ),
         )
 
     def failures(
@@ -1187,6 +1242,11 @@ class RecipeService:
                 "symbolized_frames": int(coverage_row[3]) / denominator,
             },
             competing_hypotheses=tuple(hypotheses),
+            evidence=(
+                empty_availability(empty_reason or "no_failures")
+                if not failures
+                else available_availability()
+            ),
         )
 
     def scaling(
@@ -1396,6 +1456,11 @@ class RecipeService:
             conclusion=conclusion,
             environment_stable=environment_stable,
             warnings=tuple(warnings),
+            evidence=(
+                empty_availability("no_scaling_trials")
+                if not points
+                else available_availability()
+            ),
         )
 
     def _scaling_fits(

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -489,6 +489,13 @@ class RecipeService:
                 "GROUP BY phase, name ORDER BY phase_order, phase, name",
                 parameters,
             ).fetchall()
+            profile_where, profile_parameters = self._memory_profile_artifact_predicate(scope)
+            profile_row = snapshot.execute(
+                "SELECT count(*) FROM artifact_registrations ar WHERE " + profile_where,
+                profile_parameters,
+            ).fetchone()
+            assert profile_row is not None
+            has_memory_profile = int(profile_row[0]) > 0
             hotspot_result = RecipeService(
                 self.workspace,
                 snapshot=snapshot,
@@ -540,6 +547,31 @@ class RecipeService:
                 "Runtime resource summary was not published for this evidence generation."
             )
         memory_run_id = scope.run_ids[0] if len(scope.run_ids) == 1 else None
+        evidence = (
+            EvidenceAvailability(
+                status="unavailable",
+                reason=(
+                    "memory_profile_not_extracted"
+                    if has_memory_profile
+                    else "no_memory_profile_artifact"
+                ),
+                next_tool="extract_memray" if has_memory_profile and memory_run_id else None,
+                next_arguments=(
+                    {"run_id": memory_run_id} if has_memory_profile and memory_run_id else None
+                ),
+            )
+            if not rows and has_memory_profile
+            else (
+                EvidenceAvailability(
+                    status="unavailable",
+                    reason="no_memory_profile_artifact",
+                )
+                if not rows and hotspot_result.evidence_status == "unavailable"
+                else empty_availability("no_memory_measurements")
+                if not rows
+                else available_availability()
+            )
+        )
         return MemoryAnalysisResult(
             corpus_commit_id=snapshot.commit.commit_id,
             input_id=input_id,
@@ -566,23 +598,24 @@ class RecipeService:
             writable_root_observations=writable_rows,
             policy_termination=policy_termination,
             unavailable_metrics=unavailable_metrics,
-            evidence=(
-                EvidenceAvailability(
-                    status="unavailable",
-                    reason=hotspot_result.unavailable_reason or "memory_facet_unavailable",
-                    next_tool="extract_memray" if memory_run_id is not None else None,
-                    next_arguments=(
-                        {"run_id": memory_run_id} if memory_run_id is not None else None
-                    ),
-                )
-                if hotspot_result.evidence_status == "unavailable"
-                else (
-                    empty_availability("no_memory_measurements")
-                    if not rows
-                    else available_availability()
-                )
-            ),
+            evidence=evidence,
         )
+
+    @staticmethod
+    def _memory_profile_artifact_predicate(scope: EvidenceScope) -> tuple[str, tuple[object, ...]]:
+        predicates: list[str] = []
+        parameters: list[object] = []
+        if scope.run_ids:
+            placeholders = ", ".join("?" for _ in scope.run_ids)
+            predicates.append(f"(ar.run_id IN ({placeholders}) AND ar.kind = 'memory_profile')")
+            parameters.extend(scope.run_ids)
+        if scope.artifact_ids:
+            placeholders = ", ".join("?" for _ in scope.artifact_ids)
+            predicates.append(
+                f"(ar.artifact_id IN ({placeholders}) AND ar.kind = 'memory_profile')"
+            )
+            parameters.extend(scope.artifact_ids)
+        return " OR ".join(predicates) or "FALSE", tuple(parameters)
 
     def _runtime_resources(
         self,
@@ -770,7 +803,7 @@ class RecipeService:
             limitations=tuple(limitations),
             evidence=(
                 empty_availability("no_execution_observations")
-                if total == 0
+                if not (total or added or removed or changed)
                 else available_availability()
             ),
         )

--- a/src/flameox/application/__init__.py
+++ b/src/flameox/application/__init__.py
@@ -96,6 +96,7 @@ from flameox.application.integrity import (
     IntegrityService,
 )
 from flameox.application.operations import (
+    OperationFailure,
     OperationItemOutcome,
     OperationProgress,
     OperationRecord,
@@ -276,6 +277,7 @@ __all__ = [
     "NativeViewerLaunchResult",
     "NativeViewerPlan",
     "NativeViewerService",
+    "OperationFailure",
     "OperationItemOutcome",
     "OperationProgress",
     "OperationRecord",

--- a/src/flameox/application/__init__.py
+++ b/src/flameox/application/__init__.py
@@ -14,6 +14,7 @@ from flameox.application.capabilities import (
     AdapterPreparationResult,
     CapabilityList,
     CapabilityService,
+    CapabilitySetupManager,
     CapabilitySetupResult,
     SetupVerification,
 )
@@ -65,6 +66,7 @@ from flameox.application.evidence_query import (
     MeasurementItem,
     MeasurementQueryResult,
 )
+from flameox.application.evidence_status import EvidenceAvailability, EvidenceStatus
 from flameox.application.execution_identity import ExecutionIdentityService
 from flameox.application.execution_policy import ExecutionPolicy
 from flameox.application.experiments import (
@@ -92,6 +94,15 @@ from flameox.application.integrity import (
     IntegrityIssue,
     IntegrityResult,
     IntegrityService,
+)
+from flameox.application.operations import (
+    OperationItemOutcome,
+    OperationProgress,
+    OperationRecord,
+    OperationRecovery,
+    OperationRunner,
+    OperationState,
+    OperationStatus,
 )
 from flameox.application.pipelines import (
     ArtifactPipeline,
@@ -195,6 +206,7 @@ __all__ = [
     "CallEdgeResult",
     "CapabilityList",
     "CapabilityService",
+    "CapabilitySetupManager",
     "CapabilitySetupResult",
     "CapturePlanRegistry",
     "CaptureResult",
@@ -217,10 +229,12 @@ __all__ = [
     "DetachedProgress",
     "DiscoveryCoverage",
     "DrilldownService",
+    "EvidenceAvailability",
     "EvidenceInput",
     "EvidenceLookupResult",
     "EvidenceLookupService",
     "EvidenceQueryService",
+    "EvidenceStatus",
     "EvidenceSummary",
     "EvidenceSummaryBundle",
     "EvidenceSummaryRequest",
@@ -262,6 +276,13 @@ __all__ = [
     "NativeViewerLaunchResult",
     "NativeViewerPlan",
     "NativeViewerService",
+    "OperationItemOutcome",
+    "OperationProgress",
+    "OperationRecord",
+    "OperationRecovery",
+    "OperationRunner",
+    "OperationState",
+    "OperationStatus",
     "OutcomeCount",
     "OutcomeExperimentResult",
     "PipelineComparison",

--- a/src/flameox/application/artifacts.py
+++ b/src/flameox/application/artifacts.py
@@ -25,7 +25,7 @@ class ArtifactRegistrationSummary(ContractModel):
 class ArtifactMetadataResult(ContractModel):
     schema_version: int = 1
     content: ArtifactContent
-    local_handle: str
+    resource_uri: str
     registrations: tuple[ArtifactRegistrationSummary, ...]
     total_registrations: int
     effective_sensitivity: Sensitivity
@@ -91,7 +91,7 @@ class ArtifactService:
         )
         return ArtifactMetadataResult(
             content=stored.content,
-            local_handle=str(stored.payload_path),
+            resource_uri=f"flameox://artifacts/{artifact_id}",
             registrations=registrations,
             total_registrations=int(count_row[0]),
             effective_sensitivity=max(

--- a/src/flameox/application/capabilities.py
+++ b/src/flameox/application/capabilities.py
@@ -686,7 +686,7 @@ class CapabilityService:
                         "A workspace is required to stage the managed Trace Processor.",
                         details={"next_tool": "initialize_workspace"},
                     )
-                install_trace_processor(self.workspace)
+                install_trace_processor(self.workspace, cancel_event=cancel_event)
                 self._check_cancelled(cancel_event)
         except DomainError as exc:
             self._record_setup_receipt(

--- a/src/flameox/application/capabilities.py
+++ b/src/flameox/application/capabilities.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
@@ -97,6 +98,8 @@ _CONTAINMENT_VERSION_ARGS = {
     "containment.systemd": ("--version",),
 }
 
+_CAPABILITY_INSTALL_TIMEOUT_SECONDS = 1_800
+
 
 class CapabilityService:
     """Passive discovery plus explicit, brokered, process-lifetime active probes."""
@@ -110,6 +113,9 @@ class CapabilityService:
     ) -> None:
         self.workspace = workspace
         self.broker = broker or SubprocessBroker()
+        self._uses_default_workspace_manifest = (
+            capability_manifest is None and workspace is not None
+        )
         self.capability_manifest = capability_manifest or (
             workspace.paths.records / "capabilities.json"
             if workspace is not None
@@ -650,7 +656,7 @@ class CapabilityService:
                             capture_output=True,
                             text=True,
                             check=False,
-                            timeout=1_800,
+                            timeout=_CAPABILITY_INSTALL_TIMEOUT_SECONDS,
                             env={**os.environ, "UV_NO_PROGRESS": "1"},
                         )
                     else:
@@ -771,19 +777,36 @@ class CapabilityService:
             text=True,
             env={**os.environ, "UV_NO_PROGRESS": "1"},
         )
+        deadline = time.monotonic() + _CAPABILITY_INSTALL_TIMEOUT_SECONDS
+
+        def terminate() -> None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
         while process.poll() is None:
             if cancel_event.wait(0.1):
-                process.terminate()
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait()
+                terminate()
                 raise DomainError(
                     ErrorCode.PROCESS_CANCELLED,
                     "Capability setup was cancelled and its installer was terminated.",
                     retryable=True,
                     details={"next_tool": "start_capability_setup"},
+                )
+            if time.monotonic() >= deadline:
+                terminate()
+                raise DomainError(
+                    ErrorCode.PROCESS_TIMEOUT,
+                    "Capability setup installer exceeded its 1800 second timeout.",
+                    retryable=True,
+                    details={"next_tool": "start_capability_setup"},
+                    remediation=(
+                        "Retry capability setup after checking package-index access and the "
+                        "managed runtime.",
+                    ),
                 )
         stdout, stderr = process.communicate()
         return subprocess.CompletedProcess(
@@ -927,10 +950,31 @@ class CapabilityService:
                 }
         except (OSError, ValueError):
             pass
-        atomic_write_json(
-            self.capability_manifest,
-            {"schema_version": 1, "extras": sorted(existing | values)},
-        )
+        payload = {"schema_version": 1, "extras": sorted(existing | values)}
+        atomic_write_json(self.capability_manifest, payload)
+        if self.workspace is not None and self._uses_default_workspace_manifest:
+            runtime_manifest = (
+                Path(user_data_path("flameox", appauthor=False)) / "capabilities.json"
+            )
+            if runtime_manifest != self.capability_manifest:
+                runtime_existing: set[str] = set()
+                try:
+                    runtime_payload = json.loads(runtime_manifest.read_text())
+                    if isinstance(runtime_payload, dict) and isinstance(
+                        runtime_payload.get("extras"), list
+                    ):
+                        runtime_existing = {
+                            value
+                            for value in runtime_payload["extras"]
+                            if isinstance(value, str)
+                            and value in {"cpu", "execution", "memory", "test", "trace", "torch"}
+                        }
+                except (OSError, ValueError):
+                    pass
+                atomic_write_json(
+                    runtime_manifest,
+                    {"schema_version": 1, "extras": sorted(runtime_existing | values)},
+                )
 
     def _containment_reports(
         self,

--- a/src/flameox/application/capabilities.py
+++ b/src/flameox/application/capabilities.py
@@ -22,7 +22,7 @@ from platformdirs import user_data_path
 from flameox.adapters.builtins import BUILTIN_ADAPTERS, BuiltinAdapter, builtin_adapter
 from flameox.adapters.registry import AdapterRegistry
 from flameox.adapters.setup_runtime import install_trace_processor
-from flameox.application.operations import OperationRunner, OperationStatus
+from flameox.application.operations import OperationFailure, OperationRunner, OperationStatus
 from flameox.atomic import atomic_write_json
 from flameox.domain import (
     AdapterSetup,
@@ -1052,11 +1052,18 @@ class CapabilitySetupManager:
         cancel_event = threading.Event()
         self.runner.set_cancel_hook(operation_id, cancel_event.set)
         try:
-            result = await asyncio.to_thread(
-                self.service.prepare,
-                self._requested(operation_id),
-                cancel_event=cancel_event,
-            )
+            try:
+                result = await asyncio.to_thread(
+                    self.service.prepare,
+                    self._requested(operation_id),
+                    cancel_event=cancel_event,
+                )
+            except DomainError as error:
+                receipt = self.service._read_setup_receipt()
+                raise OperationFailure(
+                    error,
+                    completed_items=receipt.completed if receipt is not None else (),
+                ) from error
             await progress("verifying", 2, 3, "Refreshing and verifying requested capabilities.")
             await progress("completed", 3, 3, "Capability setup complete.")
             return {"setup": result.model_dump(mode="json")}

--- a/src/flameox/application/capabilities.py
+++ b/src/flameox/application/capabilities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import platform
@@ -7,7 +8,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections.abc import Sequence
+import threading
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
@@ -20,6 +22,7 @@ from platformdirs import user_data_path
 from flameox.adapters.builtins import BUILTIN_ADAPTERS, BuiltinAdapter, builtin_adapter
 from flameox.adapters.registry import AdapterRegistry
 from flameox.adapters.setup_runtime import install_trace_processor
+from flameox.application.operations import OperationRunner, OperationStatus
 from flameox.atomic import atomic_write_json
 from flameox.domain import (
     AdapterSetup,
@@ -108,7 +111,9 @@ class CapabilityService:
         self.workspace = workspace
         self.broker = broker or SubprocessBroker()
         self.capability_manifest = capability_manifest or (
-            Path(user_data_path("flameox", appauthor=False)) / "capabilities.json"
+            workspace.paths.records / "capabilities.json"
+            if workspace is not None
+            else Path(user_data_path("flameox", appauthor=False)) / "capabilities.json"
         )
         self.setup_receipt_path = self.capability_manifest.with_name("capability-setup.json")
         self._active_cache: dict[str, CapabilityReport] = {}
@@ -546,7 +551,12 @@ class CapabilityService:
             remediation=("Choose one of flameox's registered adapters.",),
         )
 
-    def prepare(self, adapters: tuple[str, ...]) -> CapabilitySetupResult:
+    def prepare(
+        self,
+        adapters: tuple[str, ...],
+        *,
+        cancel_event: threading.Event | None = None,
+    ) -> CapabilitySetupResult:
         """Install only declared FlameOx-managed providers into this runtime."""
         reports = {item.adapter: item for item in self.list().capabilities}
         requested = tuple(dict.fromkeys(adapters))
@@ -625,14 +635,26 @@ class CapabilityService:
         try:
             if pending_managed:
                 with portalocker.Lock(lock_path, mode="a", timeout=30):
-                    completed = subprocess.run(
-                        [str(uv), "pip", "install", "--python", sys.executable, *requirements],
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                        timeout=1_800,
-                        env={**os.environ, "UV_NO_PROGRESS": "1"},
-                    )
+                    self._check_cancelled(cancel_event)
+                    command = [
+                        str(uv),
+                        "pip",
+                        "install",
+                        "--python",
+                        sys.executable,
+                        *requirements,
+                    ]
+                    if cancel_event is None:
+                        completed = subprocess.run(
+                            command,
+                            capture_output=True,
+                            text=True,
+                            check=False,
+                            timeout=1_800,
+                            env={**os.environ, "UV_NO_PROGRESS": "1"},
+                        )
+                    else:
+                        completed = self._run_cancellable_install(command, cancel_event)
                 if completed.returncode != 0:
                     detail = (completed.stderr.strip() or completed.stdout.strip())[:500]
                     raise DomainError(
@@ -651,6 +673,7 @@ class CapabilityService:
                     phase=("staging_trace_processor" if pending_trace else "completed"),
                 )
             if pending_trace:
+                self._check_cancelled(cancel_event)
                 if self.workspace is None:
                     raise DomainError(
                         ErrorCode.WORKSPACE_NOT_FOUND,
@@ -658,6 +681,7 @@ class CapabilityService:
                         details={"next_tool": "initialize_workspace"},
                     )
                 install_trace_processor(self.workspace)
+                self._check_cancelled(cancel_event)
         except DomainError as exc:
             self._record_setup_receipt(
                 requested,
@@ -721,6 +745,52 @@ class CapabilityService:
             installed=pending,
             already_available=already_available,
             setup_verification=self._verification(requested, refreshed),
+        )
+
+    @staticmethod
+    def _check_cancelled(cancel_event: threading.Event | None) -> None:
+        if cancel_event is not None and cancel_event.is_set():
+            raise DomainError(
+                ErrorCode.PROCESS_CANCELLED,
+                "Capability setup was cancelled before the next side effect.",
+                retryable=True,
+                details={"next_tool": "start_capability_setup"},
+                remediation=("Retry the exact capability setup request when ready.",),
+            )
+
+    @classmethod
+    def _run_cancellable_install(
+        cls,
+        command: Sequence[str],
+        cancel_event: threading.Event,
+    ) -> subprocess.CompletedProcess[str]:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**os.environ, "UV_NO_PROGRESS": "1"},
+        )
+        while process.poll() is None:
+            if cancel_event.wait(0.1):
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait()
+                raise DomainError(
+                    ErrorCode.PROCESS_CANCELLED,
+                    "Capability setup was cancelled and its installer was terminated.",
+                    retryable=True,
+                    details={"next_tool": "start_capability_setup"},
+                )
+        stdout, stderr = process.communicate()
+        return subprocess.CompletedProcess(
+            command,
+            process.returncode,
+            stdout,
+            stderr,
         )
 
     def prepare_adapter(self, adapter: str, distribution: str) -> AdapterPreparationResult:
@@ -940,3 +1010,61 @@ class CapabilityService:
         except OSError:
             return (f"{path.name}=unknown",)
         return (f"{path.name}={value}",)
+
+
+class CapabilitySetupManager:
+    """Durable MCP lifecycle for package and Trace Processor provisioning."""
+
+    def __init__(self, workspace: Workspace, service: CapabilityService) -> None:
+        self.workspace = workspace
+        self.service = service
+        self.runner = OperationRunner(workspace, "capability.setup")
+
+    async def start(
+        self,
+        adapters: tuple[str, ...],
+        idempotency_key: str,
+    ) -> OperationStatus:
+        requested = tuple(dict.fromkeys(adapters))
+        return await self.runner.start(
+            {"adapters": requested},
+            idempotency_key,
+            self._run,
+            items=requested,
+        )
+
+    async def status(self, operation_id: str) -> OperationStatus:
+        return await self.runner.status(operation_id)
+
+    async def cancel(self, operation_id: str) -> OperationStatus:
+        return await self.runner.cancel(operation_id)
+
+    async def shutdown(self) -> None:
+        await self.runner.shutdown()
+
+    async def _run(
+        self,
+        operation_id: str,
+        progress: Callable[[str, float | None, float | None, str], Awaitable[None]],
+    ) -> dict[str, object]:
+        await progress("validating_request", 0, 3, "Validating managed capability request.")
+        await progress("installing_packages", 1, 3, "Installing declared optional providers.")
+        cancel_event = threading.Event()
+        self.runner.set_cancel_hook(operation_id, cancel_event.set)
+        try:
+            result = await asyncio.to_thread(
+                self.service.prepare,
+                self._requested(operation_id),
+                cancel_event=cancel_event,
+            )
+            await progress("verifying", 2, 3, "Refreshing and verifying requested capabilities.")
+            await progress("completed", 3, 3, "Capability setup complete.")
+            return {"setup": result.model_dump(mode="json")}
+        finally:
+            self.runner.clear_cancel_hook(operation_id)
+
+    def _requested(self, operation_id: str) -> tuple[str, ...]:
+        record = self.runner.store.read(operation_id)
+        # Item identities retain the exact bounded request without exposing
+        # package-manager arguments or host paths to the protocol.
+        return tuple(item.item for item in record.item_outcomes)

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -1862,6 +1862,20 @@ class CaptureService:
             if Path(path).exists():
                 wrapped.extend(("--ro-bind", path, path))
         wrapped.extend(("--ro-bind", str(project_root), str(project_root)))
+        diagnostics = diagnostics.resolve()
+        launcher_paths = {
+            Path(argument).resolve().parent
+            for argument in argv
+            if os.path.isabs(argument)
+            and Path(argument).name.endswith("_launcher.py")
+            and Path(argument).is_file()
+            and diagnostics not in Path(argument).resolve().parents
+        }
+        for launcher_path in sorted(launcher_paths):
+            try:
+                launcher_path.relative_to(project_root)
+            except ValueError:
+                wrapped.extend(("--ro-bind", str(launcher_path), str(launcher_path)))
         for binding in writable_roots:
             wrapped.extend(("--bind", binding.storage_path, binding.target_path))
         executable = Path(argv[0])

--- a/src/flameox/application/dependencies.py
+++ b/src/flameox/application/dependencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 import sys
@@ -74,7 +75,8 @@ class WorkloadDependencyService:
             lock_path = Path(sys.executable).parent / ".flameox-workload-dependencies.lock"
             try:
                 with portalocker.Lock(lock_path, mode="a", timeout=30):
-                    completed = subprocess.run(
+                    completed = await asyncio.to_thread(
+                        subprocess.run,
                         [
                             uv,
                             "pip",

--- a/src/flameox/application/dependencies.py
+++ b/src/flameox/application/dependencies.py
@@ -75,8 +75,7 @@ class WorkloadDependencyService:
             lock_path = Path(sys.executable).parent / ".flameox-workload-dependencies.lock"
             try:
                 with portalocker.Lock(lock_path, mode="a", timeout=30):
-                    completed = await asyncio.to_thread(
-                        subprocess.run,
+                    completed = await self._run_install(
                         [
                             uv,
                             "pip",
@@ -84,12 +83,7 @@ class WorkloadDependencyService:
                             "--python",
                             sys.executable,
                             *(str(item) for item in missing),
-                        ],
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                        timeout=1_800,
-                        env={**os.environ, "UV_NO_PROGRESS": "1"},
+                        ]
                     )
             except (
                 OSError,
@@ -150,6 +144,39 @@ class WorkloadDependencyService:
             preflight=preflight,
             status=preflight.disposition,
             next_tool=next_tool,
+        )
+
+    @staticmethod
+    async def _run_install(command: list[str]) -> subprocess.CompletedProcess[str]:
+        """Run the installer as an owned subprocess that cancellation can terminate."""
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env={**os.environ, "UV_NO_PROGRESS": "1"},
+        )
+        communication = asyncio.create_task(process.communicate())
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                asyncio.shield(communication),
+                timeout=1_800,
+            )
+        except (asyncio.CancelledError, TimeoutError) as error:
+            if process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(asyncio.shield(communication), timeout=5)
+                except TimeoutError:
+                    process.kill()
+                    await asyncio.shield(communication)
+            if isinstance(error, asyncio.CancelledError):
+                raise
+            raise subprocess.TimeoutExpired(command, 1_800) from error
+        return subprocess.CompletedProcess(
+            command,
+            process.returncode if process.returncode is not None else -1,
+            stdout.decode(errors="replace"),
+            stderr.decode(errors="replace"),
         )
 
     @staticmethod

--- a/src/flameox/application/detached.py
+++ b/src/flameox/application/detached.py
@@ -85,19 +85,33 @@ class DetachedCaptureManager:
                 "idempotency_key": idempotency_key,
             }
         )
+        plan_digest = digest_model({"plan_id": plan_id})
         async with self._start_lock:
             existing_run_id = self._idempotency.get(idempotency_digest)
+            existing_record = None
+            if existing_run_id is None:
+                existing_record = next(
+                    (
+                        record
+                        for record in self.records.list()
+                        if record.idempotency_digest == idempotency_digest
+                    ),
+                    None,
+                )
+                if existing_record is not None:
+                    existing_run_id = existing_record.run_id
+
             if existing_run_id is not None:
-                record = self.records.read(existing_run_id)
-                if record.plan_digest != digest_model({"plan_id": plan_id}):
+                record = existing_record or self.records.read(existing_run_id)
+                if record.plan_digest != plan_digest:
                     raise DomainError(
                         ErrorCode.INVALID_CAPTURE_PLAN,
                         "The detached idempotency key is already bound to another plan.",
                     )
-                return self.status(existing_run_id)
+                self._idempotency[idempotency_digest] = record.run_id
+                return self.status(record.run_id)
 
             plan = await self.captures.plans.inspect(plan_id)
-            plan_digest = digest_model({"plan_id": plan_id})
             record = DetachedCaptureRecord(
                 run_id=plan.run_id,
                 idempotency_digest=idempotency_digest,

--- a/src/flameox/application/detached.py
+++ b/src/flameox/application/detached.py
@@ -32,12 +32,19 @@ class DetachedCaptureRecord(ContractModel):
     revision: Annotated[int, Field(ge=0)] = 0
     idempotency_digest: str
     plan_digest: str
+    plan_request: dict[str, object] = Field(default_factory=dict)
     state: Literal["starting", "running", "terminal", "failed_to_start"] = "starting"
     progress: Annotated[tuple[DetachedProgress, ...], Field(max_length=16)] = ()
     failure_code: str | None = None
     failure_message: str | None = None
     created_at: datetime = Field(default_factory=utc_now)
     updated_at: datetime = Field(default_factory=utc_now)
+
+
+class DetachedRecovery(ContractModel):
+    action: Literal["replan"] = "replan"
+    tool: Literal["plan_capture"] = "plan_capture"
+    arguments: dict[str, object]
 
 
 class DetachedCaptureStatus(ContractModel):
@@ -57,6 +64,7 @@ class DetachedCaptureStatus(ContractModel):
     failure_code: str | None = None
     failure_message: str | None = None
     limitations: tuple[str, ...] = ()
+    recovery: DetachedRecovery | None = None
 
 
 class DetachedCaptureManager:
@@ -116,8 +124,34 @@ class DetachedCaptureManager:
                 run_id=plan.run_id,
                 idempotency_digest=idempotency_digest,
                 plan_digest=plan_digest,
+                plan_request={
+                    "workload_name": plan.workload_name,
+                    "adapter": plan.adapter,
+                    "parameters": plan.workload_instance.parameters,
+                    "preflight_mode": "auto",
+                    "capture_mode": (
+                        "managed" if plan.execution_policy == "approved_agent" else "trusted_local"
+                    ),
+                },
             )
-            self.records.create(record)
+            with self.workspace.write_locked():
+                existing_record = next(
+                    (
+                        item
+                        for item in self.records.list()
+                        if item.idempotency_digest == idempotency_digest
+                    ),
+                    None,
+                )
+                if existing_record is not None:
+                    if existing_record.plan_digest != plan_digest:
+                        raise DomainError(
+                            ErrorCode.INVALID_CAPTURE_PLAN,
+                            "The detached idempotency key is already bound to another plan.",
+                        )
+                    self._idempotency[idempotency_digest] = existing_record.run_id
+                    return self.status(existing_record.run_id)
+                self.records.create_locked(record)
             self._idempotency[idempotency_digest] = plan.run_id
             task = asyncio.create_task(
                 self._run(plan_id, plan.run_id),
@@ -132,12 +166,26 @@ class DetachedCaptureManager:
         try:
             run = self.runs.read(run_id)
         except DomainError:
+            managed = run_id in self._tasks and not self._tasks[run_id].done()
             return DetachedCaptureStatus(
                 run_id=run_id,
-                state=record.state,
+                state="starting" if managed else "failed_to_start",
                 progress=record.progress,
                 failure_code=record.failure_code,
                 failure_message=record.failure_message,
+                limitations=(
+                    (
+                        "The server stopped before publishing a run manifest. Re-plan the "
+                        "capture and start it with a new idempotency key.",
+                    )
+                    if not managed
+                    else ()
+                ),
+                recovery=(
+                    DetachedRecovery(arguments=record.plan_request)
+                    if not managed and record.plan_request
+                    else None
+                ),
             )
         terminal = run.execution_status in {
             ExecutionStatus.SUCCEEDED,

--- a/src/flameox/application/drilldown.py
+++ b/src/flameox/application/drilldown.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 from typing import Literal
 
+from pydantic import Field
+
 from flameox.catalog import Catalog, Snapshot
 from flameox.domain import CursorCodec, DomainError, ErrorCode, digest_model
 from flameox.evidence_scope import resolve_evidence_scope
+from flameox.evidence_status import (
+    EvidenceAvailability,
+    available_availability,
+    empty_availability,
+)
 from flameox.models import ContractModel
 from flameox.storage import Workspace
 
@@ -34,6 +41,7 @@ class CallEdgeResult(ContractModel):
     limitations: tuple[str, ...] = (
         "Edges represent syntactic nesting in the captured trace, not causal dependence.",
     )
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class StackExample(ContractModel):
@@ -58,6 +66,7 @@ class StackExamplesResult(ContractModel):
     limitations: tuple[str, ...] = (
         "Examples are representative leaf stacks retained during extraction.",
     )
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class DrilldownService:
@@ -192,7 +201,12 @@ class DrilldownService:
             total=total,
             returned=len(examples),
             truncated=has_more,
-            coverage=(len(examples) / total if total else 1.0),
+            coverage=(len(examples) / total if total else 0.0),
+            evidence=(
+                empty_availability("no_matching_stacks")
+                if not examples
+                else EvidenceAvailability(status="available", reason="stacks_present")
+            ),
             next_cursor=next_cursor,
         )
 
@@ -312,7 +326,12 @@ class DrilldownService:
             total=total,
             returned=len(frames),
             truncated=has_more,
-            coverage=(len(frames) / total if total else 1.0),
+            coverage=(len(frames) / total if total else 0.0),
+            evidence=(
+                empty_availability("no_matching_edges")
+                if not frames
+                else EvidenceAvailability(status="available", reason="edges_present")
+            ),
             next_cursor=next_cursor,
         )
 

--- a/src/flameox/application/evidence_query.py
+++ b/src/flameox/application/evidence_query.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from pydantic import Field
+
 from flameox.catalog import Catalog
 from flameox.domain import CursorCodec, DomainError, ErrorCode, digest_model
+from flameox.evidence_status import EvidenceAvailability, available_availability, empty_availability
 from flameox.models import ContractModel
 from flameox.storage import Workspace
 
@@ -36,6 +39,7 @@ class MeasurementQueryResult(ContractModel):
     returned: int
     truncated: bool
     next_cursor: str | None
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
 class EvidenceQueryService:
@@ -87,12 +91,14 @@ class EvidenceQueryService:
         if artifact_id is not None:
             predicates.append("artifact_id = ?")
             parameters.append(artifact_id)
+        if not include_warmups:
+            predicates.append("is_warmup = false")
+        population_where = " AND ".join(predicates)
+        population_parameters = tuple(parameters)
         if name_prefix is not None:
             predicates.append("name LIKE ? ESCAPE '^'")
             escaped = name_prefix.replace("^", "^^").replace("%", "^%").replace("_", "^_")
             parameters.append(f"{escaped}%")
-        if not include_warmups:
-            predicates.append("is_warmup = false")
         where = " AND ".join(predicates)
         with Catalog(self.workspace).open_snapshot(head.commit_id) as snapshot:
             count_row = snapshot.execute(
@@ -100,6 +106,11 @@ class EvidenceQueryService:
                 tuple(parameters),
             ).fetchone()
             assert count_row is not None
+            population_count_row = snapshot.execute(
+                "SELECT count(*) FROM measurements WHERE " + population_where,
+                population_parameters,
+            ).fetchone()
+            assert population_count_row is not None
             page_where = where
             page_parameters = list(parameters)
             if after is not None:
@@ -156,4 +167,16 @@ class EvidenceQueryService:
             returned=len(measurements),
             truncated=has_more,
             next_cursor=next_cursor,
+            evidence=(
+                EvidenceAvailability(
+                    status="unavailable",
+                    reason="measurements_not_published",
+                )
+                if not measurements and int(population_count_row[0]) == 0
+                else (
+                    empty_availability("no_matching_measurements")
+                    if not measurements
+                    else EvidenceAvailability(status="available", reason="measurements_present")
+                )
+            ),
         )

--- a/src/flameox/application/evidence_query.py
+++ b/src/flameox/application/evidence_query.py
@@ -91,10 +91,10 @@ class EvidenceQueryService:
         if artifact_id is not None:
             predicates.append("artifact_id = ?")
             parameters.append(artifact_id)
+        published_where = " AND ".join(predicates)
+        published_parameters = tuple(parameters)
         if not include_warmups:
             predicates.append("is_warmup = false")
-        population_where = " AND ".join(predicates)
-        population_parameters = tuple(parameters)
         if name_prefix is not None:
             predicates.append("name LIKE ? ESCAPE '^'")
             escaped = name_prefix.replace("^", "^^").replace("%", "^%").replace("_", "^_")
@@ -106,11 +106,11 @@ class EvidenceQueryService:
                 tuple(parameters),
             ).fetchone()
             assert count_row is not None
-            population_count_row = snapshot.execute(
-                "SELECT count(*) FROM measurements WHERE " + population_where,
-                population_parameters,
+            published_count_row = snapshot.execute(
+                "SELECT count(*) FROM measurements WHERE " + published_where,
+                published_parameters,
             ).fetchone()
-            assert population_count_row is not None
+            assert published_count_row is not None
             page_where = where
             page_parameters = list(parameters)
             if after is not None:
@@ -172,7 +172,7 @@ class EvidenceQueryService:
                     status="unavailable",
                     reason="measurements_not_published",
                 )
-                if not measurements and int(population_count_row[0]) == 0
+                if not measurements and int(published_count_row[0]) == 0
                 else (
                     empty_availability("no_matching_measurements")
                     if not measurements

--- a/src/flameox/application/evidence_status.py
+++ b/src/flameox/application/evidence_status.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from flameox.evidence_status import (
+    EvidenceAvailability,
+    EvidenceStatus,
+    available_availability,
+    empty_availability,
+)
+
+__all__ = [
+    "EvidenceAvailability",
+    "EvidenceStatus",
+    "available_availability",
+    "empty_availability",
+]

--- a/src/flameox/application/operations.py
+++ b/src/flameox/application/operations.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Literal
+from uuid import uuid4
 
 from pydantic import Field
 
@@ -80,6 +81,8 @@ class OperationRecord(ContractModel):
     cleanup_status: Literal["not_required", "pending", "complete", "incomplete"] = "not_required"
     terminal_receipt: dict[str, Any] | None = None
     recovery: OperationRecovery | None = None
+    owner_id: str | None = None
+    owner_heartbeat_at: datetime | None = None
     created_at: datetime = Field(default_factory=utc_now)
     updated_at: datetime = Field(default_factory=utc_now)
 
@@ -108,7 +111,7 @@ class OperationStatus(ContractModel):
 
     @classmethod
     def from_record(cls, record: OperationRecord) -> OperationStatus:
-        return cls(**record.model_dump())
+        return cls.model_validate(record.model_dump(exclude={"owner_id", "owner_heartbeat_at"}))
 
 
 class OperationStore:
@@ -155,6 +158,9 @@ def operation_digests(
 class OperationRunner:
     """Small durable runner used by MCP operations with external side effects."""
 
+    _LEASE_TIMEOUT = timedelta(seconds=30)
+    _LEASE_HEARTBEAT_INTERVAL = 5.0
+
     def __init__(self, workspace: Workspace, operation: str) -> None:
         self.workspace = workspace
         self.operation = operation
@@ -162,6 +168,9 @@ class OperationRunner:
         self.tasks: dict[str, asyncio.Task[None]] = {}
         self.cancel_events: dict[str, asyncio.Event] = {}
         self.cancel_hooks: dict[str, Callable[[], None]] = {}
+        self.lease_tasks: dict[str, asyncio.Task[None]] = {}
+        self.owner_id = uuid4().hex
+        self.record_lock = asyncio.Lock()
         self.lock = asyncio.Lock()
 
     async def start(
@@ -193,7 +202,7 @@ class OperationRunner:
                 if (
                     existing.state in {"starting", "running"}
                     and existing.operation_id not in self.tasks
-                    and not existing.operation_id.startswith("op-")
+                    and not self._lease_is_active(existing)
                 ):
                     existing = self._mark_unmanaged(existing)
                     self.store.records.append(existing, expected_revision=existing.revision - 1)
@@ -202,7 +211,7 @@ class OperationRunner:
             # The digest-derived identity makes the create itself the cross-process
             # idempotency gate. A process-local asyncio lock cannot protect two MCP
             # server instances sharing one workspace.
-            operation_id = f"op-{idempotency_digest}"
+            operation_id = f"op-{idempotency_digest.removeprefix('sha256:')}"
             record = OperationRecord(
                 operation_id=operation_id,
                 operation=self.operation,
@@ -210,6 +219,8 @@ class OperationRunner:
                 request_digest=request_digest,
                 request=request,
                 idempotency_digest=idempotency_digest,
+                owner_id=self.owner_id,
+                owner_heartbeat_at=utc_now(),
                 item_outcomes=tuple(
                     OperationItemOutcome(item=item, status="pending") for item in items
                 ),
@@ -233,20 +244,21 @@ class OperationRunner:
                 self._execute(operation_id, run, cancel_event),
                 name=f"flameox-operation-{operation_id}",
             )
+            self.lease_tasks[operation_id] = asyncio.create_task(
+                self._heartbeat(operation_id),
+                name=f"flameox-operation-lease-{operation_id}",
+            )
         await asyncio.sleep(0)
         return OperationStatus.from_record(self.store.read(operation_id))
 
     async def status(self, operation_id: str) -> OperationStatus:
         record = self.store.read(operation_id)
-        if record.state in {"starting", "running"} and operation_id not in self.tasks:
-            record = record.model_copy(
-                update={
-                    "revision": record.revision + 1,
-                    "state": "unmanaged_after_restart",
-                    "recovery": self._retry_recovery(record),
-                    "updated_at": utc_now(),
-                }
-            )
+        if (
+            record.state in {"starting", "running"}
+            and operation_id not in self.tasks
+            and not self._lease_is_active(record)
+        ):
+            record = self._mark_unmanaged(record)
             self.store.records.append(record, expected_revision=record.revision - 1)
         return OperationStatus.from_record(record)
 
@@ -277,17 +289,19 @@ class OperationRunner:
         hook = self.cancel_hooks.get(operation_id)
         if hook is not None:
             hook()
-        current = self.store.read(operation_id)
-        updated = current.model_copy(
-            update={
-                "revision": current.revision + 1,
-                "cancellation_requested": True,
-                "phase": "cancelling",
-                "cleanup_status": "pending",
-                "updated_at": utc_now(),
-            }
-        )
-        self.store.records.append(updated, expected_revision=current.revision)
+        async with self.record_lock:
+            current = self.store.read(operation_id)
+            updated = current.model_copy(
+                update={
+                    "revision": current.revision + 1,
+                    "cancellation_requested": True,
+                    "phase": "cancelling",
+                    "cleanup_status": "pending",
+                    "owner_heartbeat_at": utc_now(),
+                    "updated_at": utc_now(),
+                }
+            )
+            self.store.records.append(updated, expected_revision=current.revision)
         task = self.tasks.get(operation_id)
         if task is not None:
             await asyncio.gather(task, return_exceptions=True)
@@ -347,6 +361,7 @@ class OperationRunner:
                 phase="cancelled",
                 cleanup_status="complete",
                 item_outcomes=self._items(operation_id, "pending"),
+                recovery=self._retry_recovery(self.store.read(operation_id)),
             )
         except OperationFailure as failure:
             await self._finish_domain_failure(
@@ -359,6 +374,11 @@ class OperationRunner:
             await self._finish_domain_failure(operation_id, cancel_event, error)
         except Exception as error:
             await self._finish_unexpected_failure(operation_id, error)
+        finally:
+            lease_task = self.lease_tasks.pop(operation_id, None)
+            if lease_task is not None:
+                lease_task.cancel()
+                await asyncio.gather(lease_task, return_exceptions=True)
 
     async def _finish_domain_failure(
         self,
@@ -377,6 +397,7 @@ class OperationRunner:
                 failure_code=error.code.value,
                 failure_message=error.message,
                 item_outcomes=self._items(operation_id, "pending", completed_items),
+                recovery=self._retry_recovery(self.store.read(operation_id)),
             )
         else:
             await self._update(
@@ -411,7 +432,22 @@ class OperationRunner:
             failure_code=ErrorCode.INTERNAL_ERROR.value,
             failure_message=f"Operation failed with {type(error).__name__}.",
             item_outcomes=self._items(operation_id, "failed"),
+            recovery=self._retry_recovery(self.store.read(operation_id)),
         )
+
+    async def _heartbeat(self, operation_id: str) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._LEASE_HEARTBEAT_INTERVAL)
+                current = self.store.read(operation_id)
+                if (
+                    current.state not in {"starting", "running"}
+                    or current.owner_id != self.owner_id
+                ):
+                    return
+                await self._update(operation_id, owner_heartbeat_at=utc_now())
+        except asyncio.CancelledError:
+            return
 
     async def _progress(
         self,
@@ -421,44 +457,57 @@ class OperationRunner:
         total: float | None,
         message: str,
     ) -> None:
-        current = self.store.read(operation_id)
-        if current.progress:
-            previous = current.progress[-1]
-            if (
-                completed is not None
-                and previous.completed is not None
-                and completed < previous.completed
-            ):
-                raise DomainError(
-                    ErrorCode.REVISION_CONFLICT,
-                    "Operation progress must be monotonic.",
-                )
         event = OperationProgress(
             phase=phase,
             completed=completed,
             total=total,
             message=message,
         )
-        self.store.records.append(
-            current.model_copy(
-                update={
-                    "revision": current.revision + 1,
-                    "phase": phase,
-                    "progress": (*current.progress[-31:], event),
-                    "updated_at": utc_now(),
-                }
-            ),
-            expected_revision=current.revision,
-        )
+        async with self.record_lock:
+            current = self.store.read(operation_id)
+            if current.progress:
+                previous = current.progress[-1]
+                if (
+                    completed is not None
+                    and previous.completed is not None
+                    and completed < previous.completed
+                ):
+                    raise DomainError(
+                        ErrorCode.REVISION_CONFLICT,
+                        "Operation progress must be monotonic.",
+                    )
+            self.store.records.append(
+                current.model_copy(
+                    update={
+                        "revision": current.revision + 1,
+                        "phase": phase,
+                        "progress": (*current.progress[-31:], event),
+                        "owner_heartbeat_at": (
+                            utc_now()
+                            if current.owner_id == self.owner_id
+                            else current.owner_heartbeat_at
+                        ),
+                        "updated_at": utc_now(),
+                    }
+                ),
+                expected_revision=current.revision,
+            )
 
     async def _update(self, operation_id: str, **updates: Any) -> None:
-        current = self.store.read(operation_id)
-        self.store.records.append(
-            current.model_copy(
-                update={"revision": current.revision + 1, "updated_at": utc_now(), **updates}
-            ),
-            expected_revision=current.revision,
-        )
+        async with self.record_lock:
+            current = self.store.read(operation_id)
+            state = updates.get("state", current.state)
+            if state in {"starting", "running"} and current.owner_id == self.owner_id:
+                updates.setdefault("owner_heartbeat_at", utc_now())
+            elif state not in {"starting", "running"}:
+                updates.setdefault("owner_id", None)
+                updates.setdefault("owner_heartbeat_at", None)
+            self.store.records.append(
+                current.model_copy(
+                    update={"revision": current.revision + 1, "updated_at": utc_now(), **updates}
+                ),
+                expected_revision=current.revision,
+            )
 
     def _items(
         self,
@@ -479,6 +528,8 @@ class OperationRunner:
                 "revision": record.revision + 1,
                 "state": "unmanaged_after_restart",
                 "recovery": self._retry_recovery(record),
+                "owner_id": None,
+                "owner_heartbeat_at": None,
                 "updated_at": utc_now(),
             }
         )
@@ -492,4 +543,12 @@ class OperationRunner:
                 **record.request,
                 "idempotency_key": f"{record.operation_id}:retry:{record.revision + 1}",
             },
+        )
+
+    def _lease_is_active(self, record: OperationRecord) -> bool:
+        heartbeat = record.owner_heartbeat_at
+        return (
+            record.owner_id is not None
+            and heartbeat is not None
+            and utc_now() - heartbeat < self._LEASE_TIMEOUT
         )

--- a/src/flameox/application/operations.py
+++ b/src/flameox/application/operations.py
@@ -68,9 +68,7 @@ class OperationRecord(ContractModel):
     failure_code: str | None = None
     failure_message: str | None = None
     cancellation_requested: bool = False
-    cleanup_status: Literal["not_required", "pending", "complete", "incomplete"] = (
-        "not_required"
-    )
+    cleanup_status: Literal["not_required", "pending", "complete", "incomplete"] = "not_required"
     terminal_receipt: dict[str, Any] | None = None
     recovery: OperationRecovery | None = None
     created_at: datetime = Field(default_factory=utc_now)

--- a/src/flameox/application/operations.py
+++ b/src/flameox/application/operations.py
@@ -4,7 +4,6 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Any, Literal
-from uuid import uuid4
 
 from pydantic import Field
 
@@ -41,6 +40,7 @@ class OperationRecovery(ContractModel):
     action: Literal[
         "poll",
         "retry_same_request",
+        "retry_new_operation",
         "retry_failed_items",
         "inspect_capabilities",
         "extract_required_evidence",
@@ -48,6 +48,15 @@ class OperationRecovery(ContractModel):
     ]
     tool: str
     arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class OperationFailure(Exception):
+    """A domain failure with item-level completion known to the operation."""
+
+    def __init__(self, error: DomainError, *, completed_items: tuple[str, ...] = ()) -> None:
+        super().__init__(error.message)
+        self.error = error
+        self.completed_items = completed_items
 
 
 class OperationRecord(ContractModel):
@@ -184,21 +193,16 @@ class OperationRunner:
                 if (
                     existing.state in {"starting", "running"}
                     and existing.operation_id not in self.tasks
+                    and not existing.operation_id.startswith("op-")
                 ):
-                    existing = existing.model_copy(
-                        update={
-                            "state": "unmanaged_after_restart",
-                            "recovery": OperationRecovery(
-                                action="retry_same_request",
-                                tool=f"start_{self.operation.replace('.', '_')}",
-                                arguments=request,
-                            ),
-                        }
-                    )
-                    self.store.records.append(existing, expected_revision=existing.revision)
+                    existing = self._mark_unmanaged(existing)
+                    self.store.records.append(existing, expected_revision=existing.revision - 1)
                 return OperationStatus.from_record(existing)
 
-            operation_id = f"op-{uuid4().hex}"
+            # The digest-derived identity makes the create itself the cross-process
+            # idempotency gate. A process-local asyncio lock cannot protect two MCP
+            # server instances sharing one workspace.
+            operation_id = f"op-{idempotency_digest}"
             record = OperationRecord(
                 operation_id=operation_id,
                 operation=self.operation,
@@ -210,7 +214,19 @@ class OperationRunner:
                     OperationItemOutcome(item=item, status="pending") for item in items
                 ),
             )
-            self.store.records.create(record)
+            try:
+                self.store.records.create(record)
+            except DomainError as error:
+                if error.code is not ErrorCode.REVISION_CONFLICT:
+                    raise
+                existing = self.store.read(operation_id)
+                if existing.request_digest != request_digest:
+                    raise DomainError(
+                        ErrorCode.REVISION_CONFLICT,
+                        "The idempotency key is already bound to a different request.",
+                        details={"operation_id": existing.operation_id},
+                    ) from error
+                return OperationStatus.from_record(existing)
             cancel_event = asyncio.Event()
             self.cancel_events[operation_id] = cancel_event
             self.tasks[operation_id] = asyncio.create_task(
@@ -227,11 +243,7 @@ class OperationRunner:
                 update={
                     "revision": record.revision + 1,
                     "state": "unmanaged_after_restart",
-                    "recovery": OperationRecovery(
-                        action="retry_same_request",
-                        tool=f"start_{self.operation.replace('.', '_')}",
-                        arguments=record.request,
-                    ),
+                    "recovery": self._retry_recovery(record),
                     "updated_at": utc_now(),
                 }
             )
@@ -317,11 +329,7 @@ class OperationRunner:
                     cleanup_status="complete",
                     terminal_receipt=receipt,
                     item_outcomes=self._items(operation_id, "pending"),
-                    recovery=OperationRecovery(
-                        action="retry_same_request",
-                        tool=f"start_{self.operation.replace('.', '_')}",
-                        arguments=self.store.read(operation_id).request,
-                    ),
+                    recovery=self._retry_recovery(self.store.read(operation_id)),
                 )
             else:
                 await self._update(
@@ -340,45 +348,70 @@ class OperationRunner:
                 cleanup_status="complete",
                 item_outcomes=self._items(operation_id, "pending"),
             )
+        except OperationFailure as failure:
+            await self._finish_domain_failure(
+                operation_id,
+                cancel_event,
+                failure.error,
+                completed_items=failure.completed_items,
+            )
         except DomainError as error:
-            if cancel_event.is_set() or error.code is ErrorCode.PROCESS_CANCELLED:
-                await self._update(
-                    operation_id,
-                    state="cancelled",
-                    phase="cancelled",
-                    cleanup_status="complete",
-                    failure_code=error.code.value,
-                    failure_message=error.message,
-                    item_outcomes=self._items(operation_id, "pending"),
-                )
-            else:
-                await self._update(
-                    operation_id,
-                    state="failed",
-                    phase="failed",
-                    cleanup_status="complete",
-                    failure_code=error.code.value,
-                    failure_message=error.message,
-                    item_outcomes=self._items(
-                        operation_id,
-                        "retryable" if error.retryable else "failed",
-                    ),
-                    recovery=OperationRecovery(
-                        action="retry_same_request" if error.retryable else "inspect_capabilities",
-                        tool=f"start_{self.operation.replace('.', '_')}",
-                        arguments=self.store.read(operation_id).request,
-                    ),
-                )
+            await self._finish_domain_failure(operation_id, cancel_event, error)
         except Exception as error:
+            await self._finish_unexpected_failure(operation_id, error)
+
+    async def _finish_domain_failure(
+        self,
+        operation_id: str,
+        cancel_event: asyncio.Event,
+        error: DomainError,
+        *,
+        completed_items: tuple[str, ...] = (),
+    ) -> None:
+        if cancel_event.is_set() or error.code is ErrorCode.PROCESS_CANCELLED:
+            await self._update(
+                operation_id,
+                state="cancelled",
+                phase="cancelled",
+                cleanup_status="complete",
+                failure_code=error.code.value,
+                failure_message=error.message,
+                item_outcomes=self._items(operation_id, "pending", completed_items),
+            )
+        else:
             await self._update(
                 operation_id,
                 state="failed",
                 phase="failed",
                 cleanup_status="complete",
-                failure_code=ErrorCode.INTERNAL_ERROR.value,
-                failure_message=f"Operation failed with {type(error).__name__}.",
-                item_outcomes=self._items(operation_id, "failed"),
+                failure_code=error.code.value,
+                failure_message=error.message,
+                item_outcomes=self._items(
+                    operation_id,
+                    "retryable" if error.retryable else "failed",
+                    completed_items,
+                ),
+                recovery=(
+                    self._retry_recovery(self.store.read(operation_id))
+                    if error.retryable
+                    else OperationRecovery(
+                        action="inspect_capabilities",
+                        tool=f"start_{self.operation.replace('.', '_')}",
+                        arguments=self.store.read(operation_id).request,
+                    )
+                ),
             )
+
+    async def _finish_unexpected_failure(self, operation_id: str, error: Exception) -> None:
+        await self._update(
+            operation_id,
+            state="failed",
+            phase="failed",
+            cleanup_status="complete",
+            failure_code=ErrorCode.INTERNAL_ERROR.value,
+            failure_message=f"Operation failed with {type(error).__name__}.",
+            item_outcomes=self._items(operation_id, "failed"),
+        )
 
     async def _progress(
         self,
@@ -431,6 +464,32 @@ class OperationRunner:
         self,
         operation_id: str,
         status: Literal["pending", "running", "complete", "retryable", "unavailable", "failed"],
+        completed_items: tuple[str, ...] = (),
     ) -> tuple[OperationItemOutcome, ...]:
         current = self.store.read(operation_id)
-        return tuple(item.model_copy(update={"status": status}) for item in current.item_outcomes)
+        completed = set(completed_items)
+        return tuple(
+            item.model_copy(update={"status": "complete" if item.item in completed else status})
+            for item in current.item_outcomes
+        )
+
+    def _mark_unmanaged(self, record: OperationRecord) -> OperationRecord:
+        updated = record.model_copy(
+            update={
+                "revision": record.revision + 1,
+                "state": "unmanaged_after_restart",
+                "recovery": self._retry_recovery(record),
+                "updated_at": utc_now(),
+            }
+        )
+        return updated
+
+    def _retry_recovery(self, record: OperationRecord) -> OperationRecovery:
+        return OperationRecovery(
+            action="retry_new_operation",
+            tool=f"start_{self.operation.replace('.', '_')}",
+            arguments={
+                **record.request,
+                "idempotency_key": f"{record.operation_id}:retry:{record.revision + 1}",
+            },
+        )

--- a/src/flameox/application/operations.py
+++ b/src/flameox/application/operations.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import Field
+
+from flameox.domain import DomainError, ErrorCode, digest_model
+from flameox.domain.models import utc_now
+from flameox.models import ContractModel
+from flameox.storage import JsonRecordStore, Workspace
+
+OperationState = Literal[
+    "starting",
+    "running",
+    "terminal",
+    "failed",
+    "cancelled",
+    "unmanaged_after_restart",
+]
+
+
+class OperationProgress(ContractModel):
+    phase: str = Field(min_length=1, max_length=100)
+    completed: float | None = Field(default=None, ge=0)
+    total: float | None = Field(default=None, gt=0)
+    message: str = Field(min_length=1, max_length=500)
+    observed_at: datetime = Field(default_factory=utc_now)
+
+
+class OperationItemOutcome(ContractModel):
+    item: str = Field(min_length=1, max_length=200)
+    status: Literal["pending", "running", "complete", "retryable", "unavailable", "failed"]
+    message: str | None = Field(default=None, max_length=500)
+
+
+class OperationRecovery(ContractModel):
+    action: Literal[
+        "poll",
+        "retry_same_request",
+        "retry_failed_items",
+        "inspect_capabilities",
+        "extract_required_evidence",
+        "reread_snapshot",
+    ]
+    tool: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class OperationRecord(ContractModel):
+    """Durable state for local work that may outlive one MCP request."""
+
+    schema_version: Literal[1] = 1
+    operation_id: str
+    operation: str
+    workspace_id: str
+    request_digest: str
+    request: dict[str, Any]
+    idempotency_digest: str
+    state: OperationState = "starting"
+    phase: str = "starting"
+    revision: int = 0
+    progress: tuple[OperationProgress, ...] = Field(default=(), max_length=32)
+    item_outcomes: tuple[OperationItemOutcome, ...] = Field(default=(), max_length=64)
+    failure_code: str | None = None
+    failure_message: str | None = None
+    cancellation_requested: bool = False
+    cleanup_status: Literal["not_required", "pending", "complete", "incomplete"] = (
+        "not_required"
+    )
+    terminal_receipt: dict[str, Any] | None = None
+    recovery: OperationRecovery | None = None
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+
+class OperationStatus(ContractModel):
+    schema_version: Literal[1] = 1
+    operation_id: str
+    operation: str
+    workspace_id: str
+    request_digest: str
+    request: dict[str, Any]
+    idempotency_digest: str
+    revision: int
+    state: OperationState
+    phase: str
+    progress: tuple[OperationProgress, ...]
+    item_outcomes: tuple[OperationItemOutcome, ...]
+    cancellation_requested: bool
+    cleanup_status: Literal["not_required", "pending", "complete", "incomplete"]
+    failure_code: str | None
+    failure_message: str | None
+    terminal_receipt: dict[str, Any] | None
+    recovery: OperationRecovery | None
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_record(cls, record: OperationRecord) -> OperationStatus:
+        return cls(**record.model_dump())
+
+
+class OperationStore:
+    def __init__(self, workspace: Workspace) -> None:
+        self.records = JsonRecordStore(
+            workspace,
+            kind="operations",
+            model=OperationRecord,
+            id_field="operation_id",
+            revision_field="revision",
+        )
+
+    def read(self, operation_id: str) -> OperationRecord:
+        return self.records.read(operation_id)
+
+    def find(self, *, operation: str, idempotency_digest: str) -> OperationRecord | None:
+        return next(
+            (
+                item
+                for item in self.records.list()
+                if item.operation == operation and item.idempotency_digest == idempotency_digest
+            ),
+            None,
+        )
+
+
+def operation_digests(
+    workspace: Workspace,
+    operation: str,
+    request: dict[str, Any],
+    idempotency_key: str,
+) -> tuple[str, str]:
+    request_digest = digest_model(request)
+    idempotency_digest = digest_model(
+        {
+            "workspace_id": workspace.identity.workspace_id,
+            "operation": operation,
+            "idempotency_key": idempotency_key,
+        }
+    )
+    return request_digest, idempotency_digest
+
+
+class OperationRunner:
+    """Small durable runner used by MCP operations with external side effects."""
+
+    def __init__(self, workspace: Workspace, operation: str) -> None:
+        self.workspace = workspace
+        self.operation = operation
+        self.store = OperationStore(workspace)
+        self.tasks: dict[str, asyncio.Task[None]] = {}
+        self.cancel_events: dict[str, asyncio.Event] = {}
+        self.cancel_hooks: dict[str, Callable[[], None]] = {}
+        self.lock = asyncio.Lock()
+
+    async def start(
+        self,
+        request: dict[str, Any],
+        idempotency_key: str,
+        run: Callable[[str, Callable[..., Awaitable[None]]], Awaitable[dict[str, Any]]],
+        *,
+        items: tuple[str, ...] = (),
+    ) -> OperationStatus:
+        request_digest, idempotency_digest = operation_digests(
+            self.workspace,
+            self.operation,
+            request,
+            idempotency_key,
+        )
+        async with self.lock:
+            existing = self.store.find(
+                operation=self.operation,
+                idempotency_digest=idempotency_digest,
+            )
+            if existing is not None:
+                if existing.request_digest != request_digest:
+                    raise DomainError(
+                        ErrorCode.REVISION_CONFLICT,
+                        "The idempotency key is already bound to a different request.",
+                        details={"operation_id": existing.operation_id},
+                    )
+                if (
+                    existing.state in {"starting", "running"}
+                    and existing.operation_id not in self.tasks
+                ):
+                    existing = existing.model_copy(
+                        update={
+                            "state": "unmanaged_after_restart",
+                            "recovery": OperationRecovery(
+                                action="retry_same_request",
+                                tool=f"start_{self.operation.replace('.', '_')}",
+                                arguments=request,
+                            ),
+                        }
+                    )
+                    self.store.records.append(existing, expected_revision=existing.revision)
+                return OperationStatus.from_record(existing)
+
+            operation_id = f"op-{uuid4().hex}"
+            record = OperationRecord(
+                operation_id=operation_id,
+                operation=self.operation,
+                workspace_id=self.workspace.identity.workspace_id,
+                request_digest=request_digest,
+                request=request,
+                idempotency_digest=idempotency_digest,
+                item_outcomes=tuple(
+                    OperationItemOutcome(item=item, status="pending") for item in items
+                ),
+            )
+            self.store.records.create(record)
+            cancel_event = asyncio.Event()
+            self.cancel_events[operation_id] = cancel_event
+            self.tasks[operation_id] = asyncio.create_task(
+                self._execute(operation_id, run, cancel_event),
+                name=f"flameox-operation-{operation_id}",
+            )
+        await asyncio.sleep(0)
+        return OperationStatus.from_record(self.store.read(operation_id))
+
+    async def status(self, operation_id: str) -> OperationStatus:
+        record = self.store.read(operation_id)
+        if record.state in {"starting", "running"} and operation_id not in self.tasks:
+            record = record.model_copy(
+                update={
+                    "revision": record.revision + 1,
+                    "state": "unmanaged_after_restart",
+                    "recovery": OperationRecovery(
+                        action="retry_same_request",
+                        tool=f"start_{self.operation.replace('.', '_')}",
+                        arguments=record.request,
+                    ),
+                    "updated_at": utc_now(),
+                }
+            )
+            self.store.records.append(record, expected_revision=record.revision - 1)
+        return OperationStatus.from_record(record)
+
+    def set_cancel_hook(self, operation_id: str, hook: Callable[[], None]) -> None:
+        self.cancel_hooks[operation_id] = hook
+        event = self.cancel_events.get(operation_id)
+        if event is not None and event.is_set():
+            hook()
+
+    def clear_cancel_hook(self, operation_id: str) -> None:
+        self.cancel_hooks.pop(operation_id, None)
+
+    async def cancel(self, operation_id: str) -> OperationStatus:
+        record = self.store.read(operation_id)
+        if record.state in {"terminal", "failed", "cancelled"}:
+            return OperationStatus.from_record(record)
+        event = self.cancel_events.get(operation_id)
+        if event is None:
+            raise DomainError(
+                ErrorCode.CAPABILITY_UNAVAILABLE,
+                "The server no longer owns this operation.",
+                details={"operation_id": operation_id},
+                remediation=(
+                    "Poll the operation status; retry the exact request only if it is unmanaged.",
+                ),
+            )
+        event.set()
+        hook = self.cancel_hooks.get(operation_id)
+        if hook is not None:
+            hook()
+        current = self.store.read(operation_id)
+        updated = current.model_copy(
+            update={
+                "revision": current.revision + 1,
+                "cancellation_requested": True,
+                "phase": "cancelling",
+                "cleanup_status": "pending",
+                "updated_at": utc_now(),
+            }
+        )
+        self.store.records.append(updated, expected_revision=current.revision)
+        task = self.tasks.get(operation_id)
+        if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
+        return OperationStatus.from_record(self.store.read(operation_id))
+
+    async def shutdown(self) -> None:
+        for event in self.cancel_events.values():
+            event.set()
+        for hook in self.cancel_hooks.values():
+            hook()
+        tasks = [task for task in self.tasks.values() if not task.done()]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _execute(
+        self,
+        operation_id: str,
+        run: Callable[[str, Callable[..., Awaitable[None]]], Awaitable[dict[str, Any]]],
+        cancel_event: asyncio.Event,
+    ) -> None:
+        try:
+            await self._update(operation_id, state="running", phase="starting")
+
+            async def progress(
+                phase: str,
+                completed: float | None = None,
+                total: float | None = None,
+                message: str = "Operation in progress.",
+            ) -> None:
+                await self._progress(operation_id, phase, completed, total, message)
+
+            receipt = await run(operation_id, progress)
+            current = self.store.read(operation_id)
+            if cancel_event.is_set() or current.cancellation_requested:
+                await self._update(
+                    operation_id,
+                    state="cancelled",
+                    phase="cancelled",
+                    cleanup_status="complete",
+                    terminal_receipt=receipt,
+                    item_outcomes=self._items(operation_id, "pending"),
+                    recovery=OperationRecovery(
+                        action="retry_same_request",
+                        tool=f"start_{self.operation.replace('.', '_')}",
+                        arguments=self.store.read(operation_id).request,
+                    ),
+                )
+            else:
+                await self._update(
+                    operation_id,
+                    state="terminal",
+                    phase="completed",
+                    cleanup_status="complete",
+                    terminal_receipt=receipt,
+                    item_outcomes=self._items(operation_id, "complete"),
+                )
+        except asyncio.CancelledError:
+            await self._update(
+                operation_id,
+                state="cancelled",
+                phase="cancelled",
+                cleanup_status="complete",
+                item_outcomes=self._items(operation_id, "pending"),
+            )
+        except DomainError as error:
+            if cancel_event.is_set() or error.code is ErrorCode.PROCESS_CANCELLED:
+                await self._update(
+                    operation_id,
+                    state="cancelled",
+                    phase="cancelled",
+                    cleanup_status="complete",
+                    failure_code=error.code.value,
+                    failure_message=error.message,
+                    item_outcomes=self._items(operation_id, "pending"),
+                )
+            else:
+                await self._update(
+                    operation_id,
+                    state="failed",
+                    phase="failed",
+                    cleanup_status="complete",
+                    failure_code=error.code.value,
+                    failure_message=error.message,
+                    item_outcomes=self._items(
+                        operation_id,
+                        "retryable" if error.retryable else "failed",
+                    ),
+                    recovery=OperationRecovery(
+                        action="retry_same_request" if error.retryable else "inspect_capabilities",
+                        tool=f"start_{self.operation.replace('.', '_')}",
+                        arguments=self.store.read(operation_id).request,
+                    ),
+                )
+        except Exception as error:
+            await self._update(
+                operation_id,
+                state="failed",
+                phase="failed",
+                cleanup_status="complete",
+                failure_code=ErrorCode.INTERNAL_ERROR.value,
+                failure_message=f"Operation failed with {type(error).__name__}.",
+                item_outcomes=self._items(operation_id, "failed"),
+            )
+
+    async def _progress(
+        self,
+        operation_id: str,
+        phase: str,
+        completed: float | None,
+        total: float | None,
+        message: str,
+    ) -> None:
+        current = self.store.read(operation_id)
+        if current.progress:
+            previous = current.progress[-1]
+            if (
+                completed is not None
+                and previous.completed is not None
+                and completed < previous.completed
+            ):
+                raise DomainError(
+                    ErrorCode.REVISION_CONFLICT,
+                    "Operation progress must be monotonic.",
+                )
+        event = OperationProgress(
+            phase=phase,
+            completed=completed,
+            total=total,
+            message=message,
+        )
+        self.store.records.append(
+            current.model_copy(
+                update={
+                    "revision": current.revision + 1,
+                    "phase": phase,
+                    "progress": (*current.progress[-31:], event),
+                    "updated_at": utc_now(),
+                }
+            ),
+            expected_revision=current.revision,
+        )
+
+    async def _update(self, operation_id: str, **updates: Any) -> None:
+        current = self.store.read(operation_id)
+        self.store.records.append(
+            current.model_copy(
+                update={"revision": current.revision + 1, "updated_at": utc_now(), **updates}
+            ),
+            expected_revision=current.revision,
+        )
+
+    def _items(
+        self,
+        operation_id: str,
+        status: Literal["pending", "running", "complete", "retryable", "unavailable", "failed"],
+    ) -> tuple[OperationItemOutcome, ...]:
+        current = self.store.read(operation_id)
+        return tuple(item.model_copy(update={"status": status}) for item in current.item_outcomes)

--- a/src/flameox/collectors/torch_launcher.py
+++ b/src/flameox/collectors/torch_launcher.py
@@ -19,6 +19,10 @@ def main() -> None:
 
     if options.module is not None:
         sys.path.insert(0, str(Path.cwd()))
+        script_path = None
+    else:
+        script_path = Path(options.script).resolve()
+        sys.path.insert(0, str(script_path.parent))
     try:
         import torch
     except ImportError as exc:
@@ -40,7 +44,8 @@ def main() -> None:
         if options.module is not None:
             runpy.run_module(options.module, run_name="__main__", alter_sys=True)
         else:
-            runpy.run_path(options.script, run_name="__main__")
+            assert script_path is not None
+            runpy.run_path(str(script_path), run_name="__main__")
     profile.export_chrome_trace(str(output))
 
 

--- a/src/flameox/collectors/torch_launcher.py
+++ b/src/flameox/collectors/torch_launcher.py
@@ -17,6 +17,8 @@ def main() -> None:
     parser.add_argument("arguments", nargs=argparse.REMAINDER)
     options = parser.parse_args()
 
+    if options.module is not None:
+        sys.path.insert(0, str(Path.cwd()))
     try:
         import torch
     except ImportError as exc:

--- a/src/flameox/evidence_status.py
+++ b/src/flameox/evidence_status.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from flameox.models import ContractModel
+
+EvidenceStatus = Literal["available", "empty", "unavailable", "partial", "unknown"]
+
+
+class EvidenceAvailability(ContractModel):
+    """Machine-readable evidence presence shared by analysis and query results."""
+
+    status: EvidenceStatus
+    reason: str = Field(min_length=1, max_length=200)
+    next_tool: str | None = None
+    next_arguments: dict[str, object] | None = None
+
+
+def available_availability() -> EvidenceAvailability:
+    return EvidenceAvailability(status="available", reason="evidence_present")
+
+
+def empty_availability(reason: str = "no_matching_evidence") -> EvidenceAvailability:
+    return EvidenceAvailability(status="empty", reason=reason)

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -59,7 +59,7 @@ from flameox.application import (
     CallEdgeResult,
     CapabilityList,
     CapabilityService,
-    CapabilitySetupResult,
+    CapabilitySetupManager,
     CapturePlanRegistry,
     CaptureService,
     CompareRunSetsRequest,
@@ -124,6 +124,7 @@ from flameox.application import (
     workspace_status,
 )
 from flameox.application.async_work import run_atomic_thread
+from flameox.application.operations import OperationStatus
 from flameox.catalog import Catalog
 from flameox.domain import (
     ArtifactKind,
@@ -199,8 +200,15 @@ class ManualConfigurationRecoveryContext(ContractModel):
     verification_tool: Literal["workload_configuration_status"] = "workload_configuration_status"
 
 
+class ExtractPerfettoRecoveryContext(ContractModel):
+    kind: Literal["extract_perfetto"]
+    run_id: str = Field(min_length=1)
+
+
 type RecoveryContext = Annotated[
-    ConfigureWorkloadRecoveryContext | ManualConfigurationRecoveryContext,
+    ConfigureWorkloadRecoveryContext
+    | ManualConfigurationRecoveryContext
+    | ExtractPerfettoRecoveryContext,
     Field(discriminator="kind"),
 ]
 
@@ -221,6 +229,7 @@ class RecoveryAction(ContractModel):
         "discover_runs",
         "discover_artifacts",
         "import_artifact",
+        "extract_perfetto",
         "manual",
     ]
     safe_to_repeat_same_call: bool
@@ -370,6 +379,7 @@ class AppContext:
     capture_plans: CapturePlanRegistry
     experiment_plans: ExperimentPlanRegistry
     detached_captures: DetachedCaptureManager | None = None
+    capability_setup: CapabilitySetupManager | None = None
 
     def require_workspace(self) -> Workspace:
         if self.workspace is None:
@@ -404,6 +414,12 @@ class AppContext:
                 self.capture_service(),
             )
         return self.detached_captures
+
+    def capability_setup_service(self) -> CapabilitySetupManager:
+        if self.capability_setup is None:
+            workspace = self.require_workspace()
+            self.capability_setup = CapabilitySetupManager(workspace, self.capabilities)
+        return self.capability_setup
 
 
 def _success[T: BaseModel](
@@ -586,6 +602,19 @@ def _recovery_for(error: DomainError) -> RecoveryAction:
             safe_to_repeat_same_call=False,
             next_tool="import_artifact",
         )
+    if error.details.get("next_tool") == "extract_perfetto":
+        run_id = error.details.get("run_id")
+        context = (
+            ExtractPerfettoRecoveryContext(kind="extract_perfetto", run_id=run_id)
+            if isinstance(run_id, str)
+            else None
+        )
+        return RecoveryAction(
+            kind="extract_perfetto",
+            safe_to_repeat_same_call=True,
+            next_tool="extract_perfetto",
+            context=context,
+        )
     if error.details.get("next_tool") == "list_capabilities":
         return RecoveryAction(
             kind="inspect_capabilities",
@@ -699,12 +728,15 @@ def create_server(
                 workspace,
                 state.capture_service(),
             )
+            state.capability_setup = CapabilitySetupManager(workspace, state.capabilities)
         lifespan_state.append(state)
         try:
             yield state
         finally:
             if state.detached_captures is not None:
                 await state.detached_captures.shutdown()
+            if state.capability_setup is not None:
+                await state.capability_setup.shutdown()
             lifespan_state.clear()
 
     server = StrictMCPServer(
@@ -715,7 +747,8 @@ def create_server(
             "Use Flameox to collect, preserve, compare, and inspect local runtime evidence "
             "when source, environment, command, and artifact provenance must be reproducible. "
             "Do not provision hosts or install undeclared packages. If list_capabilities reports "
-            "a managed setup action, call prepare_capabilities; it installs only the declared "
+            "a managed setup action, call start_capability_setup (or the compatibility "
+            "prepare_capabilities wrapper); it installs only the declared "
             "FlameOx optional providers into the active managed runtime, verifies them, and "
             "does not execute a workload. Host containment is not required for the agent path: "
             "plan_capture(capture_mode='auto') followed by execute_capture_plan runs the "
@@ -729,8 +762,9 @@ def create_server(
             "workspace_status. Initialization writes .diagnostics. Then call "
             "workload_configuration_status. If flameox.toml is missing, call configure_workload "
             "with the validated argument array; it writes the canonical project definition but "
-            "never executes it. After that, use list_declared_workflows → "
-            "get_declared_workflow → list_capabilities → prepare_capabilities (when the result "
+            "never executes it. After that, use list_declared_workflows (no arguments lists "
+            "workloads) → "
+            "get_declared_workflow → list_capabilities → start_capability_setup (when the result "
             "names setup_adapters) → prepare_adapter (for an unapproved installed third-party "
             "adapter) → prepare_workload_dependencies (when a named workload declares missing "
             "Python distributions) → list_capabilities → plan_capture(preflight_mode='auto', "
@@ -743,8 +777,10 @@ def create_server(
             "extract_python_startup for Python startup/import evidence, extract_pytest for "
             "test phases, fixtures, workers, and failure latency, analyze_memory for "
             "memory profiles, analyze_execution for coverage, and the other analyze_* tools "
-            "only for their documented artifact kinds. Then use get_evidence, record_analysis, "
-            "or record_finding. A "
+            "only for their documented artifact kinds. Imported Torch traces require "
+            "extract_perfetto before analyze_pytorch; absent normalized rows are recovery, not "
+            "an empty operator report. Then use get_evidence, record_analysis, "
+            "or record_finding. Poll get_capability_setup after setup starts. A "
             "synchronous consumed capture plan is never retryable; detached starts are "
             "retryable only with the same idempotency key."
         ),
@@ -775,6 +811,7 @@ def create_server(
             state.capture_plans = capture_plans
             state.experiment_plans = ExperimentPlanRegistry()
             state.detached_captures = detached_captures
+            state.capability_setup = CapabilitySetupManager(workspace, state.capabilities)
             result = workspace_status(workspace)
             return _success(result, f"Initialized workspace {result.workspace_id}.")
         except DomainError as error:
@@ -931,29 +968,97 @@ def create_server(
             ),
         ],
         ctx: Context[AppContext],
-    ) -> Annotated[CallToolResult, ToolPayload[CapabilitySetupResult]]:
-        """Install and verify selected FlameOx-managed optional providers.
+        idempotency_key: str | None = None,
+    ) -> Annotated[CallToolResult, ToolPayload[OperationStatus]]:
+        """Compatibility entry point for managed capability setup.
 
-        This action is limited to the explicit adapter enum, changes only the active managed
-        runtime or stages the user-space Trace Processor under .diagnostics/tools, and never
-        executes a project workload. Call list_capabilities again before planning or after a
-        cancelled request to inspect the durable setup receipt. It does not change host
-        permissions or install privileged collectors.
+        Starts durable setup and returns immediately with an operation ID. Poll
+        get_capability_setup, or use start_capability_setup for an explicit idempotency key.
+        Setup changes only the active managed runtime or stages Trace Processor; it never
+        executes a project workload or installs privileged collectors.
         """
         try:
-            service = ctx.request_context.lifespan_context.capabilities
-            await ctx.report_progress(
-                0,
-                2,
-                "Capability setup started; refresh capabilities for receipt",
+            key = idempotency_key or "compat:" + ",".join(dict.fromkeys(adapters))
+            result = await ctx.request_context.lifespan_context.capability_setup_service().start(
+                tuple(adapters),
+                key,
             )
-            result = await run_atomic_thread(lambda: service.prepare(tuple(adapters)))
-            await ctx.report_progress(1, 2, "Capability setup verified")
-            await ctx.report_progress(2, 2, "Capability setup complete")
             return _success(
                 result,
-                "Prepared requested capabilities; call list_capabilities before planning.",
+                f"Capability setup operation {result.operation_id} is {result.state}; "
+                "poll get_capability_setup before planning.",
             )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(annotations=CONFIGURE)
+    async def start_capability_setup(
+        adapters: Annotated[
+            tuple[
+                Literal["coverage", "memray", "perfetto", "py-spy", "pytest", "torch.profiler"],
+                ...,
+            ],
+            Field(
+                min_length=1,
+                max_length=5,
+                description="Managed adapters from list_capabilities to install or stage.",
+            ),
+        ],
+        idempotency_key: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Stable key for replaying this exact request.",
+            ),
+        ],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[OperationStatus]]:
+        """Start detached capability provisioning and return its durable operation ID.
+
+        Use the same idempotency key to reconnect after a lost request. Poll
+        get_capability_setup for named phases, item outcomes, and the terminal receipt;
+        cancel_capability_setup requests cleanup of owned work.
+        """
+        try:
+            result = await ctx.request_context.lifespan_context.capability_setup_service().start(
+                tuple(adapters), idempotency_key
+            )
+            return _success(
+                result,
+                f"Started capability setup {result.operation_id} ({result.state}).",
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="get_capability_setup", annotations=READ_ONLY)
+    async def get_capability_setup(
+        operation_id: Annotated[str, Field(min_length=4, max_length=100)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[OperationStatus]]:
+        """Read durable capability setup state after the original request disappears."""
+        try:
+            result = await ctx.request_context.lifespan_context.capability_setup_service().status(
+                operation_id
+            )
+            return _success(
+                result,
+                f"Capability setup {operation_id} is {result.state} ({result.phase}).",
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="cancel_capability_setup", annotations=CONFIGURE)
+    async def cancel_capability_setup(
+        operation_id: Annotated[str, Field(min_length=4, max_length=100)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[OperationStatus]]:
+        """Request cancellation and cleanup of a server-owned capability setup operation."""
+        try:
+            result = await ctx.request_context.lifespan_context.capability_setup_service().cancel(
+                operation_id
+            )
+            return _success(result, f"Capability setup {operation_id} is {result.state}.")
         except DomainError as error:
             return _failure(error)
 
@@ -1031,12 +1136,15 @@ def create_server(
 
     @server.tool(name="list_declared_workflows", annotations=READ_ONLY)
     async def list_declared_workflows_tool(
-        kind: Literal["workload", "experiment"],
         ctx: Context[AppContext],
+        kind: Literal["workload", "experiment"] = "workload",
         limit: Annotated[int, Field(ge=1, le=100)] = 50,
         cursor: str | None = None,
     ) -> Annotated[CallToolResult, ToolPayload[DeclaredWorkflowList]]:
-        """Discover current named workloads or experiments before planning; this never runs them."""
+        """Discover declared workflows before planning; this never runs them.
+
+        With no arguments, list workloads. Pass kind='experiment' to list declared experiments.
+        """
         try:
             result = WorkloadService(
                 ctx.request_context.lifespan_context.require_workspace()
@@ -1489,15 +1597,16 @@ def create_server(
         try:
             state = ctx.request_context.lifespan_context
             workspace = state.require_workspace()
-            result = ImportService(workspace).import_artifact(
-                ImportArtifactRequest(
-                    path=_safe_import_path(state.project_root, path, source_root),
-                    kind=kind,
-                    sensitivity=sensitivity,
-                    producer=None if producer == "auto" else producer,
-                    producer_version=producer_version,
-                    allow_external_path=source_root == "temp",
-                )
+            request = ImportArtifactRequest(
+                path=_safe_import_path(state.project_root, path, source_root),
+                kind=kind,
+                sensitivity=sensitivity,
+                producer=None if producer == "auto" else producer,
+                producer_version=producer_version,
+                allow_external_path=source_root == "temp",
+            )
+            result = await run_atomic_thread(
+                lambda: ImportService(workspace).import_artifact(request)
             )
             run_uri = f"flameox://runs/{result.run.run_id}"
             artifact_uri = f"flameox://artifacts/{result.artifact_id}"
@@ -1563,12 +1672,24 @@ def create_server(
         artifact_id: str,
         ctx: Context[AppContext],
     ) -> Annotated[CallToolResult, ToolPayload[ArtifactMetadataResult]]:
-        """Return bounded artifact metadata, never binary content."""
+        """Return bounded metadata and an opaque resource URI, never a host path or bytes."""
         try:
             result = ArtifactService(ctx.request_context.lifespan_context.require_workspace()).get(
                 artifact_id
             )
-            return _success(result, f"Artifact {artifact_id} is metadata-only.")
+            return _success(
+                result,
+                f"Artifact {artifact_id} is metadata-only; read {result.resource_uri} for the "
+                "canonical resource.",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Artifact {artifact_id}",
+                        uri=result.resource_uri,
+                        description="Opaque artifact metadata resource; no host path is exposed.",
+                        mime_type="application/json",
+                    ),
+                ),
+            )
         except DomainError as error:
             return _failure(error)
 
@@ -2032,7 +2153,11 @@ def create_server(
         ],
         ctx: Context[AppContext],
     ) -> Annotated[CallToolResult, ToolPayload[PyTorchAnalysisResult]]:
-        """Summarize one Perfetto-extracted torch.profiler run or artifact."""
+        """Summarize normalized Perfetto evidence from a torch.profiler run or artifact.
+
+        This read-only tool never extracts implicitly. If normalized rows are absent, follow
+        the typed recovery result and call extract_perfetto for the exact run.
+        """
         try:
             workspace = ctx.request_context.lifespan_context.require_workspace()
             await ctx.report_progress(0, 2, "PyTorch snapshot pinned")
@@ -2300,9 +2425,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[IntegrityResult]]:
         """Validate manifests and schemas; optionally hash every payload."""
         try:
-            result = IntegrityService(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).validate(full=mode == "full")
+            result = await run_atomic_thread(
+                lambda: IntegrityService(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).validate(full=mode == "full")
+            )
             outcome = "passed" if result.valid else "failed"
             issue_suffix = f" with {len(result.issues)} reported issues" if result.issues else ""
             return _success(result, f"Workspace validation {outcome}{issue_suffix}.")
@@ -2316,9 +2443,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[PyPerfExtractionResult]]:
         """Extract public pyperf run, warmup, loop, and value evidence."""
         try:
-            result = PyPerfExtractor(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            result = await run_atomic_thread(
+                lambda: PyPerfExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
             return _success(
                 result,
                 f"Extracted {result.measurement_count} measured values.",
@@ -2333,9 +2462,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[PythonStartupExtractionResult]]:
         """Extract repeated startup, peak RSS, and package-grouped import evidence."""
         try:
-            result = PythonStartupExtractor(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            result = await run_atomic_thread(
+                lambda: PythonStartupExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
             return _success(
                 result,
                 f"Extracted {result.measurement_count} startup measurements.",
@@ -2350,9 +2481,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[PytestExtractionResult]]:
         """Extract pytest phase, fixture, worker, outcome, and failure-latency evidence."""
         try:
-            result = PytestExtractor(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            result = await run_atomic_thread(
+                lambda: PytestExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
             return _success(
                 result,
                 f"Extracted {result.measurement_count} pytest measurements.",
@@ -2367,9 +2500,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[CoverageExtractionResult]]:
         """Extract bounded execution-path evidence through coverage.py's public API."""
         try:
-            result = CoverageExtractor(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            result = await run_atomic_thread(
+                lambda: CoverageExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
             return _success(
                 result,
                 f"Extracted {result.line_count} lines and {result.arc_count} arcs.",
@@ -2384,9 +2519,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[MemrayExtractionResult]]:
         """Extract supported memory concepts through Memray's public FileReader."""
         try:
-            result = MemrayExtractor(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            result = await run_atomic_thread(
+                lambda: MemrayExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
             return _success(
                 result,
                 f"Peak memory was {result.peak_memory_bytes} bytes; "
@@ -2420,9 +2557,11 @@ def create_server(
     ) -> Annotated[CallToolResult, ToolPayload[ObservationExtractionResult]]:
         """Extract bounded semantic observations emitted through flameox.sdk."""
         try:
-            result = ObservationExtractor(
-                ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            result = await run_atomic_thread(
+                lambda: ObservationExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
             return _success(
                 result,
                 f"Extracted {result.observation_count} semantic observations.",

--- a/src/flameox/storage/records.py
+++ b/src/flameox/storage/records.py
@@ -31,19 +31,29 @@ class JsonRecordStore[RecordT: BaseModel]:
         self.revision_field = revision_field
 
     def create(self, record: RecordT) -> RecordT:
-        identifier = self._identifier(record)
         with self.workspace.write_locked():
-            root = self._root(identifier)
-            if root.exists():
-                raise DomainError(
-                    ErrorCode.REVISION_CONFLICT,
-                    f"{self.kind} {identifier!r} already exists.",
-                )
-            root.mkdir(parents=True)
-            if self.revision_field is not None:
-                (root / "revisions").mkdir()
-                self._write_revision(record)
-            self._write_projection(record)
+            self.create_locked(record)
+        return record
+
+    def create_locked(self, record: RecordT) -> RecordT:
+        """Create a record while the caller owns the workspace write lock.
+
+        This is intentionally a small escape hatch for compound operations
+        that must inspect and create records in one cross-process critical
+        section. Callers must hold ``workspace.write_locked()``.
+        """
+        identifier = self._identifier(record)
+        root = self._root(identifier)
+        if root.exists():
+            raise DomainError(
+                ErrorCode.REVISION_CONFLICT,
+                f"{self.kind} {identifier!r} already exists.",
+            )
+        root.mkdir(parents=True)
+        if self.revision_field is not None:
+            (root / "revisions").mkdir()
+            self._write_revision(record)
+        self._write_projection(record)
         return record
 
     def read(self, identifier: str) -> RecordT:

--- a/tests/adapters/test_setup_runtime.py
+++ b/tests/adapters/test_setup_runtime.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from flameox.adapters import ManagedRuntime, install_trace_processor
+from flameox.application.capabilities import CapabilityService
 from flameox.storage import Workspace
 
 
@@ -91,6 +92,22 @@ async def test_runtime_install_carries_prepared_capabilities_into_new_runtime(
     await runtime.install("0.1.1")
 
     assert recorded_command[-1] == "flameox[memory,torch]==0.1.1"
+
+
+def test_workspace_capability_setup_is_visible_to_runtime_upgrades(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = Workspace.initialize(tmp_path / "workspace")
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setattr(
+        "flameox.application.capabilities.user_data_path",
+        lambda *_args, **_kwargs: runtime_root,
+    )
+
+    CapabilityService(workspace)._record_managed_extras(("torch",))
+
+    assert ManagedRuntime(runtime_root)._managed_extras() == ("torch",)
 
 
 def test_installed_version_discovery_ignores_unmanaged_directories(tmp_path: Path) -> None:

--- a/tests/application/test_capabilities.py
+++ b/tests/application/test_capabilities.py
@@ -515,7 +515,17 @@ python_distributions = ["agent-fixture>=2"]
     monkeypatch.setattr("flameox.application.dependencies.distribution", lookup)
     monkeypatch.setattr("flameox.application.preflight.distribution", lookup)
     monkeypatch.setattr("flameox.application.dependencies._uv_executable", lambda: "/usr/bin/uv")
-    monkeypatch.setattr("flameox.application.dependencies.subprocess.run", install)
+
+    async def install_async(
+        _: object,
+        command: list[str],
+    ) -> subprocess.CompletedProcess[str]:
+        return install(command)
+
+    monkeypatch.setattr(
+        "flameox.application.dependencies.WorkloadDependencyService._run_install",
+        install_async,
+    )
 
     result = await WorkloadDependencyService(Workspace(tmp_path / ".diagnostics")).prepare("probe")
 

--- a/tests/application/test_capture_integrations.py
+++ b/tests/application/test_capture_integrations.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from flameox.adapters import PyPerfExtractor
+from flameox.adapters.builtins import build_capture_invocation
 from flameox.analysis import RecipeService
 from flameox.application import (
     CaptureService,
@@ -14,6 +17,67 @@ from flameox.application import (
 )
 from flameox.domain import ArtifactKind, DomainError, ErrorCode, ExecutionStatus
 from flameox.storage import Workspace
+
+
+def test_torch_capture_launcher_does_not_require_flameox_in_workload_venv(
+    tmp_path: Path,
+) -> None:
+    invocation = build_capture_invocation(
+        "torch.profiler",
+        ("/workload/.venv/bin/python", "-m", "benchmarks.benchmark_kda_decode", "--repeats", "1"),
+        tmp_path,
+        executable=None,
+    )
+
+    assert Path(invocation.argv[1]).name == "torch_launcher.py"
+    assert invocation.argv[2:] == (
+        "--output",
+        str(tmp_path / "torch-trace.json"),
+        "--module",
+        "benchmarks.benchmark_kda_decode",
+        "--repeats",
+        "1",
+    )
+
+
+@pytest.mark.process
+def test_torch_capture_launcher_runs_module_from_working_directory(tmp_path: Path) -> None:
+    (tmp_path / "benchmarks").mkdir()
+    (tmp_path / "benchmarks" / "benchmark_demo.py").write_text("print('workload ran')\n")
+    (tmp_path / "torch.py").write_text(
+        "from pathlib import Path\n"
+        "class ProfilerActivity:\n"
+        "    CPU = 'cpu'\n"
+        "    CUDA = 'cuda'\n"
+        "class _Profile:\n"
+        "    def __enter__(self): return self\n"
+        "    def __exit__(self, *_): return False\n"
+        "    def export_chrome_trace(self, path): Path(path).write_text('trace')\n"
+        "class profiler:\n"
+        "    ProfilerActivity = ProfilerActivity\n"
+        "    @staticmethod\n"
+        "    def profile(**_): return _Profile()\n"
+        "class cuda:\n"
+        "    @staticmethod\n"
+        "    def is_available(): return False\n"
+    )
+    invocation = build_capture_invocation(
+        "torch.profiler",
+        (sys.executable, "-m", "benchmarks.benchmark_demo"),
+        tmp_path,
+        executable=None,
+    )
+
+    completed = subprocess.run(
+        invocation.argv,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert (tmp_path / "torch-trace.json").read_text() == "trace"
 
 
 def test_import_detects_torch_profiler_trace_for_analysis_routing(tmp_path: Path) -> None:

--- a/tests/application/test_capture_integrations.py
+++ b/tests/application/test_capture_integrations.py
@@ -41,10 +41,13 @@ def test_torch_capture_launcher_does_not_require_flameox_in_workload_venv(
 
 
 @pytest.mark.process
-def test_torch_capture_launcher_runs_module_from_working_directory(tmp_path: Path) -> None:
+def test_torch_capture_launcher_runs_script_with_sibling_imports(tmp_path: Path) -> None:
     (tmp_path / "benchmarks").mkdir()
-    (tmp_path / "benchmarks" / "benchmark_demo.py").write_text("print('workload ran')\n")
-    (tmp_path / "torch.py").write_text(
+    (tmp_path / "benchmarks" / "helper.py").write_text("MESSAGE = 'workload ran'\n")
+    (tmp_path / "benchmarks" / "benchmark_demo.py").write_text(
+        "from helper import MESSAGE\nprint(MESSAGE)\n"
+    )
+    (tmp_path / "benchmarks" / "torch.py").write_text(
         "from pathlib import Path\n"
         "class ProfilerActivity:\n"
         "    CPU = 'cpu'\n"
@@ -63,7 +66,7 @@ def test_torch_capture_launcher_runs_module_from_working_directory(tmp_path: Pat
     )
     invocation = build_capture_invocation(
         "torch.profiler",
-        (sys.executable, "-m", "benchmarks.benchmark_demo"),
+        (sys.executable, "benchmarks/benchmark_demo.py"),
         tmp_path,
         executable=None,
     )

--- a/tests/application/test_capture_lifecycle.py
+++ b/tests/application/test_capture_lifecycle.py
@@ -66,6 +66,10 @@ async def test_capture_plan_is_single_use_and_publishes_process_evidence(
     memory = RecipeService(workspace).memory(result.run.run_id)
     assert memory.runtime_resource_totals is not None
     assert memory.runtime_resource_totals.run_count == 1
+    assert memory.evidence.status in {"available", "partial"}
+    if not memory.measurements and not memory.hotspots:
+        assert memory.evidence.status == "partial"
+        assert memory.evidence.reason == "no_memory_profile_artifact_runtime_evidence_present"
     assert memory.truncated is memory.runtime_resources_truncated
     hotspots = RecipeService(workspace).hotspots(result.run.run_id)
     assert hotspots.evidence_status == "unavailable"

--- a/tests/application/test_detached.py
+++ b/tests/application/test_detached.py
@@ -205,9 +205,12 @@ async def test_restart_reconnect_is_truthfully_read_only(tmp_path: Path) -> None
     )
     await manager.start(plan.plan_id, "review-restart-001")
 
-    replacement = DetachedCaptureManager(workspace, captures)
+    replacement_captures = CaptureService(workspace)
+    replacement = DetachedCaptureManager(workspace, replacement_captures)
+    repeated = await replacement.start(plan.plan_id, "review-restart-001")
     status = replacement.status(plan.run_id)
 
+    assert repeated.run_id == plan.run_id
     assert status.state == "unmanaged_after_restart"
     assert status.limitations
     with pytest.raises(DomainError) as cancellation:

--- a/tests/application/test_detached.py
+++ b/tests/application/test_detached.py
@@ -11,10 +11,12 @@ from flameox.application import (
     CapturePlanRegistry,
     CaptureService,
     DetachedCaptureManager,
+    DetachedCaptureRecord,
+    DetachedCaptureStatus,
     ExecutionPolicy,
 )
 from flameox.catalog import Catalog
-from flameox.domain import DomainError, ErrorCode, ExecutionStatus
+from flameox.domain import DomainError, ErrorCode, ExecutionStatus, digest_model
 from flameox.storage import Workspace
 
 
@@ -100,6 +102,73 @@ async def test_detached_idempotency_key_cannot_authorize_another_plan(
 
     assert reused.value.code is ErrorCode.INVALID_CAPTURE_PLAN
     await manager.cancel(first.run_id)
+
+
+@pytest.mark.anyio
+async def test_detached_idempotency_creation_is_atomic_across_managers(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path, "import time; time.sleep(10)")
+    first_captures, first_manager = _manager(workspace)
+    second_captures, second_manager = _manager(workspace)
+    first_plan = await first_captures.plan(
+        workload_name="detached",
+        adapter="command",
+        execution_policy=ExecutionPolicy.APPROVED_AGENT,
+    )
+    second_plan = await second_captures.plan(
+        workload_name="detached",
+        adapter="command",
+        execution_policy=ExecutionPolicy.APPROVED_AGENT,
+    )
+
+    results = await asyncio.gather(
+        first_manager.start(first_plan.plan_id, "cross-process-key"),
+        second_manager.start(second_plan.plan_id, "cross-process-key"),
+        return_exceptions=True,
+    )
+
+    assert sum(isinstance(result, DomainError) for result in results) == 1
+    assert len(first_manager.records.list()) == 1
+    winner = next(result for result in results if not isinstance(result, DomainError))
+    assert isinstance(winner, DetachedCaptureStatus)
+    assert winner.run_id in {first_plan.run_id, second_plan.run_id}
+    owner = first_manager if winner.run_id == first_plan.run_id else second_manager
+    await owner.cancel(winner.run_id)
+
+
+@pytest.mark.anyio
+async def test_detached_startup_crash_returns_replan_recovery(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path, "print('done')")
+    captures, manager = _manager(workspace)
+    plan = await captures.plan(
+        workload_name="detached",
+        adapter="command",
+        execution_policy=ExecutionPolicy.APPROVED_AGENT,
+    )
+    manager.records.create(
+        DetachedCaptureRecord(
+            run_id=plan.run_id,
+            idempotency_digest="sha256:startup-crash",
+            plan_digest=digest_model({"plan_id": plan.plan_id}),
+            plan_request={
+                "workload_name": "detached",
+                "adapter": "command",
+                "parameters": {},
+                "preflight_mode": "auto",
+                "capture_mode": "managed",
+            },
+        )
+    )
+
+    status = manager.status(plan.run_id)
+
+    assert status.state == "failed_to_start"
+    assert status.recovery is not None
+    assert status.recovery.tool == "plan_capture"
+    assert status.recovery.arguments["workload_name"] == "detached"
 
 
 @pytest.mark.anyio

--- a/tests/application/test_evidence_query.py
+++ b/tests/application/test_evidence_query.py
@@ -14,7 +14,9 @@ from flameox.application import (
     InvestigationService,
 )
 from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.evidence import GenerationPublisher
 from flameox.storage import Workspace
+from tests.support.analysis import run_row
 
 
 def test_measurement_query_uses_bounded_snapshot_cursors(tmp_path: Path) -> None:
@@ -63,3 +65,45 @@ def test_measurement_query_uses_bounded_snapshot_cursors(tmp_path: Path) -> None
     with pytest.raises(DomainError) as stale:
         service.measurements(cursor=first.next_cursor)
     assert stale.value.code is ErrorCode.STALE_CURSOR
+
+
+def test_measurement_query_reports_filtered_warmups_as_empty(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runs": [run_row("warmup-only")],
+            "measurements": [
+                {
+                    "measurement_id": "warmup-measurement",
+                    "run_id": "warmup-only",
+                    "artifact_id": None,
+                    "name": "benchmark.duration",
+                    "value_int": None,
+                    "value_float": 1.0,
+                    "unit": "seconds",
+                    "aggregation": "single",
+                    "scope": "process",
+                    "trial_id": None,
+                    "worker_id": None,
+                    "worker_run_index": 0,
+                    "value_index": 0,
+                    "loop_count": None,
+                    "is_warmup": True,
+                    "block_id": None,
+                    "variant_id": None,
+                    "order_in_block": None,
+                    "phase": None,
+                    "dimensions": {},
+                    "evidence_level": "observed",
+                }
+            ],
+        },
+        publisher="warmup-fixture",
+        publisher_version="1",
+    )
+
+    result = EvidenceQueryService(workspace).measurements(run_id="warmup-only")
+
+    assert result.measurements == ()
+    assert result.evidence.status == "empty"
+    assert result.evidence.reason == "no_matching_measurements"

--- a/tests/application/test_operations.py
+++ b/tests/application/test_operations.py
@@ -7,8 +7,8 @@ from typing import cast
 
 import pytest
 
-from flameox.application.operations import OperationRunner
-from flameox.domain import DomainError
+from flameox.application.operations import OperationFailure, OperationRunner
+from flameox.domain import DomainError, ErrorCode
 from flameox.storage import Workspace
 
 
@@ -78,4 +78,57 @@ async def test_operation_runner_cancellation_persists_cleanup_and_is_replayable(
     assert cancelled.cleanup_status == "complete"
     assert cancelled.cancellation_requested is True
     assert cancelled.recovery is not None
-    assert cancelled.recovery.arguments == {"value": 1}
+    assert cancelled.recovery.action == "retry_new_operation"
+    assert cancelled.recovery.arguments["value"] == 1
+    assert cancelled.recovery.arguments["idempotency_key"]
+
+
+@pytest.mark.anyio
+async def test_operation_runner_idempotency_is_shared_by_runners(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    first_runner = OperationRunner(workspace, "test.operation")
+    second_runner = OperationRunner(workspace, "test.operation")
+    started = 0
+
+    async def run(
+        operation_id: str,
+        progress: object,
+    ) -> dict[str, object]:
+        nonlocal started
+        started += 1
+        await asyncio.sleep(0.02)
+        return {"operation_id": operation_id}
+
+    first, second = await asyncio.gather(
+        first_runner.start({"value": 1}, "same-key", run),
+        second_runner.start({"value": 1}, "same-key", run),
+    )
+    assert first.operation_id == second.operation_id
+    await asyncio.sleep(0.05)
+    assert started == 1
+
+
+@pytest.mark.anyio
+async def test_operation_runner_preserves_completed_items_on_failure(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    runner = OperationRunner(workspace, "test.operation")
+
+    async def run(
+        operation_id: str,
+        progress: object,
+    ) -> dict[str, object]:
+        raise OperationFailure(
+            DomainError(ErrorCode.PROCESS_FAILED, "The second item failed.", retryable=True),
+            completed_items=("first",),
+        )
+
+    started = await runner.start(
+        {"value": 1},
+        "failure-key",
+        run,
+        items=("first", "second"),
+    )
+    await asyncio.sleep(0.02)
+    status = await runner.status(started.operation_id)
+    assert status.state == "failed"
+    assert [item.status for item in status.item_outcomes] == ["complete", "retryable"]

--- a/tests/application/test_operations.py
+++ b/tests/application/test_operations.py
@@ -32,6 +32,7 @@ async def test_operation_runner_persists_exact_request_and_reconnects(tmp_path: 
     first = await runner.start({"run_id": "run-1"}, "same-key", run, items=("run-1",))
     second = await runner.start({"run_id": "run-1"}, "same-key", run, items=("run-1",))
     assert second.operation_id == first.operation_id
+    assert ":" not in first.operation_id
     assert second.request == {"run_id": "run-1"}
 
     for _ in range(50):
@@ -106,6 +107,34 @@ async def test_operation_runner_idempotency_is_shared_by_runners(tmp_path: Path)
     assert first.operation_id == second.operation_id
     await asyncio.sleep(0.05)
     assert started == 1
+
+
+@pytest.mark.anyio
+async def test_operation_runner_does_not_steal_a_live_cross_process_lease(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    first_runner = OperationRunner(workspace, "test.operation")
+    second_runner = OperationRunner(workspace, "test.operation")
+    stopped = asyncio.Event()
+
+    async def run(
+        operation_id: str,
+        progress: object,
+    ) -> dict[str, object]:
+        cancel_event = asyncio.Event()
+        first_runner.set_cancel_hook(operation_id, cancel_event.set)
+        await cancel_event.wait()
+        stopped.set()
+        return {"receipt": "cancelled"}
+
+    started = await first_runner.start({"value": 1}, "lease-key", run)
+    observed = await second_runner.status(started.operation_id)
+
+    assert observed.state == "running"
+    assert observed.recovery is None
+    await first_runner.cancel(started.operation_id)
+    assert stopped.is_set()
 
 
 @pytest.mark.anyio

--- a/tests/application/test_operations.py
+++ b/tests/application/test_operations.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from flameox.application.operations import OperationRunner
+from flameox.domain import DomainError
+from flameox.storage import Workspace
+
+
+@pytest.mark.anyio
+async def test_operation_runner_persists_exact_request_and_reconnects(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    runner = OperationRunner(workspace, "test.operation")
+
+    async def run(
+        operation_id: str,
+        progress: object,
+    ) -> dict[str, object]:
+        report = cast(
+            Callable[[str, float | None, float | None, str], Awaitable[None]],
+            progress,
+        )
+        await report("working", 0, 2, "Started")
+        await report("working", 2, 2, "Finished")
+        return {"receipt": "ok"}
+
+    first = await runner.start({"run_id": "run-1"}, "same-key", run, items=("run-1",))
+    second = await runner.start({"run_id": "run-1"}, "same-key", run, items=("run-1",))
+    assert second.operation_id == first.operation_id
+    assert second.request == {"run_id": "run-1"}
+
+    for _ in range(50):
+        status = await runner.status(first.operation_id)
+        if status.state == "terminal":
+            break
+        await asyncio.sleep(0.01)
+    assert status.state == "terminal"
+    assert [item.status for item in status.item_outcomes] == ["complete"]
+    assert [item.completed for item in status.progress] == [0, 2]
+    assert status.terminal_receipt == {"receipt": "ok"}
+
+    with pytest.raises(DomainError, match="different request"):
+        await runner.start({"run_id": "run-2"}, "same-key", run)
+
+
+@pytest.mark.anyio
+async def test_operation_runner_cancellation_persists_cleanup_and_is_replayable(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    runner = OperationRunner(workspace, "test.operation")
+    stopped = asyncio.Event()
+
+    async def run(
+        operation_id: str,
+        progress: object,
+    ) -> dict[str, object]:
+        report = cast(
+            Callable[[str, float | None, float | None, str], Awaitable[None]],
+            progress,
+        )
+        cancel_event = asyncio.Event()
+        runner.set_cancel_hook(operation_id, cancel_event.set)
+        await report("waiting", None, None, "Waiting for cancellation")
+        await cancel_event.wait()
+        stopped.set()
+        return {"cleanup": "complete"}
+
+    started = await runner.start({"value": 1}, "cancel-key", run, items=("item",))
+    cancelled = await runner.cancel(started.operation_id)
+    assert stopped.is_set()
+    assert cancelled.state == "cancelled"
+    assert cancelled.cleanup_status == "complete"
+    assert cancelled.cancellation_requested is True
+    assert cancelled.recovery is not None
+    assert cancelled.recovery.arguments == {"value": 1}

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 377
+expected_test_count = 381
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -43,7 +43,7 @@ expected_test_count = 377
 'tests/adapters/test_pyperf.py' = { count = 4, digest = 'a0b5fdf06a752d5d375254b2f05a5f6962df9a1e917181695f13ce6f24923fb5' }
 'tests/adapters/test_pytest.py' = { count = 6, digest = 'd7756e162c74611dd6c160c09586b40e4361157d3f021dc2497247a9bfed1a50' }
 'tests/adapters/test_python_startup.py' = { count = 8, digest = '8cfb0e6e9eeb98fad169198876908f40b710c9d138284860869c9f0713fd2538' }
-'tests/adapters/test_setup_runtime.py' = { count = 4, digest = '403f7c5c4f53e79623c67026eeb439d78028b62264389fa5a8b5991d23341166' }
+'tests/adapters/test_setup_runtime.py' = { count = 5, digest = '7d2b902ed64a32c461b2425a20c404583fbfd6d9996f57a1c621194620109b5b' }
 'tests/analysis/test_comparison.py' = { count = 4, digest = '311406582a5fda58dbd1e74e6f7dff58cbe2bb760536031bb160f0c50ff08fa2' }
 'tests/analysis/test_recipes.py' = { count = 8, digest = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e' }
 'tests/application/test_analysis_records.py' = { count = 1, digest = '7a08286f866dbeef9c9a0500cead2b3ebf6ee6546f455ed3b5cc5407ee84b69f' }
@@ -52,7 +52,7 @@ expected_test_count = 377
 'tests/application/test_capabilities.py' = { count = 11, digest = 'a64d46e17f6e080f0a78beb9ef9ab3bcf910789097c3a28f3b8d984de6d3c6f2' }
 'tests/application/test_capture_native_outputs.py' = { count = 5, digest = '73ffb01416e94a3044feeecb6f11f1fb452f0b1595ecc8b3ac3ef4f749918f77' }
 'tests/application/test_comparison_samples.py' = { count = 2, digest = 'f28179055d031cfb2d74b5f002c1c19278a64a46c5d0c02e32f91a4e9fef23df' }
-'tests/application/test_detached.py' = { count = 6, digest = 'b9ea1ff9369428a415da45feb03f7a5fbb2cab4acbde71339a258f10921b47ee' }
+'tests/application/test_detached.py' = { count = 8, digest = '25178dcfc15e9ce50eff6595814d67d223ab1550e4a0a6873862ec0e5414b0d7' }
 'tests/application/test_discovery.py' = { count = 2, digest = '154e2545ae8110e6e72d19cd62a1734779f7bf2f6b14180f57ea2852365e8fd2' }
 'tests/application/test_environment_identity.py' = { count = 10, digest = '22a3e3a5af0f747fcf9a680ba01e2d05dab7362ed5ac558d774e788826fb62c6' }
 'tests/application/test_evidence_query.py' = { count = 2, digest = '9773c3030eed6d98646628197d0aa81bb7fcfefe6bc75c72a294cf1dac0a77dd' }
@@ -76,7 +76,7 @@ expected_test_count = 377
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
 'tests/application/test_workloads.py' = { count = 4, digest = '8498d6450bad63aec49693d92b49d53555d8f134492f13f4fa8e1502adb9f758' }
 'tests/application/test_workloads_and_capture.py' = { count = 44, digest = 'e46978fe067047aa9a06ce2685fbec0f84179e220ffe112f9b9dcdfb37dcc298' }
-'tests/application/test_operations.py' = { count = 4, digest = '6ade7b7f439558867f1b04e1cee637e625651761a17f30ff403329363010fda5' }
+'tests/application/test_operations.py' = { count = 5, digest = '2e31c1f386284e3c91f0dc6cbabd839c98e38aa2c46f52c175fd0629e9044c5c' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
 'tests/domain/test_models.py' = { count = 11, digest = '3c66f63c2bd90a4d7af1393bd59fe08072fe9872cf2a3c0d101095ba6280e016' }
 'tests/evidence/test_publication_and_catalog.py' = { count = 17, digest = '904a72fd43176a273a70dcd092d849e8dd68e1231f468228e138baeadc1170e1' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 375
+expected_test_count = 377
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -32,7 +32,7 @@ expected_test_count = 375
 'tests/adapters/test_perfetto.py' = 'f10a653fb41df80732bff21b5351b1f4eacfb30dcb358f3b690fb3dc5d3fe70f'
 'tests/analysis/test_recipes.py' = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e'
 'tests/application/test_records_and_comparisons.py' = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759'
-'tests/application/test_workloads_and_capture.py' = '02981babb32a456cb6114f9a436479e8227f7ee42b89dc07f72a06df2fad7c4d'
+'tests/application/test_workloads_and_capture.py' = 'e46978fe067047aa9a06ce2685fbec0f84179e220ffe112f9b9dcdfb37dcc298'
 'tests/mcp/test_server.py' = 'ab9f9d9f2b4fa37a7ebba360ce480f9cd81e2389e6e307ab035efe3ff9ae6e26'
 'tests/test_cli_setup.py' = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561'
 
@@ -75,7 +75,7 @@ expected_test_count = 375
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = 'd169c20bdbb6f514887e75fe045f1a8950f946d915abc6d22d6836ac1959ab0c' }
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
 'tests/application/test_workloads.py' = { count = 4, digest = '8498d6450bad63aec49693d92b49d53555d8f134492f13f4fa8e1502adb9f758' }
-'tests/application/test_workloads_and_capture.py' = { count = 42, digest = '02981babb32a456cb6114f9a436479e8227f7ee42b89dc07f72a06df2fad7c4d' }
+'tests/application/test_workloads_and_capture.py' = { count = 44, digest = 'e46978fe067047aa9a06ce2685fbec0f84179e220ffe112f9b9dcdfb37dcc298' }
 'tests/application/test_operations.py' = { count = 4, digest = '6ade7b7f439558867f1b04e1cee637e625651761a17f30ff403329363010fda5' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
 'tests/domain/test_models.py' = { count = 11, digest = '3c66f63c2bd90a4d7af1393bd59fe08072fe9872cf2a3c0d101095ba6280e016' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 367
+expected_test_count = 372
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -32,7 +32,7 @@ expected_test_count = 367
 'tests/adapters/test_perfetto.py' = 'f10a653fb41df80732bff21b5351b1f4eacfb30dcb358f3b690fb3dc5d3fe70f'
 'tests/analysis/test_recipes.py' = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e'
 'tests/application/test_records_and_comparisons.py' = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759'
-'tests/application/test_workloads_and_capture.py' = 'f67ccc1330b866cdfafc0a7b4d68b9ab2cddd125e937842d823fc2026f4ba132'
+'tests/application/test_workloads_and_capture.py' = '02981babb32a456cb6114f9a436479e8227f7ee42b89dc07f72a06df2fad7c4d'
 'tests/mcp/test_server.py' = 'ab9f9d9f2b4fa37a7ebba360ce480f9cd81e2389e6e307ab035efe3ff9ae6e26'
 'tests/test_cli_setup.py' = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561'
 
@@ -49,7 +49,7 @@ expected_test_count = 367
 'tests/application/test_analysis_records.py' = { count = 1, digest = '7a08286f866dbeef9c9a0500cead2b3ebf6ee6546f455ed3b5cc5407ee84b69f' }
 'tests/application/test_artifact_service.py' = { count = 2, digest = '2ed111222920a42e8679d1e0281f185dc0d28406470ca888d80d0a01cd87731c' }
 'tests/application/test_async_work.py' = { count = 1, digest = '5c21ab9d048e8676c0b086ff6859e87b28da82ab793c2b70de975f592355067e' }
-'tests/application/test_capabilities.py' = { count = 9, digest = '94d2e77e6e7c4844c47867f509a020e79100d4a9d8c32f1727ba633eb640445d' }
+'tests/application/test_capabilities.py' = { count = 11, digest = 'a64d46e17f6e080f0a78beb9ef9ab3bcf910789097c3a28f3b8d984de6d3c6f2' }
 'tests/application/test_capture_native_outputs.py' = { count = 5, digest = '73ffb01416e94a3044feeecb6f11f1fb452f0b1595ecc8b3ac3ef4f749918f77' }
 'tests/application/test_comparison_samples.py' = { count = 2, digest = 'f28179055d031cfb2d74b5f002c1c19278a64a46c5d0c02e32f91a4e9fef23df' }
 'tests/application/test_detached.py' = { count = 6, digest = 'b9ea1ff9369428a415da45feb03f7a5fbb2cab4acbde71339a258f10921b47ee' }
@@ -75,7 +75,8 @@ expected_test_count = 367
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = 'd169c20bdbb6f514887e75fe045f1a8950f946d915abc6d22d6836ac1959ab0c' }
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
 'tests/application/test_workloads.py' = { count = 4, digest = '8498d6450bad63aec49693d92b49d53555d8f134492f13f4fa8e1502adb9f758' }
-'tests/application/test_workloads_and_capture.py' = { count = 41, digest = 'f67ccc1330b866cdfafc0a7b4d68b9ab2cddd125e937842d823fc2026f4ba132' }
+'tests/application/test_workloads_and_capture.py' = { count = 42, digest = '02981babb32a456cb6114f9a436479e8227f7ee42b89dc07f72a06df2fad7c4d' }
+'tests/application/test_operations.py' = { count = 2, digest = '0417b8a959d719352243ac841aa80039c80f579a92eb508c8e07af07e7333bca' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
 'tests/domain/test_models.py' = { count = 11, digest = '3c66f63c2bd90a4d7af1393bd59fe08072fe9872cf2a3c0d101095ba6280e016' }
 'tests/evidence/test_publication_and_catalog.py' = { count = 17, digest = '904a72fd43176a273a70dcd092d849e8dd68e1231f468228e138baeadc1170e1' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 374
+expected_test_count = 375
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -55,7 +55,7 @@ expected_test_count = 374
 'tests/application/test_detached.py' = { count = 6, digest = 'b9ea1ff9369428a415da45feb03f7a5fbb2cab4acbde71339a258f10921b47ee' }
 'tests/application/test_discovery.py' = { count = 2, digest = '154e2545ae8110e6e72d19cd62a1734779f7bf2f6b14180f57ea2852365e8fd2' }
 'tests/application/test_environment_identity.py' = { count = 10, digest = '22a3e3a5af0f747fcf9a680ba01e2d05dab7362ed5ac558d774e788826fb62c6' }
-'tests/application/test_evidence_query.py' = { count = 1, digest = '452c19dca4b8844e095364946fdf74c0c3076809f11c7d730acceeb5c6b53e39' }
+'tests/application/test_evidence_query.py' = { count = 2, digest = '9773c3030eed6d98646628197d0aa81bb7fcfefe6bc75c72a294cf1dac0a77dd' }
 'tests/application/test_evidence_scope.py' = { count = 2, digest = 'e3e51e28f67c6512e3943f88f469d937f88d5f7f88317a34868640e55b9f590b' }
 'tests/application/test_experiments.py' = { count = 11, digest = 'ef1d24a47a9ed83b4e069315bdf7057f7e2028ef840bcbd22b662d1442dae3ad' }
 'tests/application/test_gc.py' = { count = 5, digest = '366b7ea2fd9e0790315e1a20a7b23700861c0d2a6eadba968f75702cd8d16d5a' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -32,7 +32,7 @@ expected_test_count = 381
 'tests/adapters/test_perfetto.py' = 'f10a653fb41df80732bff21b5351b1f4eacfb30dcb358f3b690fb3dc5d3fe70f'
 'tests/analysis/test_recipes.py' = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e'
 'tests/application/test_records_and_comparisons.py' = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759'
-'tests/application/test_workloads_and_capture.py' = 'e46978fe067047aa9a06ce2685fbec0f84179e220ffe112f9b9dcdfb37dcc298'
+'tests/application/test_workloads_and_capture.py' = '72520d0f76ba10ca4eec4e0b4db2370783c9e8532e0f1d52314829951f9db167'
 'tests/mcp/test_server.py' = 'ab9f9d9f2b4fa37a7ebba360ce480f9cd81e2389e6e307ab035efe3ff9ae6e26'
 'tests/test_cli_setup.py' = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561'
 

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 372
+expected_test_count = 374
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -76,7 +76,7 @@ expected_test_count = 372
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
 'tests/application/test_workloads.py' = { count = 4, digest = '8498d6450bad63aec49693d92b49d53555d8f134492f13f4fa8e1502adb9f758' }
 'tests/application/test_workloads_and_capture.py' = { count = 42, digest = '02981babb32a456cb6114f9a436479e8227f7ee42b89dc07f72a06df2fad7c4d' }
-'tests/application/test_operations.py' = { count = 2, digest = '0417b8a959d719352243ac841aa80039c80f579a92eb508c8e07af07e7333bca' }
+'tests/application/test_operations.py' = { count = 4, digest = '6ade7b7f439558867f1b04e1cee637e625651761a17f30ff403329363010fda5' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
 'tests/domain/test_models.py' = { count = 11, digest = '3c66f63c2bd90a4d7af1393bd59fe08072fe9872cf2a3c0d101095ba6280e016' }
 'tests/evidence/test_publication_and_catalog.py' = { count = 17, digest = '904a72fd43176a273a70dcd092d849e8dd68e1231f468228e138baeadc1170e1' }

--- a/tests/mcp/test_workflows.py
+++ b/tests/mcp/test_workflows.py
@@ -41,7 +41,7 @@ async def test_missing_workload_configuration_routes_to_configure_workload(
         status = await client.call_tool("workload_configuration_status", {})
         missing = await client.call_tool(
             "list_declared_workflows",
-            {"kind": "workload"},
+            {},
         )
         configured = await client.call_tool(
             "configure_workload",
@@ -53,7 +53,7 @@ async def test_missing_workload_configuration_routes_to_configure_workload(
         )
         discovered = await client.call_tool(
             "list_declared_workflows",
-            {"kind": "workload"},
+            {},
         )
 
     assert status.is_error is False
@@ -148,7 +148,7 @@ async def test_mcp_inspect_instructions_match_initialize_metadata(tmp_path: Path
     inspected = json.loads(cli.stdout)
     assert inspected["schema_version"] == 1
     assert inspected["instructions"] == initialize_instructions
-    assert len(inspected["tools"]) == 63
+    assert len(inspected["tools"]) == 66
 
 
 @pytest.mark.anyio

--- a/tests/ownership.toml
+++ b/tests/ownership.toml
@@ -73,6 +73,12 @@ lane = "application"
 paths = ["tests/application/test_async_work.py"]
 markers = ["unit"]
 
+[[ownership]]
+owner = "durable-operations"
+lane = "application"
+paths = ["tests/application/test_operations.py"]
+markers = ["unit"]
+
 
 [[ownership]]
 owner = "capabilities"


### PR DESCRIPTION
## Summary

This PR completes the MCP lifecycle and evidence-contract audit for #73/#75 and also addresses #77 and #78.

### What changed

- Add a durable operation framework with persisted operation IDs, exact request/idempotency digests, bounded progress, item outcomes, cancellation cleanup, terminal receipts, and recovery actions.
- Move managed capability setup behind detached start/status/cancel tools while retaining the compatibility wrapper.
- Add explicit evidence availability states across analysis, drill-down, measurement, Perfetto, and Torch results; empty evidence no longer masquerades as complete absence.
- Replace artifact host-path exposure with an opaque `flameox://artifacts/...` resource reference.
- Keep synchronous external work off the MCP event loop and update lifecycle/interface documentation.
- Fix #77 by consulting persisted detached-capture records before plan lookup, so retrying the same idempotency key after a manager restart reconnects to the original run instead of starting another capture.
- Fix #78 by making `list_declared_workflows` argument-free for the common workload discovery path; `kind="experiment"` remains available explicitly.
- Align the README and architecture, runtime-safety, adapter, and interface documentation with the new lifecycle and recovery behavior.

### Validation

- `uv run pytest -q` — 271 passed, 101 deselected
- `uv run ruff check src tests`
- `uv run mypy src tests`
- Real stdio MCP transport and `mcp inspect` schema checks
- `git diff --check`

### Commits

- `feat(mcp): standardize lifecycle and evidence contracts`
- `fix(capture): preserve detached idempotency after restart`
- `docs: align lifecycle and discovery guidance`

This is ready for review of the cross-cutting protocol, persistence, and documentation changes.