### PR TITLE
feat(accelerator): add structured launch evidence workflows

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -176,6 +176,39 @@ Speedscope or raw output may be preserved for existing viewers, but flameox does
 not implement a bespoke sampled-stack parser when Trace Processor can ingest
 the chosen format.
 
+#### `flameox.benchmark-samples.v1`
+
+Producer-neutral accelerator benchmarks may be imported as bounded JSON with
+raw warm-up and measured samples. Every series declares its exact unit,
+measurement clock, synchronization method, loop count, phase, device/stream,
+trial/block/variant identity, and bounded workload dimensions. Extraction
+publishes one observed measurement per raw sample; it does not replace samples
+with a precomputed mean. Device-event measurements with missing or unknown
+synchronization remain available with an explicit limitation.
+
+```json
+{
+  "schema_version": "flameox.benchmark-samples.v1",
+  "producer": "decode-benchmark",
+  "producer_version": "git:abc123",
+  "benchmarks": [{
+    "name": "decode.token_latency",
+    "unit": "ns",
+    "measurement_clock": "cuda_event",
+    "synchronization": "event_synchronize",
+    "device": {"type": "cuda", "index": 0, "stream": "7"},
+    "warmups": [45000],
+    "samples": [42100, 41900, 42400]
+  }]
+}
+```
+
+Host monotonic time measures the host-side interval. A CUDA/HIP event measures
+device-stream progress and requires the declared event or stream/device
+synchronization before its result is comparable; Flameox preserves these clocks
+as different measurement semantics. Repeating extraction for the same artifact
+and extractor identity reuses the existing normalized generation.
+
 #### `torch.profiler`
 
 Use for operator-level CPU and accelerator activity. Record all enabled
@@ -189,6 +222,17 @@ The adapter has three explicit capability tiers:
   promise of application-specific phase separation;
 - SDK/recipe mode for user-instrumented steps, phases, schedules, and semantic
   annotations.
+
+Capture plans bind `mode`, activities, shapes, memory, stacks, FLOPs, module
+hierarchy, and the full bounded schedule. Whole-entrypoint mode rejects a
+schedule because an external launcher cannot infer iteration boundaries. SDK
+mode requires an explicit schedule and an approved workload using
+`flameox.sdk.torch_profiler()`; the yielded session exposes `step()` and a
+trace-visible `phase()` range. Every active cycle is exported to a distinct
+planned filename and registered with a cycle role. Missing, extra, empty, or
+overwritten cycle outputs fail the native-output publication gate.
+Normalize a multi-cycle run by calling `extract_perfetto` once per exact trace
+artifact ID; cycle roles survive normalization and keep regions separate.
 
 Arbitrary non-Python commands cannot be transparently wrapped by
 `torch.profiler`; the adapter must report that limitation instead of pretending
@@ -240,6 +284,30 @@ repository-relative line and arc sets. This adapter answers whether a path
 executed; it does not claim why the path executed or what values flowed through
 it.
 
+#### `nsight.systems` structured export
+
+The maintained import-first adapter supports official Nsight Systems SQLite
+exports registered with producer `nsight.systems`. It never parses
+`.nsys-rep` and does not require `nsys` to be installed during extraction.
+Produce the supported input outside Flameox with, for example,
+`nsys export --type sqlite --output report.sqlite report.nsys-rep`, then import
+`report.sqlite` as an execution trace with producer `nsight.systems`.
+The current compatibility family requires `CUPTI_ACTIVITY_KIND_RUNTIME` and
+`CUPTI_ACTIVITY_KIND_KERNEL`; `StringIds`, `NVTX_EVENTS`, and
+`CUPTI_ACTIVITY_KIND_DRIVER`, `CUPTI_ACTIVITY_KIND_MEMCPY`, and
+`CUPTI_ACTIVITY_KIND_MEMSET` are versioned optional evidence. Table/column
+identity is fingerprinted, unknown required schemas fail explicitly, and the
+source SQLite artifact remains authoritative. Extraction preserves nanosecond
+timestamps, CUDA runtime/driver APIs, graph launches, kernels, correlation IDs,
+device, context, stream, NVTX, memcpy, and memset fields when present. NVTX containment is
+reported as a derived temporal association, not causality.
+
+The compatibility suite currently uses a deterministic schema fixture rather
+than a vendor-produced export pinned to a certified Nsight Systems release. The
+schema fingerprint and registered producer version are therefore returned and
+bound into normalization provenance, but release certification remains an
+explicit validation gap.
+
 ### Candidate adapters
 
 - GDB/LLDB and elfutils for core metadata, with user init files, autoload, and
@@ -248,7 +316,8 @@ it.
   with narrow producer-versioned extraction rather than a claimed universal
   JSON schema;
 - `rr` recording references;
-- Nsight Systems supported Arrow, JSONL, SQLite, or Parquet exports;
+- Nsight Systems Arrow, JSONL, or Parquet exports beyond the maintained SQLite
+  subset;
 - `rocprofv3` Perfetto-compatible exports;
 - heaptrack or platform-native heap profiles;
 - VizTracer or Python monitoring integrations when ordered call evidence is

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -43,7 +43,8 @@ The following choices are settled for flameox:
 
 - flameox is permanently local.
 - Python is the implementation language.
-- The MCP SDK is pinned to `mcp==2.0.0b2`.
+- The MCP SDK and protocol models are pinned to `mcp==2.0.0` and
+  `mcp-types==2.0.0`.
 - stdio is the supported MCP transport.
 - DuckDB is the local cross-run analytical engine.
 - `catalog.duckdb` is a persistent, rebuildable cache over authoritative

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,7 +238,7 @@ MCP host.
 Required:
 
 - Python 3.12 or newer;
-- `mcp==2.0.0b2`;
+- `mcp==2.0.0` and `mcp-types==2.0.0`;
 - Pydantic 2;
 - DuckDB;
 - PyArrow;
@@ -247,13 +247,13 @@ Required:
 - Portalocker for cross-process shared and exclusive file locks;
 - structured logging using the standard library or a minimal compatible layer.
 
-The MCP beta pin is intentional. It must remain exact until a deliberate SDK
-upgrade is validated. All SDK imports and conversions live under `flameox.mcp`.
-The domain service API must be testable without importing MCP.
+The MCP packages remain exact-pinned as a matched SDK/protocol-model release.
+All SDK imports and conversions live under `flameox.mcp`. The domain service
+API must be testable without importing MCP.
 
-The project uses the v2 `MCPServer` API, not the v1
-`mcp.server.fastmcp.FastMCP` compatibility surface. The exact dependency is
-declared in `pyproject.toml`, and the resolved beta is committed in `uv.lock`.
+The project uses the stable v2 `MCPServer` API, not the v1
+`mcp.server.fastmcp.FastMCP` compatibility surface. The exact dependencies are
+declared in `pyproject.toml`, and the resolved release is committed in `uv.lock`.
 
 Optional extras group collector dependencies:
 
@@ -376,7 +376,7 @@ The design intentionally builds on:
 - [Bubblewrap](https://github.com/containers/bubblewrap) and Linux cgroup/systemd
   scopes for optional enforced workload containment;
 - the
-  [official Python MCP SDK v2.0.0b2](https://github.com/modelcontextprotocol/python-sdk/tree/v2.0.0b2)
+  [official Python MCP SDK v2.0.0](https://github.com/modelcontextprotocol/python-sdk/tree/v2.0.0)
   for the local protocol adapter.
 
 These projects remain separate dependencies or installed tools. flameox's value

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -228,9 +228,9 @@ A network transport is outside the supported product contract.
 
 ### SDK and transport
 
-The server uses the official Python SDK pinned to `mcp==2.0.0b2`. The pin is
-required because v2 is a prerelease and unpinned resolution may select an
-incompatible stable v1 release.
+The server uses the official Python SDK pinned to stable `mcp==2.0.0` with the
+matching `mcp-types==2.0.0` protocol models. Both packages remain exact-pinned
+because their wire types are released and consumed as a matched pair.
 
 The supported transport is stdio. The server:
 
@@ -659,20 +659,18 @@ flameox://run-sets/{run_set_id}
 
 Resources return JSON or text summaries. Large native artifacts are represented
 by metadata and opaque resource references, never host storage paths and never
-injected into model context. Template
-resources declare `mime_type="application/json"`, percent-encode identifiers,
-and resolve services through a server-local lifespan closure. In the exact
-`2.0.0b2` wheel, template-handler `Context` is reconstructed by Pydantic and
-loses its private request state, so `ctx.request_context` raises at runtime.
-Resource handlers therefore omit `Context`; the MCP adapter stores the active
-lifespan value in a closure for the duration of `server.run()`. Tool handlers
-continue using injected `ctx.request_context.lifespan_context`. A contract test
-must fail if a future SDK change invalidates either path, and the workaround is
-removed on upgrade when template context is proven functional.
+injected into model context. Template resources declare
+`mime_type="application/json"`, percent-encode identifiers, and resolve services
+through a server-local lifespan closure. Stable SDK 2.0.0 still passes template
+handlers through Pydantic call validation, which reconstructs `Context` without
+its private request state; resource handlers therefore omit `Context`. Tool
+handlers use injected `ctx.request_context.lifespan_context`. Contract tests
+cover both paths so SDK lifecycle changes cannot silently detach resources from
+the active workspace.
 
 Mutable workspace and capability views remain tools rather than static
-resources because this SDK beta does not inject lifespan context into static
-resource handlers. Tool results should include MCP `ResourceLink` blocks for
+resources because they require current state and explicit recovery semantics.
+Tool results should include MCP `ResourceLink` blocks for
 addressable runs, artifacts, findings, analyses, and comparisons when useful.
 
 ### No MCP prompts

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -112,8 +112,8 @@ these actions runs a workload.
 ### Capture commands
 
 ```text
-flameox capture plan <adapter> --workload <name> [--parameters '<json>']
-flameox capture run <adapter> --workload <name> [--parameters '<json>']
+flameox capture plan <adapter> --workload <name> [--parameters '<json>'] [--adapter-options '<json>']
+flameox capture run <adapter> --workload <name> [--parameters '<json>'] [--adapter-options '<json>']
 flameox import <path> [--kind KIND]
 ```
 
@@ -161,6 +161,7 @@ flameox analyze hotspots <run-or-artifact>
 flameox analyze scaling <experiment-or-run-set>
 flameox analyze compare <baseline-run-set> <candidate-run-set>
 flameox analyze pytorch <run-or-artifact>
+flameox analyze accelerator-launches <run-or-artifact> [--compare-to RUN] [--phase PHASE]
 flameox analyze memory <run-or-artifact>
 flameox analyze execution <run-or-artifact> [--compare RUN]
 flameox analyze failures [filters]
@@ -323,7 +324,7 @@ The supported tools are grouped as follows:
 | Family | Tools |
 | --- | --- |
 | Workspace | `initialize_workspace`, `workspace_status`, `workload_configuration_status`, `configure_workload`, `list_capabilities`, `start_capability_setup`, `get_capability_setup`, `cancel_capability_setup`, `prepare_capabilities`, `prepare_adapter`, `prepare_workload_dependencies`, `validate_workspace` |
-| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_observations` |
+| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_benchmark_samples`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_nsight_systems`, `extract_observations` |
 | Detached capture | `start_detached_capture`, `get_detached_capture`, `cancel_detached_capture` |
 | Discovery | `list_declared_workflows`, `get_declared_workflow`, `list_runs`, `list_findings` |
 | Investigations | `create_investigation`, `list_investigations`, `get_investigation`, `record_hypothesis`, `get_hypothesis` |
@@ -331,7 +332,7 @@ The supported tools are grouped as follows:
 | Runs and artifacts | `list_runs`, `get_run`, `list_artifacts`, `get_artifact`, `get_native_viewer_plan` |
 | Evidence products | `summarize_evidence`, `register_artifact_pipeline`, `compare_artifact_pipelines` |
 | Reductions | `plan_reduction`, `execute_reduction`, `get_reduction` |
-| Analysis | `analyze_hotspots`, `analyze_scaling`, `analyze_pytorch`, `analyze_memory`, `analyze_execution`, `analyze_failures`, `compare_run_sets`, `record_analysis`, `record_comparison` |
+| Analysis | `analyze_hotspots`, `analyze_scaling`, `analyze_pytorch`, `analyze_accelerator_launches`, `analyze_memory`, `analyze_execution`, `analyze_failures`, `compare_run_sets`, `record_analysis`, `record_comparison` |
 | Drill-down | `get_evidence`, `query_measurements`, `get_frame_callers`, `get_frame_callees`, `get_stack_examples`, `get_trace_window` |
 | Findings | `record_finding`, `list_findings`, `get_finding` |
 
@@ -598,6 +599,14 @@ They do not accept arbitrary SQL or caller-supplied result bodies.
 Read-only over a Perfetto-extracted trace. Returns operator and accelerator summaries.
 For imported Torch Chrome traces, run `extract_perfetto` first. If the trace has not been
 normalized, the tool returns the exact `run_id` and recovery action instead of an empty report.
+
+#### `analyze_accelerator_launches`
+
+Read-only over normalized `trace.event` evidence from Perfetto or the maintained Nsight
+Systems extractor. It reports direct and graph runtime launches, accelerator kernels,
+bounded per-stream idle-gap summaries with device/context/stream identity, and matched
+host-to-device correlation coverage. Missing runtime or accelerator tracks produce a
+typed partial result. Comparisons are descriptive and do not claim equivalent computation.
 
 #### `analyze_memory`
 

--- a/docs/storage-and-evidence.md
+++ b/docs/storage-and-evidence.md
@@ -92,7 +92,8 @@ intentional:
 `corpus/HEAD` contains one commit ID. A corpus commit is immutable and lists
 the exact generation manifests visible to a reader. Each generation manifest
 lists exact Parquet paths, hashes, row counts, Arrow schema versions, input
-artifacts and runs, extractor or publisher identity, and superseded
+artifacts and runs, extractor or publisher identity, an optional exact-operation
+digest for idempotent extraction, and superseded
 generations. A file not reachable from the pinned commit is not queryable,
 even if it exists beneath `evidence/`.
 
@@ -943,8 +944,9 @@ Every manifest, MCP result, and Parquet table carries an integer
 
 ### Extractor versions
 
-An extractor version changes whenever output semantics change. Re-extraction
-from the same native artifact creates new Parquet partitions or a new evidence
+An extractor version changes whenever output semantics change. Repeating the
+same operation identity over the same native artifact reuses its active
+generation. A changed extractor/tool/configuration identity creates a new
 generation and supersedes older derivations without deleting them immediately.
 
 ### Adapter compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ requires-python = ">=3.12"
 dependencies = [
     "anyio>=4.9,<5",
     "duckdb>=1.5.4,<1.6",
-    "mcp==2.0.0b2",
-    "mcp-types==2.0.0b2",
+    "mcp==2.0.0",
+    "mcp-types==2.0.0",
     "numpy>=2.2,<3",
     "packaging>=24,<27",
     "portalocker>=3.2,<4",

--- a/src/flameox/adapters/__init__.py
+++ b/src/flameox/adapters/__init__.py
@@ -1,3 +1,8 @@
+from flameox.adapters.benchmark_samples import (
+    BenchmarkSamplesExtractionResult,
+    BenchmarkSamplesExtractor,
+    BenchmarkSamplesV1,
+)
 from flameox.adapters.client_setup import (
     ALL_SETUP_CLIENTS,
     ClientConfigEdit,
@@ -8,6 +13,10 @@ from flameox.adapters.client_setup import (
 )
 from flameox.adapters.coverage import CoverageExtractionResult, CoverageExtractor
 from flameox.adapters.memray import MemrayExtractionResult, MemrayExtractor
+from flameox.adapters.nsight_systems import (
+    NsightSystemsExtractionResult,
+    NsightSystemsExtractor,
+)
 from flameox.adapters.observations import (
     ObservationExtractionResult,
     ObservationExtractor,
@@ -36,6 +45,10 @@ from flameox.adapters.setup_runtime import (
     TraceProcessorInstallation,
     install_trace_processor,
 )
+from flameox.adapters.torch_profiler import (
+    TorchProfilerCaptureOptions,
+    TorchProfilerSchedule,
+)
 
 __all__ = [
     "ALL_SETUP_CLIENTS",
@@ -43,6 +56,9 @@ __all__ = [
     "AdapterDescriptor",
     "AdapterDiscoveryResult",
     "AdapterRegistry",
+    "BenchmarkSamplesExtractionResult",
+    "BenchmarkSamplesExtractor",
+    "BenchmarkSamplesV1",
     "ClientConfigEdit",
     "ClientConfigRegistry",
     "ClientPlanAction",
@@ -52,6 +68,8 @@ __all__ = [
     "ManagedRuntime",
     "MemrayExtractionResult",
     "MemrayExtractor",
+    "NsightSystemsExtractionResult",
+    "NsightSystemsExtractor",
     "ObservationExtractionResult",
     "ObservationExtractor",
     "PerfettoExtractionResult",
@@ -64,6 +82,8 @@ __all__ = [
     "PythonStartupExtractor",
     "RuntimeInstallation",
     "SetupClient",
+    "TorchProfilerCaptureOptions",
+    "TorchProfilerSchedule",
     "TraceEvent",
     "TraceProcessorInstallation",
     "TraceWindowResult",

--- a/src/flameox/adapters/benchmark_samples.py
+++ b/src/flameox/adapters/benchmark_samples.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import (
+    Field,
+    StrictFloat,
+    StrictInt,
+    StringConstraints,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, digest_model
+from flameox.evidence import GenerationPublisher
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+MetricName = Annotated[
+    str,
+    StringConstraints(
+        min_length=1,
+        max_length=200,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+    ),
+]
+DimensionValue = Annotated[str, StringConstraints(max_length=200)]
+SampleValue = StrictInt | StrictFloat
+
+
+class AcceleratorDevice(ContractModel):
+    type: Literal["cuda", "hip", "xpu", "mps", "other"]
+    index: Annotated[int, Field(ge=0)] | None = None
+    stream: Annotated[str, StringConstraints(max_length=200)] | None = None
+
+
+class BenchmarkSeries(ContractModel):
+    name: MetricName
+    unit: Literal["ns", "bytes", "count", "ratio"]
+    measurement_clock: Literal[
+        "host_monotonic",
+        "cuda_event",
+        "hip_event",
+        "device_event",
+        "unknown",
+    ]
+    synchronization: Literal[
+        "not_required",
+        "device_synchronize",
+        "event_synchronize",
+        "stream_synchronize",
+        "none",
+        "unknown",
+    ]
+    scope: Literal["process", "thread", "operator", "device", "workload"] = "workload"
+    phase: Annotated[str, StringConstraints(max_length=100)] | None = "steady_state"
+    loop_count: Annotated[int, Field(gt=0)] | None = None
+    worker_id: Annotated[str, StringConstraints(max_length=200)] | None = None
+    worker_run_index: Annotated[int, Field(ge=0)] | None = None
+    trial_id: Annotated[str, StringConstraints(max_length=200)] | None = None
+    block_id: Annotated[str, StringConstraints(max_length=200)] | None = None
+    variant_id: Annotated[str, StringConstraints(max_length=200)] | None = None
+    order_in_block: Annotated[int, Field(ge=0)] | None = None
+    device: AcceleratorDevice | None = None
+    dimensions: dict[MetricName, DimensionValue] = Field(default_factory=dict, max_length=32)
+    warmups: Annotated[tuple[SampleValue, ...], Field(max_length=1_000_000)] = ()
+    samples: Annotated[
+        tuple[SampleValue, ...],
+        Field(min_length=1, max_length=1_000_000),
+    ]
+
+    @field_validator("warmups", "samples")
+    @classmethod
+    def finite_values(cls, values: tuple[SampleValue, ...]) -> tuple[SampleValue, ...]:
+        if any(isinstance(value, float) and not math.isfinite(value) for value in values):
+            raise ValueError("benchmark samples must be finite")
+        return values
+
+    @model_validator(mode="after")
+    def values_match_unit(self) -> BenchmarkSeries:
+        values = (*self.warmups, *self.samples)
+        if self.unit in {"ns", "bytes", "count"} and any(
+            not isinstance(value, int) for value in values
+        ):
+            raise ValueError(f"{self.unit} samples require exact integer values")
+        reserved_dimensions = {
+            "measurement_clock",
+            "producer",
+            "producer_version",
+            "synchronization",
+        }
+        conflicts = sorted(
+            key
+            for key in self.dimensions
+            if key in reserved_dimensions or key.startswith("device.")
+        )
+        if conflicts:
+            raise ValueError("benchmark dimensions use reserved keys: " + ", ".join(conflicts))
+        return self
+
+
+class BenchmarkSamplesV1(ContractModel):
+    schema_version: Literal["flameox.benchmark-samples.v1"]
+    producer: Annotated[str, StringConstraints(min_length=1, max_length=200)]
+    producer_version: Annotated[str, StringConstraints(max_length=200)] | None = None
+    benchmarks: Annotated[tuple[BenchmarkSeries, ...], Field(min_length=1, max_length=1_000)]
+
+
+class BenchmarkSamplesExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    producer: str
+    producer_version: str | None
+    benchmark_names: tuple[str, ...]
+    measurement_count: int
+    warmup_count: int
+    corpus_commit_id: str
+    limitations: tuple[str, ...] = ()
+
+
+class BenchmarkSamplesExtractor:
+    name = "flameox.benchmark-samples"
+    version = "1"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.runs = RunStore(workspace)
+        self.artifacts = ArtifactStore(workspace)
+        self.publisher = GenerationPublisher(workspace)
+
+    def extract(self, run_id: str) -> BenchmarkSamplesExtractionResult:
+        run = self.runs.read(run_id)
+        registrations = tuple(
+            item for item in run.artifacts if item.kind is ArtifactKind.BENCHMARK_SAMPLES
+        )
+        if len(registrations) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one structured benchmark-samples artifact.",
+                run_id=run_id,
+            )
+        registration = registrations[0]
+        stored = self.artifacts.get(registration.artifact_id)
+        payload = self._load(stored.payload_path)
+        self._check_registration_identity(
+            registration.producer,
+            registration.producer_version,
+            payload,
+        )
+
+        total_rows = sum(len(item.warmups) + len(item.samples) for item in payload.benchmarks)
+        if total_rows > self.workspace.config.storage.max_rows_per_generation:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "Structured benchmark samples exceed the workspace generation row limit.",
+                details={
+                    "rows": total_rows,
+                    "max_rows": self.workspace.config.storage.max_rows_per_generation,
+                },
+            )
+
+        rows: list[dict[str, object]] = []
+        limitations: list[str] = []
+        producer_version = payload.producer_version or registration.producer_version
+        if producer_version is None:
+            limitations.append("The benchmark producer version was not declared.")
+        for series_index, series in enumerate(payload.benchmarks):
+            if series.measurement_clock in {
+                "cuda_event",
+                "hip_event",
+                "device_event",
+            } and series.synchronization in {"none", "unknown"}:
+                limitations.append(
+                    f"{series.name} uses asynchronous device timing with "
+                    f"synchronization={series.synchronization}."
+                )
+            for is_warmup, values in ((True, series.warmups), (False, series.samples)):
+                for value_index, value in enumerate(values):
+                    rows.append(
+                        self._measurement_row(
+                            run_id=run_id,
+                            artifact_id=registration.artifact_id,
+                            producer=payload.producer,
+                            producer_version=producer_version,
+                            series=series,
+                            series_index=series_index,
+                            value_index=value_index,
+                            value=value,
+                            is_warmup=is_warmup,
+                        )
+                    )
+
+        published = self.publisher.publish_rows_idempotent(
+            {"measurements": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=(registration.artifact_id,),
+            operation_identity={
+                "schema_version": payload.schema_version,
+                "producer": payload.producer,
+                "producer_version": producer_version,
+            },
+        )
+        return BenchmarkSamplesExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            producer=payload.producer,
+            producer_version=producer_version,
+            benchmark_names=tuple(item.name for item in payload.benchmarks),
+            measurement_count=sum(len(item.samples) for item in payload.benchmarks),
+            warmup_count=sum(len(item.warmups) for item in payload.benchmarks),
+            corpus_commit_id=published.commit.commit_id,
+            limitations=tuple(dict.fromkeys(limitations)),
+        )
+
+    @staticmethod
+    def _load(path: Path) -> BenchmarkSamplesV1:
+        try:
+            with path.open(encoding="utf-8") as stream:
+                return BenchmarkSamplesV1.model_validate(json.load(stream))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The artifact is not a valid flameox benchmark-samples v1 document.",
+            ) from exc
+
+    @staticmethod
+    def _check_registration_identity(
+        registration_producer: str | None,
+        registration_version: str | None,
+        payload: BenchmarkSamplesV1,
+    ) -> None:
+        if registration_producer not in {None, "flameox.import", payload.producer}:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Benchmark producer identity conflicts with the artifact registration.",
+                details={
+                    "registered_producer": registration_producer,
+                    "document_producer": payload.producer,
+                },
+            )
+        if (
+            registration_version is not None
+            and payload.producer_version is not None
+            and registration_version != payload.producer_version
+        ):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Benchmark producer version conflicts with the artifact registration.",
+                details={
+                    "registered_version": registration_version,
+                    "document_version": payload.producer_version,
+                },
+            )
+
+    @staticmethod
+    def _measurement_row(
+        *,
+        run_id: str,
+        artifact_id: str,
+        producer: str,
+        producer_version: str | None,
+        series: BenchmarkSeries,
+        series_index: int,
+        value_index: int,
+        value: SampleValue,
+        is_warmup: bool,
+    ) -> dict[str, object]:
+        dimensions = dict(series.dimensions)
+        dimensions.update(
+            {
+                "measurement_clock": series.measurement_clock,
+                "synchronization": series.synchronization,
+                "producer": producer,
+            }
+        )
+        if producer_version is not None:
+            dimensions["producer_version"] = producer_version
+        if series.device is not None:
+            dimensions["device.type"] = series.device.type
+            if series.device.index is not None:
+                dimensions["device.index"] = str(series.device.index)
+            if series.device.stream is not None:
+                dimensions["device.stream"] = series.device.stream
+        identity = {
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "series_index": series_index,
+            "name": series.name,
+            "is_warmup": is_warmup,
+            "value_index": value_index,
+        }
+        integer_unit = series.unit in {"ns", "bytes", "count"}
+        return {
+            "measurement_id": digest_model(identity),
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "name": series.name,
+            "value_int": int(value) if integer_unit else None,
+            "value_float": float(value) if not integer_unit else None,
+            "unit": series.unit,
+            "aggregation": "sample",
+            "scope": series.scope,
+            "trial_id": series.trial_id,
+            "worker_id": series.worker_id,
+            "worker_run_index": series.worker_run_index,
+            "value_index": value_index,
+            "loop_count": series.loop_count,
+            "is_warmup": is_warmup,
+            "block_id": series.block_id,
+            "variant_id": series.variant_id,
+            "order_in_block": series.order_in_block,
+            "phase": "warmup" if is_warmup else series.phase,
+            "dimensions": dimensions,
+            "evidence_level": "observed",
+        }

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from flameox.adapters.torch_profiler import torch_profiler_options
 from flameox.domain import ArtifactKind, DomainError, ErrorCode
 
 DependencyKind = Literal["internal", "executable", "package"]
@@ -38,6 +40,7 @@ class CaptureInvocation:
     artifact_kinds: tuple[ArtifactKind, ...]
     expected_overhead: str
     limitations: tuple[str, ...]
+    environment: dict[str, str]
 
 
 BUILTIN_ADAPTERS = {
@@ -177,18 +180,25 @@ BUILTIN_ADAPTERS = {
             name="torch.profiler",
             dependency_kind="package",
             dependency="torch",
-            supported_modes=("trace_import", "launcher", "sdk"),
+            supported_modes=("trace_import", "whole_entrypoint", "sdk"),
             supported_formats=("chrome-trace",),
-            features=("operators", "input_shapes", "allocations", "stacks"),
+            features=(
+                "operators",
+                "input_shapes",
+                "allocations",
+                "stacks",
+                "bounded_schedules",
+                "multi_cycle_exports",
+            ),
             output_filename="torch-trace.json",
             artifact_kinds=(ArtifactKind.EXECUTION_TRACE,),
             expected_overhead=(
                 "Operator tracing with shapes, memory, and Python stacks has substantial overhead."
             ),
             capture_limitations=(
-                "Whole-entrypoint mode cannot distinguish application-specific "
-                "warm-up and steady-state phases.",
-                "FLOP estimates and module hierarchy are not enabled.",
+                "Evidence coverage and overhead depend on the feature flags bound into the "
+                "capture plan.",
+                "Scheduled SDK mode requires explicit workload step boundaries.",
             ),
             managed_extra="torch",
             managed_requirement="torch>=2.7",
@@ -240,6 +250,7 @@ def build_capture_invocation(
     output_root: Path,
     *,
     executable: str | None,
+    options: dict[str, object] | None = None,
 ) -> CaptureInvocation:
     adapter = BUILTIN_ADAPTERS.get(adapter_name)
     if (
@@ -252,7 +263,14 @@ def build_capture_invocation(
             ErrorCode.CAPABILITY_UNAVAILABLE,
             f"Adapter {adapter_name!r} does not support capture planning.",
         )
+    if options and adapter_name != "torch.profiler":
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            f"Adapter {adapter_name!r} does not accept capture options.",
+        )
     output = str(output_root / adapter.output_filename)
+    environment: dict[str, str] = {}
+    limitations = adapter.capture_limitations
     if adapter_name == "command":
         argv = workload_argv
     elif adapter_name == "py-spy":
@@ -275,7 +293,7 @@ def build_capture_invocation(
             "--",
             *workload_argv,
         )
-    elif adapter_name in {"coverage", "memray", "torch.profiler"}:
+    elif adapter_name in {"coverage", "memray"}:
         python, target = _python_target(workload_argv)
         if adapter_name == "coverage":
             argv = (
@@ -297,23 +315,14 @@ def build_capture_invocation(
                 output,
                 *target,
             )
-        else:
-            if target[0] == "-m":
-                if len(target) < 2:
-                    raise DomainError(
-                        ErrorCode.INVALID_CAPTURE_PLAN,
-                        "The Python module name is missing.",
-                    )
-                launcher_target = ("--module", target[1], *target[2:])
-            else:
-                launcher_target = ("--script", target[0], *target[1:])
-            argv = (
-                python,
-                _launcher_path("torch_launcher.py"),
-                "--output",
-                output,
-                *launcher_target,
-            )
+    elif adapter_name == "torch.profiler":
+        return _torch_capture_invocation(
+            adapter,
+            workload_argv,
+            output_root,
+            output,
+            options=options,
+        )
     elif adapter_name == "pyperf":
         python, _ = _python_target(workload_argv)
         argv = (
@@ -366,7 +375,114 @@ def build_capture_invocation(
         argv=argv,
         artifact_kinds=adapter.artifact_kinds,
         expected_overhead=adapter.expected_overhead,
-        limitations=adapter.capture_limitations,
+        limitations=limitations,
+        environment=environment,
+    )
+
+
+def _torch_capture_invocation(
+    adapter: BuiltinAdapter,
+    workload_argv: tuple[str, ...],
+    output_root: Path,
+    output: str,
+    *,
+    options: dict[str, object] | None,
+) -> CaptureInvocation:
+    python, target = _python_target(workload_argv)
+    selected = torch_profiler_options(options)
+    config = selected.model_dump(mode="json")
+    config["expected_cycles"] = selected.expected_cycles
+    encoded_config = json.dumps(
+        config,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    feature_limitations = tuple(
+        message
+        for enabled, message in (
+            (selected.record_shapes, "Input shapes were not collected."),
+            (selected.profile_memory, "Profiler memory events were not collected."),
+            (selected.with_stack, "Python stacks were not collected."),
+            (selected.with_flops, "Operator-limited FLOP estimates were not collected."),
+            (selected.with_modules, "Module hierarchy was not collected."),
+        )
+        if not enabled
+    )
+    feature_limitations = (
+        *feature_limitations,
+        *(
+            ("FLOP estimates cover only operators supported by PyTorch's estimator.",)
+            if selected.with_flops
+            else ()
+        ),
+        *(
+            ("Module hierarchy coverage is limited by the active PyTorch execution mode.",)
+            if selected.with_modules
+            else ()
+        ),
+    )
+    expensive_features = tuple(
+        name
+        for name, enabled in (
+            ("shapes", selected.record_shapes),
+            ("memory", selected.profile_memory),
+            ("stacks", selected.with_stack),
+            ("FLOPs", selected.with_flops),
+            ("modules", selected.with_modules),
+        )
+        if enabled
+    )
+    expected_overhead = (
+        "Operator tracing with enabled expensive features: " + ", ".join(expensive_features) + "."
+        if expensive_features
+        else "Operator tracing without shapes, memory, stacks, FLOPs, or modules."
+    )
+    if selected.mode == "sdk":
+        return CaptureInvocation(
+            argv=workload_argv,
+            artifact_kinds=adapter.artifact_kinds,
+            expected_overhead=expected_overhead,
+            limitations=(
+                "The approved workload owns profiler context entry and must call "
+                "flameox.sdk.torch_profiler().step() at each declared step boundary.",
+                "The workload environment must be able to import flameox.sdk.",
+                "Schedule state is driven only by explicit workload step calls; Flameox does "
+                "not infer iteration boundaries.",
+                *feature_limitations,
+            ),
+            environment={
+                "FLAMEOX_TORCH_PROFILER_CONFIG": encoded_config,
+                "FLAMEOX_TORCH_PROFILER_OUTPUT_ROOT": str(output_root),
+            },
+        )
+    if target[0] == "-m":
+        if len(target) < 2:
+            raise DomainError(
+                ErrorCode.INVALID_CAPTURE_PLAN,
+                "The Python module name is missing.",
+            )
+        launcher_target = ("--module", target[1], *target[2:])
+    else:
+        launcher_target = ("--script", target[0], *target[1:])
+    return CaptureInvocation(
+        argv=(
+            python,
+            _launcher_path("torch_launcher.py"),
+            "--output",
+            output,
+            "--config",
+            encoded_config,
+            *launcher_target,
+        ),
+        artifact_kinds=adapter.artifact_kinds,
+        expected_overhead=expected_overhead,
+        limitations=(
+            "Whole-entrypoint mode cannot distinguish application-specific warm-up and "
+            "steady-state phases.",
+            *feature_limitations,
+        ),
+        environment={},
     )
 
 

--- a/src/flameox/adapters/nsight_systems.py
+++ b/src/flameox/adapters/nsight_systems.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import heapq
+import json
+import secrets
+import shutil
+import sys
+from typing import Any
+
+from pydantic import JsonValue
+
+from flameox.atomic import atomic_write_json
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, digest_model
+from flameox.evidence import GenerationPublisher
+from flameox.execution import ExecutionRequest, SubprocessBroker
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+
+def _integer(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int | str | bytes | bytearray):
+        raise ValueError(f"expected an integer-compatible event value, got {type(value).__name__}")
+    return int(value)
+
+
+def _range_assignments(
+    indexed_events: list[tuple[int, dict[str, object]]],
+    ranges: list[dict[str, object]],
+) -> dict[int, tuple[str, int]]:
+    assignments: dict[int, tuple[str, int]] = {}
+    ordered_ranges = sorted(ranges, key=lambda item: _integer(item["start_ns"]))
+    active: list[tuple[int, int, str]] = []
+    cursor = 0
+    for index, event in sorted(
+        indexed_events,
+        key=lambda item: _integer(item[1]["start_ns"]),
+    ):
+        start = _integer(event["start_ns"])
+        end = start + _integer(event["duration_ns"])
+        while (
+            cursor < len(ordered_ranges) and _integer(ordered_ranges[cursor]["start_ns"]) <= start
+        ):
+            selected = ordered_ranges[cursor]
+            duration = _integer(selected["duration_ns"])
+            heapq.heappush(
+                active,
+                (
+                    duration,
+                    _integer(selected["start_ns"]) + duration,
+                    str(selected["name"]),
+                ),
+            )
+            cursor += 1
+        while active and active[0][1] < end:
+            heapq.heappop(active)
+        if active:
+            duration, _, name = active[0]
+            assignments[index] = (name, duration)
+    return assignments
+
+
+def _nvtx_phase_assignments(
+    events: list[dict[str, object]],
+) -> dict[int, tuple[str, str]]:
+    def lane(event: dict[str, object]) -> str | None:
+        if event.get("thread") is not None:
+            return f"thread:{event['thread']}"
+        if event.get("process") is not None:
+            return f"process:{event['process']}"
+        return None
+
+    ranges_by_lane: dict[str | None, list[dict[str, object]]] = {}
+    events_by_lane: dict[str | None, list[tuple[int, dict[str, object]]]] = {}
+    lane_by_correlation = {
+        str(event["correlation_id"]): event_lane
+        for event in events
+        if (event_lane := lane(event)) is not None
+        if event.get("category") in {"cuda_runtime", "cuda_driver"}
+        and event.get("correlation_id") is not None
+    }
+    for index, event in enumerate(events):
+        event_lane = lane(event)
+        if event_lane is None and event.get("correlation_id") is not None:
+            event_lane = lane_by_correlation.get(str(event["correlation_id"]))
+        if event.get("category") == "nvtx" and _integer(event.get("duration_ns", 0)) > 0:
+            ranges_by_lane.setdefault(event_lane, []).append(event)
+        elif event.get("category") != "nvtx":
+            events_by_lane.setdefault(event_lane, []).append((index, event))
+    global_ranges = ranges_by_lane.get(None, [])
+    assignments: dict[int, tuple[str, str]] = {}
+    for event_lane, indexed_events in events_by_lane.items():
+        candidates = _range_assignments(indexed_events, global_ranges)
+        if event_lane is not None:
+            specific = _range_assignments(
+                indexed_events,
+                ranges_by_lane.get(event_lane, []),
+            )
+            for index, candidate in specific.items():
+                if index not in candidates or candidate[1] < candidates[index][1]:
+                    candidates[index] = candidate
+        event_by_index = dict(indexed_events)
+        for index, (name, _) in candidates.items():
+            evidence = "derived_from_containing_nvtx_range"
+            if lane(event_by_index[index]) is None:
+                evidence = "derived_from_correlation_and_containing_nvtx_range"
+            assignments[index] = (name, evidence)
+    return assignments
+
+
+class NsightSystemsExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    producer_version: str | None
+    export_format: str
+    compatibility_family: str
+    query_version: str
+    schema_fingerprint: str
+    observed_tables: tuple[str, ...]
+    event_count: int
+    runtime_event_count: int
+    driver_event_count: int
+    kernel_event_count: int
+    nvtx_event_count: int
+    memory_copy_event_count: int
+    memory_set_event_count: int
+    coverage: dict[str, bool]
+    corpus_commit_id: str
+    limitations: tuple[str, ...]
+
+
+class NsightSystemsExtractor:
+    """Import one supported official Nsight Systems SQLite export."""
+
+    name = "nsight.systems.sqlite"
+    version = "1"
+    query_version = "flameox.nsight-systems.cuda-events.v1"
+    compatibility_family = "nsight-systems.sqlite.cuda.v1"
+
+    def __init__(
+        self,
+        workspace: Workspace,
+        *,
+        broker: SubprocessBroker | None = None,
+    ) -> None:
+        self.workspace = workspace
+        self.broker = broker or SubprocessBroker()
+        self.publisher = GenerationPublisher(workspace)
+
+    async def extract(self, run_id: str) -> NsightSystemsExtractionResult:
+        run = RunStore(self.workspace).read(run_id)
+        registrations = [
+            item for item in run.artifacts if item.kind is ArtifactKind.EXECUTION_TRACE
+        ]
+        if len(registrations) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one Nsight Systems structured export.",
+                run_id=run_id,
+            )
+        registration = registrations[0]
+        if registration.producer not in {"nsight.systems", "nsys"}:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The execution trace is not registered as an Nsight Systems export.",
+                run_id=run_id,
+                details={"registered_producer": registration.producer},
+                remediation=(
+                    "Import an official `nsys export --type sqlite` output with "
+                    "producer='nsight.systems'.",
+                ),
+            )
+        artifact = ArtifactStore(self.workspace).get(registration.artifact_id)
+        try:
+            with artifact.payload_path.open("rb") as stream:
+                header = stream.read(16)
+        except OSError as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The Nsight Systems export cannot be read.",
+            ) from exc
+        if header != b"SQLite format 3\x00":
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Only official Nsight Systems SQLite structured exports are supported.",
+                remediation=(
+                    "Use `nsys export --type sqlite --output <path> <report>.nsys-rep`, then "
+                    "import the SQLite file; Flameox does not parse .nsys-rep directly.",
+                ),
+            )
+
+        maximum = self.workspace.config.storage.max_rows_per_generation
+        if maximum < 7:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "Nsight Systems normalization requires room for provenance and one event table.",
+            )
+        max_rows_per_table = (maximum - 1) // 6
+        response = await self._run_worker(
+            {
+                "artifact_path": str(artifact.payload_path),
+                "max_rows_per_table": max_rows_per_table,
+            }
+        )
+        raw_events = response.get("events")
+        raw_coverage = response.get("coverage")
+        raw_tables = response.get("tables")
+        if (
+            not isinstance(raw_events, list)
+            or not isinstance(raw_coverage, dict)
+            or not isinstance(raw_tables, list)
+            or any(not isinstance(table, str) for table in raw_tables)
+        ):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Nsight Systems worker returned an invalid normalized result.",
+            )
+        if len(raw_events) > maximum:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "Nsight Systems events exceed the workspace generation row limit.",
+            )
+        events = [event for event in raw_events if isinstance(event, dict)]
+        if len(events) != len(raw_events):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Nsight Systems worker returned a non-object event.",
+            )
+
+        phase_assignments = _nvtx_phase_assignments(events)
+        rows: list[dict[str, object]] = []
+        for index, event in enumerate(events):
+            phase: str | None = None
+            phase_evidence: str | None = None
+            if event.get("category") == "nvtx":
+                phase = str(event["name"])
+                phase_evidence = "observed"
+            elif index in phase_assignments:
+                phase, phase_evidence = phase_assignments[index]
+            values = {
+                **event,
+                "phase": phase,
+                "phase_evidence": phase_evidence,
+                "artifact_role": registration.role,
+                "clock_domain": "nsight_systems_export",
+                "timestamp_unit": "ns",
+            }
+            rows.append(
+                {
+                    "observation_id": digest_model(
+                        {
+                            "artifact_id": registration.artifact_id,
+                            "event_index": index,
+                            "kind": "trace.event",
+                        }
+                    ),
+                    "run_id": run_id,
+                    "artifact_id": registration.artifact_id,
+                    "kind": "trace.event",
+                    "name": str(event["name"]),
+                    "value_json": json.dumps(
+                        values,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                    "file": None,
+                    "line_from": None,
+                    "line_to": None,
+                    "context": phase,
+                    "evidence_level": "observed",
+                }
+            )
+
+        coverage = {str(key): bool(value) for key, value in raw_coverage.items()}
+        schema_fingerprint = str(response["schema_fingerprint"])
+        rows.append(
+            {
+                "observation_id": digest_model(
+                    {
+                        "artifact_id": registration.artifact_id,
+                        "kind": "trace.extraction",
+                        "query_version": self.query_version,
+                        "schema_fingerprint": schema_fingerprint,
+                    }
+                ),
+                "run_id": run_id,
+                "artifact_id": registration.artifact_id,
+                "kind": "trace.extraction",
+                "name": self.query_version,
+                "value_json": json.dumps(
+                    {
+                        "compatibility_family": self.compatibility_family,
+                        "coverage": coverage,
+                        "producer_version": registration.producer_version,
+                        "query_version": self.query_version,
+                        "schema_fingerprint": schema_fingerprint,
+                    },
+                    allow_nan=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+                "file": None,
+                "line_from": None,
+                "line_to": None,
+                "context": "extractor_provenance",
+                "evidence_level": "observed",
+            }
+        )
+        truncated_tables = response.get("truncated_tables")
+        limitations = [
+            "The SQLite export is authoritative; normalized rows cover only the declared "
+            "compatibility schema.",
+            "NVTX containment is a derived temporal association and does not prove causality.",
+            "Timestamps use the Nsight Systems export clock; cross-profiler clock alignment is "
+            "unknown.",
+        ]
+        for capability, present in coverage.items():
+            if not present:
+                limitations.append(
+                    f"Optional Nsight Systems evidence is unavailable: {capability}."
+                )
+        if isinstance(truncated_tables, list) and truncated_tables:
+            limitations.append(
+                "Structured extraction reached the row budget for: "
+                + ", ".join(str(item) for item in truncated_tables)
+                + "."
+            )
+        published = self.publisher.publish_rows_idempotent(
+            {"observations": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=(registration.artifact_id,),
+            operation_identity={
+                "compatibility_family": self.compatibility_family,
+                "max_rows_per_table": max_rows_per_table,
+                "producer_version": registration.producer_version,
+                "query_version": self.query_version,
+                "schema_fingerprint": schema_fingerprint,
+            },
+        )
+        counts = {
+            category: sum(event.get("category") == category for event in events)
+            for category in (
+                "cuda_runtime",
+                "cuda_driver",
+                "kernel",
+                "nvtx",
+                "memcpy",
+                "memset",
+            )
+        }
+        return NsightSystemsExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            producer_version=registration.producer_version,
+            export_format="sqlite",
+            compatibility_family=self.compatibility_family,
+            query_version=self.query_version,
+            schema_fingerprint=schema_fingerprint,
+            observed_tables=tuple(raw_tables),
+            event_count=len(events),
+            runtime_event_count=counts["cuda_runtime"],
+            driver_event_count=counts["cuda_driver"],
+            kernel_event_count=counts["kernel"],
+            nvtx_event_count=counts["nvtx"],
+            memory_copy_event_count=counts["memcpy"],
+            memory_set_event_count=counts["memset"],
+            coverage=coverage,
+            corpus_commit_id=published.commit.commit_id,
+            limitations=tuple(limitations),
+        )
+
+    async def _run_worker(self, request: dict[str, JsonValue]) -> dict[str, Any]:
+        job_root = self.workspace.paths.staging / "nsight-systems" / secrets.token_hex(16)
+        job_root.mkdir(parents=True, exist_ok=False)
+        request_path = job_root / "request.json"
+        response_path = job_root / "response.json"
+        atomic_write_json(request_path, request)
+        try:
+            outcome = await self.broker.run(
+                ExecutionRequest(
+                    argv=(
+                        sys.executable,
+                        "-m",
+                        "flameox.workers.nsight_systems",
+                        "--request",
+                        str(request_path),
+                        "--response",
+                        str(response_path),
+                    ),
+                    cwd=self.workspace.project_root,
+                    environment_allowlist=tuple(
+                        self.workspace.config.execution.child_environment_allowlist
+                    ),
+                    allowed_working_roots=(self.workspace.project_root,),
+                    timeout_seconds=120,
+                    max_output_bytes=1_048_576,
+                )
+            )
+            if outcome.process.exit_code != 0 or not response_path.is_file():
+                raise DomainError(
+                    ErrorCode.ARTIFACT_PARSE_FAILED,
+                    "Nsight Systems worker exited without a valid response.",
+                    details={
+                        "exit_code": outcome.process.exit_code,
+                        "stderr": outcome.stderr.decode(errors="replace")[-2_000:],
+                    },
+                )
+            if response_path.stat().st_size > self.workspace.config.capture.max_artifact_bytes:
+                raise DomainError(
+                    ErrorCode.ARTIFACT_TOO_LARGE,
+                    "Nsight Systems worker response exceeds the configured artifact budget.",
+                )
+            payload = json.loads(response_path.read_text())
+            if not isinstance(payload, dict):
+                raise ValueError("worker response must be a JSON object")
+            if payload.get("ok") is not True:
+                raise DomainError(
+                    ErrorCode.ARTIFACT_PARSE_FAILED,
+                    str(payload.get("message", "Nsight Systems worker failed.")),
+                )
+            return payload
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Nsight Systems worker response is invalid.",
+            ) from exc
+        finally:
+            shutil.rmtree(job_root, ignore_errors=True)

--- a/src/flameox/adapters/perfetto.py
+++ b/src/flameox/adapters/perfetto.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import secrets
@@ -13,6 +14,7 @@ from pydantic import Field, JsonValue
 from flameox.atomic import atomic_write_json
 from flameox.domain import (
     ArtifactKind,
+    ArtifactRegistration,
     CursorCodec,
     DomainError,
     ErrorCode,
@@ -32,10 +34,14 @@ class PerfettoExtractionResult(ContractModel):
     run_id: str
     artifact_id: str
     trace_processor_path: str
+    trace_processor_sha256: str
+    query_version: str
     slice_count: int
     frame_count: int
     call_edge_count: int
     representative_stack_count: int
+    trace_event_count: int
+    truncated: bool = False
     corpus_commit_id: str
     limitations: tuple[str, ...]
 
@@ -73,6 +79,7 @@ class PerfettoExtractor:
 
     name = "perfetto"
     version = "1"
+    query_version = "flameox.perfetto.trace-events.v1"
 
     def __init__(
         self,
@@ -84,27 +91,33 @@ class PerfettoExtractor:
         self.broker = broker or SubprocessBroker()
         self.publisher = GenerationPublisher(workspace)
 
-    async def extract(self, run_id: str) -> PerfettoExtractionResult:
+    async def extract(
+        self,
+        run_id: str,
+        *,
+        artifact_id: str | None = None,
+    ) -> PerfettoExtractionResult:
         run = RunStore(self.workspace).read(run_id)
-        registrations = [
-            item
-            for item in run.artifacts
-            if item.kind in {ArtifactKind.EXECUTION_TRACE, ArtifactKind.SAMPLE_PROFILE}
-        ]
-        if len(registrations) != 1:
-            raise DomainError(
-                ErrorCode.ARTIFACT_PARSE_FAILED,
-                "The run must contain exactly one Perfetto-compatible trace.",
-                run_id=run_id,
-            )
-        registration = registrations[0]
+        registration = self._trace_registration(run.artifacts, artifact_id, run_id=run_id)
+
         artifact = ArtifactStore(self.workspace).get(registration.artifact_id)
+
         binary = self._trace_processor_path()
+        with binary.open("rb") as stream:
+            trace_processor_sha256 = "sha256:" + hashlib.file_digest(stream, "sha256").hexdigest()
+        maximum = self.workspace.config.storage.max_rows_per_generation
+        if maximum < 7:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "Perfetto normalization requires room for provenance and one bounded slice.",
+            )
+        max_slices = (maximum - 1) // 6
         response = await self._run_worker(
             {
                 "operation": "extract",
                 "artifact_path": str(artifact.payload_path),
                 "binary_path": str(binary),
+                "max_rows": max_slices,
             }
         )
         rows = response.get("rows")
@@ -114,10 +127,12 @@ class PerfettoExtractor:
                 "Perfetto worker returned no slice rows.",
                 run_id=run_id,
             )
+        normalized_phase_by_id = self._normalized_phases(rows)
         frame_by_id: dict[str, dict[str, Any]] = {}
         aggregates: dict[_AggregateKey, tuple[int, int]] = {}
         phases_by_aggregate: dict[_AggregateKey, set[str]] = {}
         operator_observation_rows: list[dict[str, Any]] = []
+        trace_event_observation_rows: list[dict[str, Any]] = []
         torch_source = "torch" in (run.collector or "").lower() or (
             registration.producer is not None and "torch" in registration.producer.lower()
         )
@@ -179,7 +194,7 @@ class PerfettoExtractor:
             aggregate_key = (frame_id, thread_name, process_name)
             count, inclusive = aggregates.get(aggregate_key, (0, 0))
             aggregates[aggregate_key] = (count + 1, inclusive + duration)
-            phase = str(row["phase"]) if row.get("phase") is not None else None
+            phase = normalized_phase_by_id.get(int(row["id"]))
             if phase is not None:
                 phases_by_aggregate.setdefault(aggregate_key, set()).add(phase)
             if torch_source:
@@ -223,6 +238,49 @@ class PerfettoExtractor:
                         "evidence_level": "observed",
                     }
                 )
+            trace_event_values = {
+                "slice_id": int(row["id"]),
+                "parent_id": int(row["parent_id"]) if row["parent_id"] is not None else None,
+                "category": category,
+                "start_ns": int(row["ts"]),
+                "duration_ns": duration,
+                "track_id": int(row["track_id"]),
+                "thread_name": thread_name,
+                "process_name": process_name,
+                "phase": phase,
+                "correlation_id": (
+                    str(row["correlation_id"]) if row.get("correlation_id") is not None else None
+                ),
+                "device": str(row["device"]) if row.get("device") is not None else None,
+                "stream": str(row["stream"]) if row.get("stream") is not None else None,
+                "artifact_role": registration.role,
+            }
+            trace_event_observation_rows.append(
+                {
+                    "observation_id": digest_model(
+                        {
+                            "artifact_id": registration.artifact_id,
+                            "slice_id": int(row["id"]),
+                            "kind": "trace.event",
+                        }
+                    ),
+                    "run_id": run_id,
+                    "artifact_id": registration.artifact_id,
+                    "kind": "trace.event",
+                    "name": name,
+                    "value_json": json.dumps(
+                        trace_event_values,
+                        allow_nan=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                    "file": filename,
+                    "line_from": line,
+                    "line_to": line,
+                    "context": phase,
+                    "evidence_level": "observed",
+                }
+            )
             events[int(row["id"])] = (
                 int(row["parent_id"]) if row["parent_id"] is not None else None,
                 frame_id,
@@ -353,30 +411,145 @@ class PerfettoExtractor:
             "call_edges": edge_rows,
             "stacks": stack_rows,
         }
-        if operator_observation_rows:
-            evidence_rows["observations"] = operator_observation_rows
-        published = self.publisher.publish_rows(
+        extraction_observation = {
+            "observation_id": digest_model(
+                {
+                    "artifact_id": registration.artifact_id,
+                    "kind": "trace.extraction",
+                    "query_version": self.query_version,
+                    "trace_processor_sha256": trace_processor_sha256,
+                }
+            ),
+            "run_id": run_id,
+            "artifact_id": registration.artifact_id,
+            "kind": "trace.extraction",
+            "name": self.query_version,
+            "value_json": json.dumps(
+                {
+                    "query_version": self.query_version,
+                    "trace_processor_sha256": trace_processor_sha256,
+                    "normalized_slice_count": len(events),
+                    "truncated": response.get("truncated") is True,
+                },
+                allow_nan=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            "file": None,
+            "line_from": None,
+            "line_to": None,
+            "context": "extractor_provenance",
+            "evidence_level": "observed",
+        }
+        if operator_observation_rows or trace_event_observation_rows:
+            evidence_rows["observations"] = [
+                extraction_observation,
+                *operator_observation_rows,
+                *trace_event_observation_rows,
+            ]
+        else:
+            evidence_rows["observations"] = [extraction_observation]
+        published = self.publisher.publish_rows_idempotent(
             evidence_rows,
             publisher=self.name,
             publisher_version=self.version,
             input_run_ids=(run_id,),
             input_artifact_ids=(registration.artifact_id,),
+            operation_identity={
+                "query_version": self.query_version,
+                "trace_processor_sha256": trace_processor_sha256,
+                "max_slices": max_slices,
+            },
         )
         return PerfettoExtractionResult(
             run_id=run_id,
             artifact_id=registration.artifact_id,
             trace_processor_path=str(binary),
+            trace_processor_sha256=trace_processor_sha256,
+            query_version=self.query_version,
             slice_count=len(events),
             frame_count=len(frame_by_id),
             call_edge_count=len(edge_rows),
             representative_stack_count=len(stack_rows),
+            trace_event_count=len(trace_event_observation_rows),
+            truncated=response.get("truncated") is True,
             corpus_commit_id=published.commit.commit_id,
             limitations=(
                 "Slice duration is inclusive and nested slices can overlap.",
                 "Parent-child edges reflect trace nesting, not causal dependence.",
                 "Complete temporal detail remains in the native trace.",
+                *(
+                    (
+                        "Normalized extraction reached the generation row budget; later slices "
+                        "remain only in the native trace.",
+                    )
+                    if response.get("truncated") is True
+                    else ()
+                ),
             ),
         )
+
+    @staticmethod
+    def _trace_registration(
+        artifacts: tuple[ArtifactRegistration, ...],
+        artifact_id: str | None,
+        *,
+        run_id: str,
+    ) -> ArtifactRegistration:
+        registrations = [
+            item
+            for item in artifacts
+            if item.kind in {ArtifactKind.EXECUTION_TRACE, ArtifactKind.SAMPLE_PROFILE}
+        ]
+        available_artifact_ids = [item.artifact_id for item in registrations]
+        if artifact_id is not None:
+            registrations = [item for item in registrations if item.artifact_id == artifact_id]
+        if len(registrations) == 1:
+            return registrations[0]
+        if artifact_id is not None:
+            message = "The selected Perfetto-compatible trace artifact was not found on the run."
+        elif registrations:
+            message = "The run contains multiple Perfetto-compatible traces; select one."
+        else:
+            message = "The run contains no Perfetto-compatible trace."
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            message,
+            run_id=run_id,
+            details={
+                "artifact_ids": available_artifact_ids,
+                "next_tool": "extract_perfetto",
+            },
+            remediation=("Pass one execution-trace artifact_id from the run artifact list.",),
+        )
+
+    @staticmethod
+    def _normalized_phases(rows: list[object]) -> dict[int, str | None]:
+        row_by_id = {
+            int(row["id"]): row
+            for row in rows
+            if isinstance(row, dict) and row.get("id") is not None
+        }
+        normalized: dict[int, str | None] = {}
+        for event_id, row in row_by_id.items():
+            explicit = row.get("phase")
+            selected: str | None = str(explicit) if explicit is not None else None
+            cursor: int | None = event_id
+            seen: set[int] = set()
+            while selected is None and cursor is not None and cursor not in seen:
+                seen.add(cursor)
+                ancestor = row_by_id.get(cursor)
+                if ancestor is None:
+                    break
+                ancestor_name = str(ancestor.get("name") or "")
+                if ancestor_name.startswith("flameox.phase:"):
+                    candidate = ancestor_name.removeprefix("flameox.phase:")
+                    selected = candidate or None
+                    break
+                parent_id = ancestor.get("parent_id")
+                cursor = int(parent_id) if parent_id is not None else None
+            normalized[event_id] = selected
+        return normalized
 
     async def trace_window(
         self,

--- a/src/flameox/adapters/torch_profiler.py
+++ b/src/flameox/adapters/torch_profiler.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field, StrictBool, StrictInt, ValidationError, model_validator
+
+from flameox.domain import DomainError, ErrorCode
+from flameox.models import ContractModel
+
+
+class TorchProfilerSchedule(ContractModel):
+    wait: StrictInt = Field(default=1, ge=0, le=10_000)
+    warmup: StrictInt = Field(default=1, ge=0, le=10_000)
+    active: StrictInt = Field(default=1, ge=1, le=10_000)
+    repeat: StrictInt = Field(default=1, ge=1, le=100)
+    skip_first: StrictInt = Field(default=0, ge=0, le=10_000)
+
+
+class TorchProfilerCaptureOptions(ContractModel):
+    mode: Literal["whole_entrypoint", "sdk"] = "whole_entrypoint"
+    activities: tuple[Literal["cpu", "cuda", "cuda_if_available"], ...] = (
+        "cpu",
+        "cuda_if_available",
+    )
+    record_shapes: StrictBool = True
+    profile_memory: StrictBool = True
+    with_stack: StrictBool = True
+    with_flops: StrictBool = False
+    with_modules: StrictBool = False
+    schedule: TorchProfilerSchedule | None = None
+
+    @model_validator(mode="after")
+    def validate_mode(self) -> TorchProfilerCaptureOptions:
+        if not self.activities:
+            raise ValueError("at least one torch.profiler activity is required")
+        if len(set(self.activities)) != len(self.activities):
+            raise ValueError("torch.profiler activities must be unique")
+        if {"cuda", "cuda_if_available"}.issubset(self.activities):
+            raise ValueError("choose either cuda or cuda_if_available, not both")
+        if self.mode == "whole_entrypoint" and self.schedule is not None:
+            raise ValueError(
+                "a torch.profiler schedule requires SDK mode and explicit profile.step() calls"
+            )
+        if self.mode == "sdk" and self.schedule is None:
+            raise ValueError("SDK mode requires an explicit bounded torch.profiler schedule")
+        return self
+
+    @property
+    def expected_cycles(self) -> int:
+        return self.schedule.repeat if self.schedule is not None else 1
+
+    @property
+    def output_filenames(self) -> tuple[str, ...]:
+        if self.mode == "whole_entrypoint":
+            return ("torch-trace.json",)
+        return tuple(f"torch-trace-cycle-{cycle:04d}.json" for cycle in range(self.expected_cycles))
+
+
+def torch_profiler_options(
+    value: dict[str, object] | None,
+) -> TorchProfilerCaptureOptions:
+    try:
+        return TorchProfilerCaptureOptions.model_validate(value or {})
+    except ValidationError as exc:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "Invalid torch.profiler capture options.",
+            details={"validation_errors": exc.errors(include_url=False)},
+            remediation=(
+                "Use mode='whole_entrypoint' without a schedule, or mode='sdk' with a "
+                "bounded wait/warmup/active/repeat schedule and explicit profile.step() calls.",
+            ),
+        ) from exc

--- a/src/flameox/analysis/__init__.py
+++ b/src/flameox/analysis/__init__.py
@@ -1,5 +1,9 @@
 from flameox.analysis.comparison import compare_paired_samples
 from flameox.analysis.recipes import (
+    AcceleratorLaunchAnalysisResult,
+    AcceleratorLaunchComparison,
+    AcceleratorLaunchRegion,
+    AcceleratorStreamSummary,
     ExecutionAnalysisResult,
     ExecutionObservationChange,
     FailureAnalysisResult,
@@ -7,6 +11,7 @@ from flameox.analysis.recipes import (
     FailureCluster,
     Hotspot,
     HotspotResult,
+    KernelNameCount,
     MeasurementSummary,
     MemoryAnalysisResult,
     MemoryPhaseGrowth,
@@ -21,6 +26,10 @@ from flameox.analysis.recipes import (
 )
 
 __all__ = [
+    "AcceleratorLaunchAnalysisResult",
+    "AcceleratorLaunchComparison",
+    "AcceleratorLaunchRegion",
+    "AcceleratorStreamSummary",
     "ExecutionAnalysisResult",
     "ExecutionObservationChange",
     "FailureAnalysisResult",
@@ -28,6 +37,7 @@ __all__ = [
     "FailureCluster",
     "Hotspot",
     "HotspotResult",
+    "KernelNameCount",
     "MeasurementSummary",
     "MemoryAnalysisResult",
     "MemoryPhaseGrowth",

--- a/src/flameox/analysis/recipes.py
+++ b/src/flameox/analysis/recipes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import warnings
+from collections import Counter, defaultdict
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -191,6 +192,78 @@ class PyTorchAnalysisResult(ContractModel):
     evidence: EvidenceAvailability = Field(default_factory=available_availability)
 
 
+class KernelNameCount(ContractModel):
+    name: str
+    count: int
+
+
+class AcceleratorStreamSummary(ContractModel):
+    identity: str
+    device: str | None = None
+    context: str | None = None
+    stream: str | None = None
+    track_id: str | None = None
+    kernel_count: int
+    kernel_duration_ns: int
+    idle_gap_count: int
+    idle_gap_total_ns: int
+    idle_gap_max_ns: int
+
+
+class AcceleratorLaunchRegion(ContractModel):
+    region: str
+    region_start_ns: int
+    region_end_ns: int
+    region_duration_ns: int
+    selection_rule: str
+    direct_launch_count: int
+    direct_launch_duration_ns: int
+    graph_launch_count: int
+    graph_launch_duration_ns: int
+    kernel_count: int
+    kernel_duration_ns: int
+    kernel_names: tuple[KernelNameCount, ...]
+    kernel_names_truncated: bool
+    correlated_kernel_count: int
+    runtime_launch_gap_count: int
+    runtime_launch_gap_total_ns: int
+    runtime_launch_gap_max_ns: int
+    idle_gap_count: int
+    idle_gap_total_ns: int
+    idle_gap_max_ns: int
+    stream_count: int
+    streams: tuple[AcceleratorStreamSummary, ...]
+    streams_truncated: bool
+
+
+class AcceleratorLaunchComparison(ContractModel):
+    region: str
+    direct_launch_count_delta: int
+    graph_launch_count_delta: int
+    kernel_count_delta: int
+    kernel_duration_delta_ns: int
+    runtime_launch_gap_total_delta_ns: int
+    idle_gap_total_delta_ns: int
+
+
+class AcceleratorLaunchAnalysisResult(ContractModel):
+    schema_version: int = 1
+    corpus_commit_id: str
+    input_id: str
+    comparison_input_id: str | None = None
+    phase_filter: str | None = None
+    regions: tuple[AcceleratorLaunchRegion, ...]
+    comparison_regions: tuple[AcceleratorLaunchRegion, ...] = ()
+    comparisons: tuple[AcceleratorLaunchComparison, ...] = ()
+    total: int
+    returned: int
+    truncated: bool
+    coverage: dict[str, bool]
+    comparison_coverage: dict[str, bool] | None = None
+    limitations: tuple[str, ...]
+    evidence: EvidenceAvailability = Field(default_factory=available_availability)
+
+
 class FailureCluster(ContractModel):
     collector: str | None
     execution_status: str
@@ -318,6 +391,51 @@ class ScalingAnalysisResult(ContractModel):
         "Points are per-trial medians; statistical decisions belong to frozen run-set comparisons.",
     )
     evidence: EvidenceAvailability = Field(default_factory=available_availability)
+
+
+def _trace_integer(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _accelerator_stream_key(value: dict[str, Any]) -> str:
+    stream = value.get("stream")
+    if stream not in {None, ""}:
+        return "/".join(
+            (
+                f"device:{value.get('device', 'unknown')}",
+                f"context:{value.get('context', 'unknown')}",
+                f"stream:{stream}",
+            )
+        )
+    track = value.get("track_id")
+    return f"track:{track if track not in {None, ''} else 'unknown'}"
+
+
+def _runtime_track_key(value: dict[str, Any]) -> str:
+    for field in ("track_id", "thread", "process", "thread_name"):
+        identity = value.get(field)
+        if identity not in {None, ""}:
+            return f"{field}:{identity}"
+    return "runtime:unknown"
+
+
+def _positive_gaps(events: list[tuple[int, int]]) -> list[int]:
+    gaps: list[int] = []
+    cursor: int | None = None
+    for start, duration in sorted(events):
+        if cursor is not None and start > cursor:
+            gaps.append(start - cursor)
+        cursor = max(cursor if cursor is not None else start, start + duration)
+    return gaps
 
 
 class RecipeService:
@@ -1079,6 +1197,391 @@ class RecipeService:
                 if total == 0
                 else available_availability()
             ),
+        )
+
+    def accelerator_launches(
+        self,
+        input_id: str,
+        *,
+        comparison_input_id: str | None = None,
+        phase: str | None = None,
+        limit: int | None = None,
+        corpus_commit_id: str | None = None,
+    ) -> AcceleratorLaunchAnalysisResult:
+        corpus_commit_id = self._pinned_commit_id(corpus_commit_id)
+        bounded = self._limit(limit)
+        with self._open_snapshot(corpus_commit_id) as snapshot:
+            regions, total, coverage, limitations = self._accelerator_launch_regions(
+                snapshot,
+                input_id,
+                phase=phase,
+                limit=bounded,
+            )
+            comparison_regions: tuple[AcceleratorLaunchRegion, ...] = ()
+            comparison_coverage: dict[str, bool] | None = None
+            if comparison_input_id is not None:
+                (
+                    comparison_regions,
+                    _,
+                    comparison_coverage,
+                    comparison_limitations,
+                ) = self._accelerator_launch_regions(
+                    snapshot,
+                    comparison_input_id,
+                    phase=phase,
+                    limit=bounded,
+                )
+                limitations = (
+                    *limitations,
+                    *(f"Comparison input: {item}" for item in comparison_limitations),
+                )
+        primary_by_region = {item.region: item for item in regions}
+        comparison_by_region = {item.region: item for item in comparison_regions}
+        comparisons = tuple(
+            AcceleratorLaunchComparison(
+                region=region,
+                direct_launch_count_delta=(
+                    comparison_by_region[region].direct_launch_count
+                    - primary_by_region[region].direct_launch_count
+                ),
+                graph_launch_count_delta=(
+                    comparison_by_region[region].graph_launch_count
+                    - primary_by_region[region].graph_launch_count
+                ),
+                kernel_count_delta=(
+                    comparison_by_region[region].kernel_count
+                    - primary_by_region[region].kernel_count
+                ),
+                kernel_duration_delta_ns=(
+                    comparison_by_region[region].kernel_duration_ns
+                    - primary_by_region[region].kernel_duration_ns
+                ),
+                runtime_launch_gap_total_delta_ns=(
+                    comparison_by_region[region].runtime_launch_gap_total_ns
+                    - primary_by_region[region].runtime_launch_gap_total_ns
+                ),
+                idle_gap_total_delta_ns=(
+                    comparison_by_region[region].idle_gap_total_ns
+                    - primary_by_region[region].idle_gap_total_ns
+                ),
+            )
+            for region in sorted(primary_by_region.keys() & comparison_by_region.keys())
+        )
+        if comparison_input_id is not None:
+            limitations = (
+                *limitations,
+                "Launch-structure deltas are descriptive; they do not prove semantic "
+                "equivalence or causality.",
+            )
+        return AcceleratorLaunchAnalysisResult(
+            corpus_commit_id=corpus_commit_id,
+            input_id=input_id,
+            comparison_input_id=comparison_input_id,
+            phase_filter=phase,
+            regions=regions,
+            comparison_regions=comparison_regions,
+            comparisons=comparisons,
+            total=total,
+            returned=len(regions),
+            truncated=total > len(regions),
+            coverage=coverage,
+            comparison_coverage=comparison_coverage,
+            limitations=tuple(dict.fromkeys(limitations)),
+            evidence=(
+                empty_availability("no_matching_accelerator_launch_events")
+                if total == 0
+                else (
+                    EvidenceAvailability(
+                        status="partial",
+                        reason="runtime_or_accelerator_tracks_missing",
+                    )
+                    if not (
+                        coverage["runtime_launches"]
+                        and coverage["accelerator_kernels"]
+                        and (
+                            comparison_coverage is None
+                            or (
+                                comparison_coverage["runtime_launches"]
+                                and comparison_coverage["accelerator_kernels"]
+                            )
+                        )
+                    )
+                    else available_availability()
+                )
+            ),
+        )
+
+    def _accelerator_launch_regions(
+        self,
+        snapshot: Snapshot,
+        input_id: str,
+        *,
+        phase: str | None,
+        limit: int,
+    ) -> tuple[
+        tuple[AcceleratorLaunchRegion, ...],
+        int,
+        dict[str, bool],
+        tuple[str, ...],
+    ]:
+        scope = resolve_evidence_scope(snapshot, input_id)
+        where, parameters = scope.predicate(
+            run_column="run_id",
+            artifact_column="artifact_id",
+        )
+        rows = snapshot.execute(
+            "SELECT name, value_json, context FROM observations WHERE ("
+            + where
+            + ") AND kind = 'trace.event' ORDER BY observation_id",
+            parameters,
+        ).fetchall()
+        if not rows:
+            producer_rows = (
+                snapshot.execute(
+                    "SELECT DISTINCT producer FROM artifact_registrations "
+                    "WHERE artifact_id IN (" + ", ".join("?" for _ in scope.artifact_ids) + ")",
+                    scope.artifact_ids,
+                ).fetchall()
+                if scope.artifact_ids
+                else ()
+            )
+            producers = {str(row[0]).casefold() for row in producer_rows if row[0] is not None}
+            next_tool = (
+                "extract_nsight_systems"
+                if producers & {"nsight.systems", "nsys"}
+                else "extract_perfetto"
+            )
+            details: dict[str, object] = {"next_tool": next_tool}
+            if scope.run_ids:
+                details["run_id"] = scope.run_ids[0]
+            raise DomainError(
+                ErrorCode.CAPABILITY_UNAVAILABLE,
+                "Accelerator launch analysis requires current normalized trace-event evidence.",
+                details=details,
+                remediation=(
+                    f"Call {next_tool} for the reported run, then retry "
+                    "analyze_accelerator_launches.",
+                ),
+            )
+        events_by_region: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+        trace_phase_present = False
+        correlation_present = False
+        stream_present = False
+        for name, value_json, context in rows:
+            try:
+                value = json.loads(str(value_json))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+            if not isinstance(value, dict):
+                continue
+            phase_value = context or value.get("phase")
+            normalized_phase = str(phase_value) if phase_value not in {None, ""} else "<unscoped>"
+            trace_phase_present = trace_phase_present or normalized_phase != "<unscoped>"
+            if phase is not None and normalized_phase != phase:
+                continue
+            artifact_role = str(value.get("artifact_role") or "")
+            cycle = (
+                artifact_role if artifact_role.startswith(("cycle_", "partial_cycle_")) else None
+            )
+            region = f"{cycle}/{normalized_phase}" if cycle is not None else normalized_phase
+            correlation_present = correlation_present or value.get("correlation_id") not in {
+                None,
+                "",
+            }
+            stream_present = stream_present or value.get("stream") not in {None, ""}
+            events_by_region[region].append((str(name), value))
+        summaries = tuple(
+            self._summarize_accelerator_region(region, events, limit=limit)
+            for region, events in sorted(events_by_region.items())
+        )
+        runtime_present = any(
+            item.direct_launch_count or item.graph_launch_count for item in summaries
+        )
+        accelerator_present = any(item.kernel_count for item in summaries)
+        kernel_count = sum(item.kernel_count for item in summaries)
+        correlated_kernel_count = sum(item.correlated_kernel_count for item in summaries)
+        matched_correlation_present = correlated_kernel_count > 0
+        limitations = [
+            "Launch and kernel counts are observed trace events; matching counts or names do "
+            "not prove equivalent computation.",
+            "A gap is the positive uncovered interval between consecutive observed slices on "
+            "the same runtime track or accelerator stream; zero and overlap are not gaps.",
+        ]
+        if not trace_phase_present:
+            limitations.append(
+                "The trace contains no phase annotations; events are grouped as <unscoped>."
+            )
+        elif phase is not None and not summaries:
+            limitations.append(f"No normalized trace events matched phase {phase!r}.")
+        if not correlation_present:
+            limitations.append(
+                "Runtime-to-kernel correlation identifiers were unavailable in normalized evidence."
+            )
+        elif correlated_kernel_count < kernel_count:
+            limitations.append(
+                f"Correlation identifiers covered {correlated_kernel_count} of "
+                f"{kernel_count} selected kernels."
+            )
+        if not runtime_present:
+            limitations.append(
+                "No recognized direct or CUDA Graph runtime launch events were found."
+            )
+        if not accelerator_present:
+            limitations.append("No recognized accelerator kernel events were found.")
+        return (
+            summaries[:limit],
+            len(summaries),
+            {
+                "runtime_launches": runtime_present,
+                "accelerator_kernels": accelerator_present,
+                "phase_annotations": trace_phase_present,
+                "correlation_ids": correlation_present,
+                "host_to_device_correlation": matched_correlation_present,
+                "stream_identity": stream_present,
+            },
+            tuple(limitations),
+        )
+
+    @staticmethod
+    def _summarize_accelerator_region(
+        region: str,
+        events: list[tuple[str, dict[str, Any]]],
+        *,
+        limit: int,
+    ) -> AcceleratorLaunchRegion:
+        direct: list[dict[str, Any]] = []
+        graph: list[dict[str, Any]] = []
+        kernels: list[tuple[str, dict[str, Any]]] = []
+        for name, value in events:
+            normalized_name = "".join(
+                character for character in name.casefold() if character.isalnum()
+            )
+            category = str(value.get("category") or "").casefold()
+            runtime_api = "runtime" in category or "driver" in category
+            if runtime_api:
+                if "graphlaunch" in normalized_name:
+                    graph.append(value)
+                elif any(
+                    token in normalized_name
+                    for token in (
+                        "cudalaunchkernel",
+                        "cudalaunchcooperativekernel",
+                        "culaunchkernel",
+                        "culaunchcooperativekernel",
+                        "hiplaunchkernel",
+                        "hipmodulelaunchkernel",
+                    )
+                ):
+                    direct.append(value)
+            if "kernel" in category and "runtime" not in category:
+                kernels.append((name, value))
+
+        kernel_names = Counter(name for name, _ in kernels)
+        selected_names = tuple(
+            KernelNameCount(name=name, count=count)
+            for name, count in sorted(
+                kernel_names.items(),
+                key=lambda item: (-item[1], item[0]),
+            )[:limit]
+        )
+        kernels_by_stream: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        stream_identity: dict[str, dict[str, str | None]] = {}
+        for _, value in kernels:
+            start = _trace_integer(value.get("start_ns"))
+            duration = _trace_integer(value.get("duration_ns"))
+            if start is None or duration is None:
+                continue
+            stream_key = _accelerator_stream_key(value)
+            kernels_by_stream[stream_key].append((start, duration))
+            stream_identity.setdefault(
+                stream_key,
+                {
+                    field: (str(value[field]) if value.get(field) not in {None, ""} else None)
+                    for field in ("device", "context", "stream", "track_id")
+                },
+            )
+        stream_summaries: list[AcceleratorStreamSummary] = []
+        for stream_key, stream_events in sorted(kernels_by_stream.items()):
+            stream_gaps = _positive_gaps(stream_events)
+            identity = stream_identity[stream_key]
+            stream_summaries.append(
+                AcceleratorStreamSummary(
+                    identity=stream_key,
+                    device=identity["device"],
+                    context=identity["context"],
+                    stream=identity["stream"],
+                    track_id=identity["track_id"],
+                    kernel_count=len(stream_events),
+                    kernel_duration_ns=sum(duration for _, duration in stream_events),
+                    idle_gap_count=len(stream_gaps),
+                    idle_gap_total_ns=sum(stream_gaps),
+                    idle_gap_max_ns=max(stream_gaps, default=0),
+                )
+            )
+        gaps = [
+            gap
+            for stream_events in kernels_by_stream.values()
+            for gap in _positive_gaps(stream_events)
+        ]
+        runtime_by_track: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        for value in (*direct, *graph):
+            start = _trace_integer(value.get("start_ns"))
+            duration = _trace_integer(value.get("duration_ns"))
+            if start is None or duration is None:
+                continue
+            runtime_by_track[_runtime_track_key(value)].append((start, duration))
+        runtime_gaps = [
+            gap
+            for track_events in runtime_by_track.values()
+            for gap in _positive_gaps(track_events)
+        ]
+        runtime_correlation_ids = {
+            str(value["correlation_id"])
+            for value in (*direct, *graph)
+            if value.get("correlation_id") not in {None, ""}
+        }
+        starts_and_ends = [
+            (start, start + duration)
+            for _, value in events
+            if (start := _trace_integer(value.get("start_ns"))) is not None
+            and (duration := _trace_integer(value.get("duration_ns"))) is not None
+        ]
+        region_start = min((start for start, _ in starts_and_ends), default=0)
+        region_end = max((end for _, end in starts_and_ends), default=region_start)
+        return AcceleratorLaunchRegion(
+            region=region,
+            region_start_ns=region_start,
+            region_end_ns=region_end,
+            region_duration_ns=max(0, region_end - region_start),
+            selection_rule="exact normalized phase or cycle/phase grouping",
+            direct_launch_count=len(direct),
+            direct_launch_duration_ns=sum(
+                _trace_integer(item.get("duration_ns")) or 0 for item in direct
+            ),
+            graph_launch_count=len(graph),
+            graph_launch_duration_ns=sum(
+                _trace_integer(item.get("duration_ns")) or 0 for item in graph
+            ),
+            kernel_count=len(kernels),
+            kernel_duration_ns=sum(
+                _trace_integer(item.get("duration_ns")) or 0 for _, item in kernels
+            ),
+            kernel_names=selected_names,
+            kernel_names_truncated=len(kernel_names) > len(selected_names),
+            correlated_kernel_count=sum(
+                str(item["correlation_id"]) in runtime_correlation_ids
+                for _, item in kernels
+                if item.get("correlation_id") not in {None, ""}
+            ),
+            runtime_launch_gap_count=len(runtime_gaps),
+            runtime_launch_gap_total_ns=sum(runtime_gaps),
+            runtime_launch_gap_max_ns=max(runtime_gaps, default=0),
+            idle_gap_count=len(gaps),
+            idle_gap_total_ns=sum(gaps),
+            idle_gap_max_ns=max(gaps, default=0),
+            stream_count=len(kernels_by_stream),
+            streams=tuple(stream_summaries[:limit]),
+            streams_truncated=len(stream_summaries) > limit,
         )
 
     def failures(

--- a/src/flameox/application/analysis_records.py
+++ b/src/flameox/application/analysis_records.py
@@ -7,6 +7,7 @@ from typing import Literal
 from pydantic import Field, model_validator
 
 from flameox.analysis import (
+    AcceleratorLaunchAnalysisResult,
     ExecutionAnalysisResult,
     FailureAnalysisResult,
     HotspotResult,
@@ -33,6 +34,7 @@ from flameox.models import ContractModel
 from flameox.storage import ArtifactStore, GenerationManifest, Workspace
 
 AnalysisRecipe = Literal[
+    "accelerator_launches",
     "hotspots",
     "memory",
     "execution",
@@ -41,7 +43,8 @@ AnalysisRecipe = Literal[
     "scaling",
 ]
 AnalysisValue = (
-    HotspotResult
+    AcceleratorLaunchAnalysisResult
+    | HotspotResult
     | MemoryAnalysisResult
     | ExecutionAnalysisResult
     | PyTorchAnalysisResult
@@ -56,6 +59,7 @@ class MaterializeAnalysisRequest(ContractModel):
     comparison_input_id: str | None = None
     experiment_id: str | None = None
     limit: int | None = Field(default=None, ge=1, le=1_000)
+    phase: str | None = Field(default=None, min_length=1, max_length=200)
 
     @model_validator(mode="after")
     def validate_scope(self) -> MaterializeAnalysisRequest:
@@ -75,8 +79,15 @@ class MaterializeAnalysisRequest(ContractModel):
                 raise ValueError("failures uses the pinned corpus population")
         elif self.input_id is None or self.experiment_id is not None:
             raise ValueError(f"{self.recipe} requires only input_id")
-        elif self.comparison_input_id is not None and self.recipe != "execution":
-            raise ValueError("comparison_input_id is supported only by execution")
+        elif self.comparison_input_id is not None and self.recipe not in {
+            "execution",
+            "accelerator_launches",
+        }:
+            raise ValueError(
+                "comparison_input_id is supported only by execution and accelerator_launches"
+            )
+        if self.phase is not None and self.recipe != "accelerator_launches":
+            raise ValueError("phase is supported only by accelerator_launches")
         return self
 
 
@@ -258,6 +269,14 @@ class AnalysisMaterializationService:
             assert request.input_id is not None
             return recipes.pytorch(
                 request.input_id,
+                limit=request.limit,
+            )
+        if request.recipe == "accelerator_launches":
+            assert request.input_id is not None
+            return recipes.accelerator_launches(
+                request.input_id,
+                comparison_input_id=request.comparison_input_id,
+                phase=request.phase,
                 limit=request.limit,
             )
         if request.recipe == "failures":

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -24,6 +24,7 @@ from flameox.adapters.builtins import (
     builtin_adapter,
 )
 from flameox.adapters.registry import AdapterRegistry
+from flameox.adapters.torch_profiler import torch_profiler_options
 from flameox.application.async_work import run_atomic_thread
 from flameox.application.capabilities import CapabilityService
 from flameox.application.environment import AcceleratorIdentityService, collect_environment
@@ -162,6 +163,7 @@ class _AdapterBinding:
     artifact_kinds: tuple[ArtifactKind, ...]
     expected_overhead: str
     limitations: tuple[str, ...]
+    environment: dict[str, str]
     limitation_details: tuple[LimitationDetail, ...]
     permissions: tuple[str, ...]
     version: str | None
@@ -385,6 +387,7 @@ class CaptureService:
         workload_name: str,
         adapter: str,
         parameters: dict[str, Scalar] | None = None,
+        adapter_options: dict[str, JsonValue] | None = None,
         execution_policy: ExecutionPolicy,
         preflight_mode: Literal["auto", "passive", "active"] = "auto",
         external_context: ExternalExecutionContext | None = None,
@@ -452,12 +455,25 @@ class CaptureService:
         collector_environment = {
             "FLAMEOX_OBSERVATIONS_PATH": str(output_root / "observations.jsonl")
         }
+        if adapter == "torch.profiler":
+            bound_adapter_options = torch_profiler_options(
+                cast(dict[str, object] | None, adapter_options)
+            ).model_dump(mode="json")
+        elif adapter_options:
+            raise DomainError(
+                ErrorCode.INVALID_CAPTURE_PLAN,
+                f"Adapter {adapter!r} does not accept capture options.",
+            )
+        else:
+            bound_adapter_options = {}
         adapter_binding = await self._adapter_command(
             adapter,
             instance.command,
             output_root,
             capability=adapter_capability,
+            options=bound_adapter_options,
         )
+        collector_environment.update(adapter_binding.environment)
         collector_argv = adapter_binding.argv
         kinds = adapter_binding.artifact_kinds
         overhead = adapter_binding.expected_overhead
@@ -514,6 +530,7 @@ class CaptureService:
             "workload_definition_id": definition.workload_definition_id,
             "instance": instance.model_dump(mode="json"),
             "adapter": adapter,
+            "adapter_options": bound_adapter_options,
             "adapter_version": adapter_version,
             "adapter_execution_plan": (
                 adapter_binding.execution_plan.model_dump(mode="json")
@@ -550,6 +567,7 @@ class CaptureService:
             workload_definition_id=definition.workload_definition_id,
             workload_instance=instance,
             adapter=adapter,
+            adapter_options=bound_adapter_options,
             adapter_version=adapter_version,
             adapter_execution_plan=(
                 adapter_binding.execution_plan.model_dump(mode="json")
@@ -650,6 +668,7 @@ class CaptureService:
             measurement_protocol_id=digest_model(
                 {
                     "adapter": plan.adapter,
+                    "adapter_options": plan.adapter_options,
                     "adapter_version": plan.adapter_version,
                     "collector_executable_identity": plan.bound_identities.get(
                         "collector_executable"
@@ -803,12 +822,12 @@ class CaptureService:
                 if "process" in error.details
                 else None
             )
-            native = self._native_output_path(plan, output_root)
+            native_paths = self._native_output_paths(plan, output_root)
+            valid_native_paths = self._valid_native_output_paths(plan, output_root)
             if (
                 status is ExecutionStatus.TIMED_OUT
                 and partial_process is not None
-                and native is not None
-                and self._native_output_is_valid(plan, output_root)
+                and valid_native_paths
             ):
                 outcome = ExecutionOutcome(
                     process=partial_process,
@@ -865,8 +884,14 @@ class CaptureService:
             )
 
         collector_succeeded = outcome.process.exit_code == 0
-        native = self._native_output_path(plan, output_root)
-        native_valid = self._native_output_is_valid(plan, output_root)
+        native_paths = self._native_output_paths(plan, output_root)
+        valid_native_paths = self._valid_native_output_paths(plan, output_root)
+        unexpected_native_paths = self._unexpected_native_output_paths(plan, output_root)
+        native_complete = bool(native_paths) and (
+            len(valid_native_paths) == len(native_paths)
+            and not unexpected_native_paths
+            and self._native_output_manifest_is_valid(plan, output_root)
+        )
         native_definition = builtin_adapter(plan.adapter)
         preserve_nonzero_artifact = bool(
             native_definition is not None and native_definition.preserve_artifact_on_nonzero
@@ -880,7 +905,7 @@ class CaptureService:
                 )
             )
         if (
-            native is not None
+            native_paths
             and not collector_succeeded
             and not outcome.process.timed_out
             and not preserve_nonzero_artifact
@@ -896,12 +921,13 @@ class CaptureService:
             )
             if quarantined is not None:
                 collector_limitation_details.append(quarantined)
-            native_valid = False
-        elif native is not None and not native_valid:
+            valid_native_paths = ()
+            native_complete = False
+        elif native_paths and not native_complete and not outcome.process.timed_out:
             reason = (
-                "Collector completed without the expected native output."
-                if not native.exists()
-                else "Collector completed with an empty or non-regular native output."
+                "Collector completed without every expected native output."
+                if not any(path.exists() for path in native_paths)
+                else "Collector emitted an incomplete, extra, empty, or non-regular output set."
             )
             quarantined = await run_atomic_thread(
                 lambda: self._quarantine_native_output(plan, output_root, reason=reason)
@@ -911,7 +937,8 @@ class CaptureService:
             collector_limitation_details.append(
                 _limitation("artifact", "expected_output_invalid", reason)
             )
-        if native is not None and outcome.process.timed_out and native_valid:
+            valid_native_paths = ()
+        if native_paths and outcome.process.timed_out and valid_native_paths:
             collector_limitation_details.append(
                 _limitation(
                     "collector",
@@ -1166,16 +1193,45 @@ class CaptureService:
                                 )
                             )
             else:
-                if native is not None and native_valid:
+                for native in valid_native_paths:
+                    cycle_index = native_paths.index(native)
+                    if outcome.process.timed_out:
+                        role = (
+                            f"partial_cycle_{cycle_index:04d}"
+                            if len(native_paths) > 1
+                            else "partial"
+                        )
+                    elif len(native_paths) > 1:
+                        role = f"cycle_{cycle_index:04d}"
+                    else:
+                        role = "primary"
                     registrations.append(
                         await self._register_path_async(
                             run_id,
                             native,
                             kind=plan.expected_artifact_kinds[0],
-                            role=("partial" if outcome.process.timed_out else "primary"),
+                            role=role,
                             media_type=(
                                 mimetypes.guess_type(native.name)[0] or "application/octet-stream"
                             ),
+                            producer=plan.adapter,
+                            producer_version=plan.adapter_version,
+                        )
+                    )
+                manifest = output_root / "torch-profiler-cycles.json"
+                if (
+                    plan.adapter == "torch.profiler"
+                    and torch_profiler_options(cast(dict[str, object], plan.adapter_options)).mode
+                    == "sdk"
+                    and native_complete
+                ):
+                    registrations.append(
+                        await self._register_path_async(
+                            run_id,
+                            manifest,
+                            kind=ArtifactKind.COLLECTOR_METADATA,
+                            role="torch_profiler_cycle_manifest",
+                            media_type="application/json",
                             producer=plan.adapter,
                             producer_version=plan.adapter_version,
                         )
@@ -1304,9 +1360,9 @@ class CaptureService:
                 "capture_status": (
                     CaptureStatus.REGISTERED
                     if (
-                        (succeeded and (native is None or native_valid))
-                        or (preserve_nonzero_artifact and native_valid)
-                        or (timed_out and native_valid)
+                        (succeeded and (not native_paths or native_complete))
+                        or (preserve_nonzero_artifact and bool(valid_native_paths))
+                        or (timed_out and bool(valid_native_paths))
                     )
                     else CaptureStatus.FAILED
                 ),
@@ -1546,21 +1602,75 @@ class CaptureService:
             return False
         return True
 
-    def _native_output_path(self, plan: CapturePlan, output_root: Path) -> Path | None:
+    def _native_output_paths(self, plan: CapturePlan, output_root: Path) -> tuple[Path, ...]:
         definition = builtin_adapter(plan.adapter)
         if definition is None or plan.adapter == "command" or definition.output_filename is None:
-            return None
-        return output_root / definition.output_filename
+            return ()
+        if plan.adapter == "torch.profiler":
+            options = torch_profiler_options(cast(dict[str, object], plan.adapter_options))
+            return tuple(output_root / filename for filename in options.output_filenames)
+        return (output_root / definition.output_filename,)
 
-    def _native_output_is_valid(self, plan: CapturePlan, output_root: Path) -> bool:
-        path = self._native_output_path(plan, output_root)
-        if path is None:
-            return True
+    def _valid_native_output_paths(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+    ) -> tuple[Path, ...]:
+        return tuple(
+            path
+            for path in self._native_output_paths(plan, output_root)
+            if self._native_output_is_valid(path)
+        )
+
+    @staticmethod
+    def _native_output_is_valid(path: Path) -> bool:
         try:
             metadata = path.stat()
             return not path.is_symlink() and stat.S_ISREG(metadata.st_mode) and metadata.st_size > 0
         except OSError:
             return False
+
+    def _unexpected_native_output_paths(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+    ) -> tuple[Path, ...]:
+        if plan.adapter != "torch.profiler":
+            return ()
+        options = torch_profiler_options(cast(dict[str, object], plan.adapter_options))
+        if options.mode != "sdk":
+            return ()
+        expected = set(self._native_output_paths(plan, output_root))
+        return tuple(
+            path
+            for path in sorted(output_root.glob("torch-trace-cycle-*.json"))
+            if path not in expected
+        )
+
+    def _native_output_manifest_is_valid(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+    ) -> bool:
+        if plan.adapter != "torch.profiler":
+            return True
+        options = torch_profiler_options(cast(dict[str, object], plan.adapter_options))
+        if options.mode != "sdk":
+            return True
+        path = output_root / "torch-profiler-cycles.json"
+        try:
+            if path.is_symlink() or path.stat().st_size > 65_536:
+                return False
+            payload = json.loads(path.read_text())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return False
+        if not isinstance(payload, dict):
+            return False
+        return payload == {
+            "schema_version": "flameox.torch-profiler-cycles.v1",
+            "expected_cycles": options.expected_cycles,
+            "files": list(options.output_filenames),
+        }
 
     def _quarantine_native_output(
         self,
@@ -1569,8 +1679,20 @@ class CaptureService:
         *,
         reason: str,
     ) -> LimitationDetail | None:
-        path = self._native_output_path(plan, output_root)
-        if path is None or not path.exists():
+        paths = tuple(
+            path
+            for path in (
+                *self._native_output_paths(plan, output_root),
+                *self._unexpected_native_output_paths(plan, output_root),
+                *(
+                    (output_root / "torch-profiler-cycles.json",)
+                    if plan.adapter == "torch.profiler"
+                    else ()
+                ),
+            )
+            if path.exists()
+        )
+        if not paths:
             return None
         definition = builtin_adapter(plan.adapter)
         expected_format = (
@@ -1578,20 +1700,23 @@ class CaptureService:
             if definition is not None and definition.supported_formats
             else None
         )
+        quarantine_ids: list[str] = []
         try:
-            manifest = QuarantineService(self.workspace).quarantine(
-                path,
-                operation="capture.native_output",
-                reason=reason,
-                expected_format=expected_format,
-                actual_format=(
-                    "symlink"
-                    if path.is_symlink()
-                    else ("regular_file" if path.is_file() else "non_regular_file")
-                ),
-                adapter=plan.adapter,
-                originating_run_id=plan.run_id,
-            )
+            for path in paths:
+                manifest = QuarantineService(self.workspace).quarantine(
+                    path,
+                    operation="capture.native_output",
+                    reason=reason,
+                    expected_format=expected_format,
+                    actual_format=(
+                        "symlink"
+                        if path.is_symlink()
+                        else ("regular_file" if path.is_file() else "non_regular_file")
+                    ),
+                    adapter=plan.adapter,
+                    originating_run_id=plan.run_id,
+                )
+                quarantine_ids.append(manifest.quarantine_id)
         except DomainError as error:
             return _limitation(
                 "artifact",
@@ -1601,7 +1726,8 @@ class CaptureService:
         return _limitation(
             "artifact",
             "native_output_quarantined",
-            f"Invalid {plan.adapter} output was quarantined ({manifest.quarantine_id}): {reason}",
+            f"Invalid {plan.adapter} output was quarantined "
+            f"({', '.join(quarantine_ids)}): {reason}",
         )
 
     def _quarantine_adapter_output(
@@ -1629,6 +1755,7 @@ class CaptureService:
         output_root: Path,
         *,
         capability: CapabilityReport | None = None,
+        options: dict[str, JsonValue] | None = None,
     ) -> _AdapterBinding:
         adapter_definition = builtin_adapter(adapter)
         if adapter_definition is not None:
@@ -1646,12 +1773,14 @@ class CaptureService:
                 workload.argv,
                 output_root,
                 executable=capability.executable,
+                options=cast(dict[str, object] | None, options),
             )
             return _AdapterBinding(
                 argv=invocation.argv,
                 artifact_kinds=invocation.artifact_kinds,
                 expected_overhead=invocation.expected_overhead,
                 limitations=invocation.limitations,
+                environment=invocation.environment,
                 limitation_details=tuple(
                     _limitation("adapter", "capture.limitation", message)
                     for message in invocation.limitations
@@ -1701,6 +1830,7 @@ class CaptureService:
             artifact_kinds=tuple(item.kind for item in execution_plan.artifacts),
             expected_overhead=execution_plan.expected_overhead,
             limitations=(*probe.limitations, *execution_plan.limitations),
+            environment={},
             limitation_details=tuple(
                 _limitation("adapter", "probe.limitation", message)
                 for message in (*probe.limitations, *execution_plan.limitations)
@@ -1932,6 +2062,7 @@ class CaptureService:
             "workload_definition_id": plan.workload_definition_id,
             "instance": plan.workload_instance.model_dump(mode="json"),
             "adapter": plan.adapter,
+            "adapter_options": plan.adapter_options,
             "adapter_version": plan.adapter_version,
             "adapter_execution_plan": plan.adapter_execution_plan,
             "execution_policy": plan.execution_policy,

--- a/src/flameox/application/evidence_query.py
+++ b/src/flameox/application/evidence_query.py
@@ -28,6 +28,7 @@ class MeasurementItem(ContractModel):
     variant_id: str | None
     order_in_block: int | None
     phase: str | None
+    dimensions: dict[str, str] = Field(default_factory=dict)
     evidence_level: str
 
 
@@ -120,7 +121,7 @@ class EvidenceQueryService:
                 "SELECT measurement_id, run_id, artifact_id, name, value_int, "
                 "value_float, unit, aggregation, scope, worker_id, "
                 "worker_run_index, value_index, loop_count, is_warmup, block_id, "
-                "variant_id, order_in_block, phase, evidence_level "
+                "variant_id, order_in_block, phase, dimensions, evidence_level "
                 "FROM measurements WHERE " + page_where + " ORDER BY measurement_id LIMIT ?",
                 (*page_parameters, bounded + 1),
             ).fetchall()
@@ -146,7 +147,8 @@ class EvidenceQueryService:
                 variant_id=row[15],
                 order_in_block=row[16],
                 phase=row[17],
-                evidence_level=row[18],
+                dimensions=dict(row[18] or {}),
+                evidence_level=row[19],
             )
             for row in selected
         )

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -18,8 +18,10 @@ from pydantic import BaseModel
 from flameox import __version__, setup_ui
 from flameox.adapters import (
     AdapterRegistry,
+    BenchmarkSamplesExtractor,
     CoverageExtractor,
     MemrayExtractor,
+    NsightSystemsExtractor,
     ObservationExtractor,
     PerfettoExtractor,
     PyPerfExtractor,
@@ -979,6 +981,13 @@ def capture_plan(
         str,
         typer.Option("--parameters", help="JSON object of declared scalar overrides."),
     ] = "{}",
+    adapter_options: Annotated[
+        str,
+        typer.Option(
+            "--adapter-options",
+            help="JSON object of adapter-specific capture options.",
+        ),
+    ] = "{}",
     workspace: WorkspaceOption = None,
     json_output: JsonOption = False,
 ) -> None:
@@ -989,10 +998,14 @@ def capture_plan(
             values = json.loads(parameters)
             if not isinstance(values, dict):
                 raise ValueError("parameters must be a JSON object")
+            options = json.loads(adapter_options)
+            if not isinstance(options, dict):
+                raise ValueError("adapter options must be a JSON object")
             return await CaptureService(_workspace(workspace)).plan(
                 workload_name=workload_name,
                 adapter=adapter,
                 parameters=values,
+                adapter_options=options,
                 execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
             )
         except (json.JSONDecodeError, ValueError) as exc:
@@ -1013,6 +1026,7 @@ def capture_run(
     adapter: Annotated[str, typer.Argument(help="Registered capture adapter.")],
     workload_name: Annotated[str, typer.Option("--workload")],
     parameters: Annotated[str, typer.Option("--parameters")] = "{}",
+    adapter_options: Annotated[str, typer.Option("--adapter-options")] = "{}",
     workspace: WorkspaceOption = None,
     json_output: JsonOption = False,
 ) -> None:
@@ -1022,11 +1036,15 @@ def capture_run(
         values = json.loads(parameters)
         if not isinstance(values, dict):
             raise ValueError("parameters must be a JSON object")
+        options = json.loads(adapter_options)
+        if not isinstance(options, dict):
+            raise ValueError("adapter options must be a JSON object")
         service = CaptureService(_workspace(workspace))
         plan = await service.plan(
             workload_name=workload_name,
             adapter=adapter,
             parameters=values,
+            adapter_options=options,
             execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
         )
         return await service.execute(plan.plan_id)
@@ -1481,6 +1499,34 @@ def analyze_pytorch(
     _emit(result, as_json=json_output)
 
 
+@analyze_app.command("accelerator-launches")
+def analyze_accelerator_launches(
+    input_id: Annotated[str, typer.Argument(help="Run or artifact identifier.")],
+    compare_to: Annotated[
+        str | None,
+        typer.Option("--compare-to", help="Optional comparison run or artifact."),
+    ] = None,
+    phase: Annotated[
+        str | None,
+        typer.Option("--phase", help="Exact normalized phase to select."),
+    ] = None,
+    limit: Annotated[int | None, typer.Option(min=1)] = None,
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Summarize direct launches, graph launches, kernels, and accelerator idle gaps."""
+    try:
+        result = RecipeService(_workspace(workspace)).accelerator_launches(
+            input_id,
+            comparison_input_id=compare_to,
+            phase=phase,
+            limit=limit,
+        )
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
 @analyze_app.command("failures")
 def analyze_failures(
     limit: Annotated[int | None, typer.Option(min=1)] = None,
@@ -1723,6 +1769,23 @@ def extract_pyperf(
     _emit(result, as_json=json_output)
 
 
+@extract_app.command("benchmark-samples")
+def extract_benchmark_samples(
+    run_id: Annotated[
+        str,
+        typer.Argument(help="Import run containing flameox benchmark-samples v1 JSON."),
+    ],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract producer-neutral raw benchmark samples and timing semantics."""
+    try:
+        result = BenchmarkSamplesExtractor(_workspace(workspace)).extract(run_id)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
 @extract_app.command("python-startup")
 def extract_python_startup(
     run_id: Annotated[str, typer.Argument(help="Run containing Python startup JSON.")],
@@ -1788,6 +1851,10 @@ def extract_perfetto(
         str,
         typer.Argument(help="Import run containing a Perfetto-compatible trace."),
     ],
+    artifact_id: Annotated[
+        str | None,
+        typer.Option("--artifact-id", help="Exact trace artifact for a multi-cycle run."),
+    ] = None,
     workspace: WorkspaceOption = None,
     json_output: JsonOption = False,
 ) -> None:
@@ -1795,7 +1862,31 @@ def extract_perfetto(
     try:
 
         async def run() -> BaseModel:
-            return await PerfettoExtractor(_workspace(workspace)).extract(run_id)
+            return await PerfettoExtractor(_workspace(workspace)).extract(
+                run_id,
+                artifact_id=artifact_id,
+            )
+
+        result = _run_async(run)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@extract_app.command("nsight-systems")
+def extract_nsight_systems(
+    run_id: Annotated[
+        str,
+        typer.Argument(help="Import run containing an official Nsight Systems SQLite export."),
+    ],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract a maintained, versioned subset of an Nsight Systems SQLite export."""
+    try:
+
+        async def run() -> BaseModel:
+            return await NsightSystemsExtractor(_workspace(workspace)).extract(run_id)
 
         result = _run_async(run)
     except DomainError as error:

--- a/src/flameox/collectors/torch_launcher.py
+++ b/src/flameox/collectors/torch_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import runpy
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ def main() -> None:
         description="Profile one declared Python entrypoint with torch.profiler."
     )
     parser.add_argument("--output", required=True)
+    parser.add_argument("--config", required=True)
     target = parser.add_mutually_exclusive_group(required=True)
     target.add_argument("--module")
     target.add_argument("--script")
@@ -27,9 +29,26 @@ def main() -> None:
         import torch
     except ImportError as exc:
         parser.error(f"PyTorch is unavailable: {exc}")
-    activities = [torch.profiler.ProfilerActivity.CPU]
-    if torch.cuda.is_available():
+    try:
+        config = json.loads(options.config)
+    except json.JSONDecodeError as exc:
+        parser.error(f"Invalid profiler configuration: {exc}")
+    if not isinstance(config, dict) or config.get("mode") != "whole_entrypoint":
+        parser.error("Whole-entrypoint launcher requires whole_entrypoint mode")
+    configured_activities = config.get("activities")
+    if not isinstance(configured_activities, list):
+        parser.error("Profiler activities are missing")
+    activities = []
+    if "cpu" in configured_activities:
+        activities.append(torch.profiler.ProfilerActivity.CPU)
+    if "cuda" in configured_activities and not torch.cuda.is_available():
+        parser.error("The capture plan requires CUDA, but CUDA is unavailable")
+    if "cuda" in configured_activities:
         activities.append(torch.profiler.ProfilerActivity.CUDA)
+    if "cuda_if_available" in configured_activities and torch.cuda.is_available():
+        activities.append(torch.profiler.ProfilerActivity.CUDA)
+    if not activities:
+        parser.error("No requested torch.profiler activity is available")
     output = Path(options.output)
     output.parent.mkdir(parents=True, exist_ok=True)
     target_name = options.module or options.script
@@ -37,9 +56,11 @@ def main() -> None:
     sys.argv = [target_name, *options.arguments]
     with torch.profiler.profile(
         activities=activities,
-        record_shapes=True,
-        profile_memory=True,
-        with_stack=True,
+        record_shapes=config["record_shapes"],
+        profile_memory=config["profile_memory"],
+        with_stack=config["with_stack"],
+        with_flops=config["with_flops"],
+        with_modules=config["with_modules"],
     ) as profile:
         if options.module is not None:
             runpy.run_module(options.module, run_name="__main__", alter_sys=True)

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -577,6 +577,7 @@ class CapturePlan(ContractModel):
     workload_definition_id: Digest
     workload_instance: WorkloadInstance
     adapter: Identifier
+    adapter_options: dict[str, JsonValue] = Field(default_factory=dict)
     execution_policy: Literal["trusted_local", "approved_agent"]
     adapter_version: str | None = None
     adapter_execution_plan: dict[str, JsonValue] | None = None

--- a/src/flameox/evidence/publisher.py
+++ b/src/flameox/evidence/publisher.py
@@ -16,6 +16,7 @@ import pyarrow.parquet as pq
 
 from flameox.atomic import atomic_write_json, fsync_directory
 from flameox.domain.errors import DomainError, ErrorCode
+from flameox.domain.identity import digest_model
 from flameox.domain.models import utc_now
 from flameox.evidence.schemas import SCHEMA_MAJOR, SCHEMA_MINOR, schema_for
 from flameox.observability import OperationLogger, elapsed_ms
@@ -55,6 +56,7 @@ class GenerationPublisher:
         publisher_version: str,
         input_run_ids: tuple[str, ...] = (),
         input_artifact_ids: tuple[str, ...] = (),
+        operation_digest: str | None = None,
         supersedes: tuple[str, ...] = (),
         expected_head: str | None = None,
     ) -> PublishedGeneration:
@@ -73,6 +75,7 @@ class GenerationPublisher:
                     publisher_version=publisher_version,
                     input_run_ids=input_run_ids,
                     input_artifact_ids=input_artifact_ids,
+                    operation_digest=operation_digest,
                     supersedes=supersedes,
                     expected_head=expected_head,
                 )
@@ -90,6 +93,64 @@ class GenerationPublisher:
         assert last_error is not None
         raise last_error
 
+    def publish_rows_idempotent(
+        self,
+        rows_by_table: Mapping[str, Sequence[Mapping[str, Any]]],
+        *,
+        publisher: str,
+        publisher_version: str,
+        input_run_ids: tuple[str, ...] = (),
+        input_artifact_ids: tuple[str, ...] = (),
+        operation_identity: Mapping[str, Any],
+    ) -> PublishedGeneration:
+        operation_digest = digest_model(
+            {
+                "publisher": publisher,
+                "publisher_version": publisher_version,
+                "input_run_ids": input_run_ids,
+                "input_artifact_ids": input_artifact_ids,
+                "operation": dict(operation_identity),
+            }
+        )
+        expected_tables = set(rows_by_table)
+        last_conflict: DomainError | None = None
+        for _ in range(32):
+            head = self.workspace.corpus.read_head()
+            matching: list[GenerationManifest] = []
+            for relative_path in head.generation_manifests:
+                manifest = GenerationManifest.model_validate_json(
+                    (self.workspace.paths.root / relative_path).read_text()
+                )
+                if (
+                    manifest.publisher == publisher
+                    and manifest.input_run_ids == input_run_ids
+                    and manifest.input_artifact_ids == input_artifact_ids
+                ):
+                    matching.append(manifest)
+            for manifest in matching:
+                if (
+                    manifest.operation_digest == operation_digest
+                    and {item.table for item in manifest.files} == expected_tables
+                ):
+                    return PublishedGeneration(manifest=manifest, commit=head)
+            try:
+                return self.publish_rows(
+                    rows_by_table,
+                    publisher=publisher,
+                    publisher_version=publisher_version,
+                    input_run_ids=input_run_ids,
+                    input_artifact_ids=input_artifact_ids,
+                    operation_digest=operation_digest,
+                    supersedes=tuple(manifest.generation_id for manifest in matching),
+                    expected_head=head.commit_id,
+                )
+            except DomainError as error:
+                if error.code is not ErrorCode.REVISION_CONFLICT:
+                    raise
+                last_conflict = error
+        assert last_conflict is not None
+        raise last_conflict
+
     def _publish_once(
         self,
         rows_by_table: Mapping[str, Sequence[Mapping[str, Any]]],
@@ -99,6 +160,7 @@ class GenerationPublisher:
         publisher_version: str,
         input_run_ids: tuple[str, ...] = (),
         input_artifact_ids: tuple[str, ...] = (),
+        operation_digest: str | None = None,
         supersedes: tuple[str, ...] = (),
         expected_head: str | None = None,
     ) -> PublishedGeneration:
@@ -179,6 +241,7 @@ class GenerationPublisher:
             input_artifact_ids=input_artifact_ids,
             publisher=publisher,
             publisher_version=publisher_version,
+            operation_digest=operation_digest,
             files=tuple(final_files),
             supersedes=supersedes,
         )

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -19,14 +19,18 @@ from mcp_types import (
     Tool,
     ToolAnnotations,
 )
-from pydantic import BaseModel, Field, RootModel, ValidationError
+from pydantic import BaseModel, Field, RootModel, StrictInt, ValidationError
 
 from flameox import __version__
 from flameox.adapters import (
+    BenchmarkSamplesExtractionResult,
+    BenchmarkSamplesExtractor,
     CoverageExtractionResult,
     CoverageExtractor,
     MemrayExtractionResult,
     MemrayExtractor,
+    NsightSystemsExtractionResult,
+    NsightSystemsExtractor,
     ObservationExtractionResult,
     ObservationExtractor,
     PerfettoExtractionResult,
@@ -37,9 +41,11 @@ from flameox.adapters import (
     PytestExtractor,
     PythonStartupExtractionResult,
     PythonStartupExtractor,
+    TorchProfilerCaptureOptions,
     TraceWindowResult,
 )
 from flameox.analysis import (
+    AcceleratorLaunchAnalysisResult,
     ExecutionAnalysisResult,
     FailureAnalysisResult,
     HotspotResult,
@@ -1196,6 +1202,7 @@ def create_server(
         preflight_mode: Literal["auto", "passive", "active"] = "auto",
         capture_mode: Literal["auto", "managed", "trusted_local"] = "auto",
         external_context: ExternalExecutionContext | None = None,
+        torch_profiler_options: TorchProfilerCaptureOptions | None = None,
     ) -> Annotated[CallToolResult, ToolPayload[CapturePlan]]:
         """Bind one current capture without running it.
 
@@ -1217,6 +1224,11 @@ def create_server(
                 execution_policy=execution_policy,
                 preflight_mode=preflight_mode,
                 external_context=external_context,
+                adapter_options=(
+                    torch_profiler_options.model_dump(mode="json")
+                    if torch_profiler_options is not None
+                    else None
+                ),
             )
             return _success(
                 result,
@@ -2174,6 +2186,49 @@ def create_server(
         except DomainError as error:
             return _failure(error)
 
+    @server.tool(name="analyze_accelerator_launches", annotations=READ_ONLY)
+    async def analyze_accelerator_launches_tool(
+        run_or_artifact: Annotated[
+            str,
+            Field(
+                min_length=1,
+                max_length=200,
+                description="Run or artifact with normalized Perfetto or Nsight trace events.",
+            ),
+        ],
+        limit: Annotated[
+            StrictInt,
+            Field(ge=1, le=1_000, description="Maximum regions and kernel names to return."),
+        ],
+        ctx: Context[AppContext],
+        comparison_run_or_artifact: Annotated[
+            str | None,
+            Field(min_length=1, max_length=200),
+        ] = None,
+        phase: Annotated[str | None, Field(min_length=1, max_length=200)] = None,
+    ) -> Annotated[CallToolResult, ToolPayload[AcceleratorLaunchAnalysisResult]]:
+        """Analyze observed runtime launches, graph launches, kernels, and idle gaps."""
+        try:
+            workspace = ctx.request_context.lifespan_context.require_workspace()
+            await ctx.report_progress(0, 2, "Accelerator trace snapshot pinned")
+            result = await Catalog(workspace).run_interruptible(
+                lambda snapshot: RecipeService(
+                    workspace,
+                    snapshot=snapshot,
+                ).accelerator_launches(
+                    run_or_artifact,
+                    comparison_input_id=comparison_run_or_artifact,
+                    phase=phase,
+                    limit=limit,
+                ),
+                query_name="analyze_accelerator_launches",
+            )
+            await ctx.report_progress(1, 2, "Accelerator launch query complete")
+            await ctx.report_progress(2, 2, "Accelerator launch result ready")
+            return _success(result, f"Returned {result.returned} launch regions.")
+        except DomainError as error:
+            return _failure(error)
+
     @server.tool(name="analyze_scaling", annotations=READ_ONLY)
     async def analyze_scaling_tool(
         experiment_id: str,
@@ -2455,6 +2510,26 @@ def create_server(
         except DomainError as error:
             return _failure(error)
 
+    @server.tool(name="extract_benchmark_samples", annotations=ADDITIVE)
+    async def extract_benchmark_samples_tool(
+        run_id: Annotated[str, Field(min_length=1, max_length=200)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[BenchmarkSamplesExtractionResult]]:
+        """Extract raw accelerator benchmark samples with explicit timing semantics."""
+        try:
+            result = await run_atomic_thread(
+                lambda: BenchmarkSamplesExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
+            return _success(
+                result,
+                f"Extracted {result.measurement_count} measured values and "
+                f"{result.warmup_count} warmups.",
+            )
+        except DomainError as error:
+            return _failure(error)
+
     @server.tool(name="extract_python_startup", annotations=ADDITIVE)
     async def extract_python_startup_tool(
         run_id: str,
@@ -2534,18 +2609,36 @@ def create_server(
 
     @server.tool(name="extract_perfetto", annotations=ADDITIVE)
     async def extract_perfetto_tool(
-        run_id: str,
+        run_id: Annotated[str, Field(min_length=1, max_length=200)],
         ctx: Context[AppContext],
+        artifact_id: Annotated[str | None, Field(min_length=1, max_length=200)] = None,
     ) -> Annotated[CallToolResult, ToolPayload[PerfettoExtractionResult]]:
         """Run versioned curated queries through a configured local Trace Processor."""
         try:
             result = await PerfettoExtractor(
                 ctx.request_context.lifespan_context.require_workspace()
-            ).extract(run_id)
+            ).extract(run_id, artifact_id=artifact_id)
             return _success(
                 result,
                 f"Extracted {result.slice_count} slices into "
                 f"{result.frame_count} frame aggregates.",
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="extract_nsight_systems", annotations=ADDITIVE)
+    async def extract_nsight_systems_tool(
+        run_id: Annotated[str, Field(min_length=1, max_length=200)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[NsightSystemsExtractionResult]]:
+        """Extract curated evidence from an imported official Nsight Systems SQLite export."""
+        try:
+            result = await NsightSystemsExtractor(
+                ctx.request_context.lifespan_context.require_workspace()
+            ).extract(run_id)
+            return _success(
+                result,
+                f"Extracted {result.event_count} Nsight Systems events.",
             )
         except DomainError as error:
             return _failure(error)

--- a/src/flameox/sdk.py
+++ b/src/flameox/sdk.py
@@ -6,7 +6,7 @@ import os
 import threading
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +16,8 @@ _PHASE: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 )
 _WRITE_LOCK = threading.Lock()
 _MAX_EVENT_BYTES = 16 * 1024
+_TORCH_PROFILER_CONFIG = "FLAMEOX_TORCH_PROFILER_CONFIG"
+_TORCH_PROFILER_OUTPUT_ROOT = "FLAMEOX_TORCH_PROFILER_OUTPUT_ROOT"
 
 
 def observe(name: str, **values: Any) -> None:
@@ -57,6 +59,133 @@ def phase(name: str) -> Iterator[None]:
     finally:
         observe("flameox.phase.end", phase_name=name)
         _PHASE.reset(token)
+
+
+class TorchProfilerSession:
+    """Narrow scheduled-profiler handle exposed to an approved workload."""
+
+    def __init__(self, profile: Any, torch: Any) -> None:
+        self._profile = profile
+        self._torch = torch
+
+    def step(self) -> None:
+        """Advance one declared workload step in the configured schedule."""
+        self._profile.step()
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        """Emit both a semantic phase and a trace-visible record-function range."""
+        if not name or len(name) > 200:
+            raise ValueError("phase names must contain 1 to 200 characters")
+        with ExitStack() as stack:
+            stack.enter_context(phase(name))
+            stack.enter_context(self._torch.profiler.record_function(f"flameox.phase:{name}"))
+            yield
+
+
+@contextmanager
+def torch_profiler() -> Iterator[TorchProfilerSession]:
+    """Run the scheduled profiler configuration bound into a Flameox capture plan."""
+    raw_config = os.environ.get(_TORCH_PROFILER_CONFIG)
+    output_root_value = os.environ.get(_TORCH_PROFILER_OUTPUT_ROOT)
+    if raw_config is None or output_root_value is None:
+        raise RuntimeError("torch_profiler() requires a Flameox torch.profiler SDK capture plan")
+    try:
+        config = json.loads(raw_config)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("invalid Flameox torch.profiler configuration") from exc
+    if not isinstance(config, dict) or config.get("mode") != "sdk":
+        raise RuntimeError("Flameox torch.profiler SDK configuration is invalid")
+    schedule = config.get("schedule")
+    activities = config.get("activities")
+    expected_cycles = config.get("expected_cycles")
+    if (
+        not isinstance(schedule, dict)
+        or not isinstance(activities, list)
+        or not isinstance(expected_cycles, int)
+        or isinstance(expected_cycles, bool)
+        or expected_cycles < 1
+    ):
+        raise RuntimeError("Flameox torch.profiler SDK configuration is incomplete")
+    try:
+        import torch
+    except ImportError as exc:
+        raise RuntimeError("PyTorch is unavailable in the workload environment") from exc
+
+    selected_activities = []
+    if "cpu" in activities:
+        selected_activities.append(torch.profiler.ProfilerActivity.CPU)
+    if "cuda" in activities and not torch.cuda.is_available():
+        raise RuntimeError("the Flameox capture plan requires CUDA, but CUDA is unavailable")
+    if "cuda" in activities:
+        selected_activities.append(torch.profiler.ProfilerActivity.CUDA)
+    if "cuda_if_available" in activities and torch.cuda.is_available():
+        selected_activities.append(torch.profiler.ProfilerActivity.CUDA)
+    if not selected_activities:
+        raise RuntimeError("no requested torch.profiler activity is available")
+    output_root = Path(output_root_value)
+    output_root.mkdir(parents=True, exist_ok=True)
+    cycle = 0
+
+    def export_trace(profile: Any) -> None:
+        nonlocal cycle
+        if cycle >= expected_cycles:
+            raise RuntimeError("torch.profiler emitted more trace cycles than planned")
+        output = output_root / f"torch-trace-cycle-{cycle:04d}.json"
+        if output.exists():
+            raise RuntimeError(f"torch.profiler cycle output already exists: {output.name}")
+        profile.export_chrome_trace(str(output))
+        cycle += 1
+
+    profile = torch.profiler.profile(
+        activities=selected_activities,
+        schedule=torch.profiler.schedule(
+            wait=schedule["wait"],
+            warmup=schedule["warmup"],
+            active=schedule["active"],
+            repeat=schedule["repeat"],
+            skip_first=schedule["skip_first"],
+        ),
+        on_trace_ready=export_trace,
+        record_shapes=config["record_shapes"],
+        profile_memory=config["profile_memory"],
+        with_stack=config["with_stack"],
+        with_flops=config["with_flops"],
+        with_modules=config["with_modules"],
+    )
+    failed = False
+    try:
+        with profile:
+            yield TorchProfilerSession(profile, torch)
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        if not failed and cycle != expected_cycles:
+            raise RuntimeError(
+                f"torch.profiler emitted {cycle} of {expected_cycles} planned trace cycles"
+            )
+        if not failed and cycle == expected_cycles:
+            manifest = output_root / "torch-profiler-cycles.json"
+            temporary = output_root / ".torch-profiler-cycles.tmp"
+            if manifest.exists() or temporary.exists():
+                raise RuntimeError("torch.profiler cycle manifest already exists")
+            temporary.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "flameox.torch-profiler-cycles.v1",
+                        "expected_cycles": expected_cycles,
+                        "files": [
+                            f"torch-trace-cycle-{index:04d}.json"
+                            for index in range(expected_cycles)
+                        ],
+                    },
+                    allow_nan=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+            )
+            os.replace(temporary, manifest)
 
 
 def _bounded_value(value: Any, *, depth: int = 0) -> Any:

--- a/src/flameox/storage/corpus.py
+++ b/src/flameox/storage/corpus.py
@@ -35,6 +35,7 @@ class GenerationManifest(ContractModel):
     input_artifact_ids: tuple[Digest, ...] = ()
     publisher: str
     publisher_version: str
+    operation_digest: Digest | None = None
     files: tuple[GenerationFile, ...]
     supersedes: tuple[str, ...] = ()
 

--- a/src/flameox/workers/nsight_systems.py
+++ b/src/flameox/workers/nsight_systems.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+from urllib.parse import quote
+
+
+def _identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _column(columns: dict[str, str], *candidates: str) -> str | None:
+    for candidate in candidates:
+        found = columns.get(candidate.casefold())
+        if found is not None:
+            return found
+    return None
+
+
+def _required_column(table: str, columns: dict[str, str], *candidates: str) -> str:
+    found = _column(columns, *candidates)
+    if found is None:
+        raise ValueError(f"Unsupported Nsight Systems schema: {table} lacks one of {candidates!r}")
+    return found
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> dict[str, str]:
+    rows = connection.execute(f"PRAGMA table_info({_identifier(table)})").fetchall()
+    return {str(row[1]).casefold(): str(row[1]) for row in rows}
+
+
+def _rows(
+    connection: sqlite3.Connection,
+    table: str,
+    selected: dict[str, str | None],
+    *,
+    limit: int,
+) -> tuple[list[dict[str, object]], bool]:
+    available = {key: value for key, value in selected.items() if value is not None}
+    expressions = ", ".join(
+        f"{_identifier(value)} AS {_identifier(key)}" for key, value in available.items()
+    )
+    ordering = ", ".join(_identifier(key) for key in available)
+    query = f"SELECT {expressions} FROM {_identifier(table)} ORDER BY {ordering} LIMIT ?"
+    records = connection.execute(query, (limit + 1,)).fetchall()
+    return (
+        [{key: record[index] for index, key in enumerate(available)} for record in records[:limit]],
+        len(records) > limit,
+    )
+
+
+def _name(value: object, strings: dict[int, str], fallback: str) -> str:
+    if isinstance(value, int):
+        return strings.get(value, f"{fallback}:{value}")
+    if value not in {None, ""}:
+        return str(value)
+    return fallback
+
+
+def _integer(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int | str | bytes | bytearray):
+        raise ValueError(f"expected an integer-compatible SQLite value, got {type(value).__name__}")
+    return int(value)
+
+
+def _string_values(
+    connection: sqlite3.Connection,
+    tables: dict[str, str],
+    *,
+    limit: int,
+) -> tuple[dict[int, str], bool, str | None]:
+    table = tables.get("stringids")
+    if table is None:
+        return {}, False, None
+    columns = _table_columns(connection, table)
+    id_column = _column(columns, "id")
+    value_column = _column(columns, "value", "string")
+    if id_column is None or value_column is None:
+        return {}, False, table
+    rows = connection.execute(
+        f"SELECT {_identifier(id_column)}, {_identifier(value_column)} "
+        f"FROM {_identifier(table)} ORDER BY {_identifier(id_column)} LIMIT ?",
+        (limit + 1,),
+    ).fetchall()
+    values = {
+        _integer(identifier): str(value)
+        for identifier, value in rows[:limit]
+        if identifier is not None and value is not None
+    }
+    return values, len(rows) > limit, table
+
+
+def _api_events(
+    connection: sqlite3.Connection,
+    table: str,
+    strings: dict[int, str],
+    *,
+    category: str,
+    limit: int,
+) -> tuple[list[dict[str, object]], bool]:
+    columns = _table_columns(connection, table)
+    rows, truncated = _rows(
+        connection,
+        table,
+        {
+            "start": _required_column(table, columns, "start"),
+            "end": _required_column(table, columns, "end"),
+            "name": _required_column(table, columns, "nameId", "name"),
+            "correlation": _column(columns, "correlationId", "correlation"),
+            "thread": _column(columns, "globalTid"),
+            "process": _column(columns, "processId", "pid"),
+        },
+        limit=limit,
+    )
+    events: list[dict[str, object]] = []
+    for row in rows:
+        start = _integer(row["start"])
+        end = _integer(row["end"])
+        events.append(
+            {
+                "name": _name(row.get("name"), strings, category),
+                "category": category,
+                "start_ns": start,
+                "duration_ns": max(0, end - start),
+                "correlation_id": row.get("correlation"),
+                "thread": row.get("thread"),
+                "process": row.get("process"),
+            }
+        )
+    return events, truncated
+
+
+def _memory_events(
+    connection: sqlite3.Connection,
+    table: str,
+    *,
+    category: str,
+    limit: int,
+) -> tuple[list[dict[str, object]], bool, bool]:
+    columns = _table_columns(connection, table)
+    start_column = _column(columns, "start")
+    end_column = _column(columns, "end")
+    if start_column is None or end_column is None:
+        return [], False, False
+    rows, truncated = _rows(
+        connection,
+        table,
+        {
+            "start": start_column,
+            "end": end_column,
+            "bytes": _column(columns, "bytes", "size"),
+            "copy_kind": _column(columns, "copyKind", "kind"),
+            "value": _column(columns, "value"),
+            "device": _column(columns, "deviceId", "device"),
+            "context": _column(columns, "contextId", "context"),
+            "stream": _column(columns, "streamId", "stream"),
+        },
+        limit=limit,
+    )
+    events: list[dict[str, object]] = []
+    for row in rows:
+        start = _integer(row["start"])
+        end = _integer(row["end"])
+        events.append(
+            {
+                "name": (
+                    f"cuda_memcpy:{row.get('copy_kind', 'unknown')}"
+                    if category == "memcpy"
+                    else "cuda_memset"
+                ),
+                "category": category,
+                "start_ns": start,
+                "duration_ns": max(0, end - start),
+                "bytes": row.get("bytes"),
+                "copy_kind": row.get("copy_kind"),
+                "value": row.get("value"),
+                "device": row.get("device"),
+                "context": row.get("context"),
+                "stream": row.get("stream"),
+            }
+        )
+    return events, truncated, True
+
+
+def _extract(path: Path, *, limit: int) -> dict[str, object]:
+    uri = f"file:{quote(str(path.resolve()))}?mode=ro&immutable=1"
+    connection = sqlite3.connect(uri, uri=True)
+    try:
+        table_rows = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table', 'view') ORDER BY name"
+        ).fetchall()
+        tables = {str(row[0]).casefold(): str(row[0]) for row in table_rows}
+        runtime_table = tables.get("cupti_activity_kind_runtime")
+        kernel_table = tables.get("cupti_activity_kind_kernel")
+        if runtime_table is None or kernel_table is None:
+            raise ValueError(
+                "Unsupported Nsight Systems schema: CUDA runtime and kernel tables are required"
+            )
+        schema = {
+            table: sorted(_table_columns(connection, table).values())
+            for table in sorted(tables.values())
+        }
+        schema_fingerprint = (
+            "sha256:"
+            + hashlib.sha256(
+                json.dumps(schema, separators=(",", ":"), sort_keys=True).encode()
+            ).hexdigest()
+        )
+
+        strings, strings_truncated, string_table = _string_values(
+            connection,
+            tables,
+            limit=limit,
+        )
+
+        events: list[dict[str, object]] = []
+        truncated_tables: list[str] = []
+        if strings_truncated and string_table is not None:
+            truncated_tables.append(string_table)
+        runtime_events, truncated = _api_events(
+            connection,
+            runtime_table,
+            strings,
+            category="cuda_runtime",
+            limit=limit,
+        )
+        events.extend(runtime_events)
+        if truncated:
+            truncated_tables.append(runtime_table)
+
+        driver_table = tables.get("cupti_activity_kind_driver")
+        if driver_table is not None:
+            driver_events, truncated = _api_events(
+                connection,
+                driver_table,
+                strings,
+                category="cuda_driver",
+                limit=limit,
+            )
+            events.extend(driver_events)
+            if truncated:
+                truncated_tables.append(driver_table)
+
+        kernel_columns = _table_columns(connection, kernel_table)
+        kernel_rows, truncated = _rows(
+            connection,
+            kernel_table,
+            {
+                "start": _required_column(kernel_table, kernel_columns, "start"),
+                "end": _required_column(kernel_table, kernel_columns, "end"),
+                "name": _required_column(
+                    kernel_table,
+                    kernel_columns,
+                    "demangledName",
+                    "shortName",
+                    "name",
+                ),
+                "correlation": _column(kernel_columns, "correlationId", "correlation"),
+                "device": _column(kernel_columns, "deviceId", "device"),
+                "context": _column(kernel_columns, "contextId", "context"),
+                "stream": _column(kernel_columns, "streamId", "stream"),
+            },
+            limit=limit,
+        )
+        if truncated:
+            truncated_tables.append(kernel_table)
+        for row in kernel_rows:
+            start = _integer(row["start"])
+            end = _integer(row["end"])
+            events.append(
+                {
+                    "name": _name(row.get("name"), strings, "cuda_kernel"),
+                    "category": "kernel",
+                    "start_ns": start,
+                    "duration_ns": max(0, end - start),
+                    "correlation_id": row.get("correlation"),
+                    "device": row.get("device"),
+                    "context": row.get("context"),
+                    "stream": row.get("stream"),
+                }
+            )
+
+        coverage = {
+            "cuda_runtime": True,
+            "cuda_driver": driver_table is not None,
+            "cuda_kernels": True,
+            "nvtx": False,
+            "memory_copies": False,
+            "memory_sets": False,
+            "correlation_ids": any(event.get("correlation_id") is not None for event in events),
+            "stream_identity": any(event.get("stream") is not None for event in events),
+            "thread_identity": any(event.get("thread") is not None for event in events),
+            "process_identity": any(event.get("process") is not None for event in events),
+        }
+        nvtx_table = tables.get("nvtx_events")
+        if nvtx_table is not None:
+            columns = _table_columns(connection, nvtx_table)
+            start_column = _column(columns, "start")
+            end_column = _column(columns, "end")
+            text_column = _column(columns, "text", "name")
+            text_id_column = _column(columns, "textId")
+            if (
+                start_column is not None
+                and end_column is not None
+                and (text_column is not None or text_id_column is not None)
+            ):
+                nvtx_rows, truncated = _rows(
+                    connection,
+                    nvtx_table,
+                    {
+                        "start": start_column,
+                        "end": end_column,
+                        "name_text": text_column,
+                        "name_id": text_id_column,
+                        "thread": _column(columns, "globalTid"),
+                        "process": _column(columns, "processId", "pid"),
+                    },
+                    limit=limit,
+                )
+                if truncated:
+                    truncated_tables.append(nvtx_table)
+                for row in nvtx_rows:
+                    start = _integer(row["start"])
+                    end = _integer(row["end"])
+                    events.append(
+                        {
+                            "name": _name(
+                                row.get("name_text")
+                                if row.get("name_text") not in {None, ""}
+                                else row.get("name_id"),
+                                strings,
+                                "nvtx",
+                            ),
+                            "category": "nvtx",
+                            "start_ns": start,
+                            "duration_ns": max(0, end - start),
+                            "thread": row.get("thread"),
+                            "process": row.get("process"),
+                        }
+                    )
+                coverage["nvtx"] = True
+
+        memcpy_table = tables.get("cupti_activity_kind_memcpy")
+        if memcpy_table is not None:
+            memory_events, truncated, supported = _memory_events(
+                connection,
+                memcpy_table,
+                category="memcpy",
+                limit=limit,
+            )
+            events.extend(memory_events)
+            if truncated:
+                truncated_tables.append(memcpy_table)
+            coverage["memory_copies"] = supported
+
+        memset_table = tables.get("cupti_activity_kind_memset")
+        if memset_table is not None:
+            memory_events, truncated, supported = _memory_events(
+                connection,
+                memset_table,
+                category="memset",
+                limit=limit,
+            )
+            events.extend(memory_events)
+            if truncated:
+                truncated_tables.append(memset_table)
+            coverage["memory_sets"] = supported
+
+        return {
+            "ok": True,
+            "schema_fingerprint": schema_fingerprint,
+            "tables": sorted(tables.values()),
+            "events": sorted(
+                events,
+                key=lambda event: (
+                    _integer(event["start_ns"]),
+                    str(event["category"]),
+                    json.dumps(event, allow_nan=False, separators=(",", ":"), sort_keys=True),
+                ),
+            ),
+            "coverage": coverage,
+            "truncated_tables": sorted(set(truncated_tables)),
+        }
+    finally:
+        connection.close()
+
+
+def _write_response(path: Path, payload: dict[str, object]) -> None:
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True)
+    )
+    os.replace(temporary, path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    parser.add_argument("--response", required=True)
+    options = parser.parse_args()
+    try:
+        request = json.loads(Path(options.request).read_text())
+        payload = _extract(
+            Path(request["artifact_path"]),
+            limit=int(request["max_rows_per_table"]),
+        )
+    except (OSError, sqlite3.DatabaseError, ValueError, KeyError, TypeError) as exc:
+        payload = {
+            "ok": False,
+            "code": "ARTIFACT_PARSE_FAILED",
+            "message": f"Nsight Systems structured export is unsupported or invalid: {exc}",
+        }
+    _write_response(Path(options.response), payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flameox/workers/perfetto.py
+++ b/src/flameox/workers/perfetto.py
@@ -36,7 +36,15 @@ _SLICE_QUERY = """
         sum(CASE WHEN a.key IN ('args.Bytes', 'args.Allocation Bytes')
             THEN a.int_value END) AS allocation_bytes,
         max(CASE WHEN a.key IN ('args.phase', 'args.Phase')
-            THEN a.string_value END) AS phase
+            THEN a.string_value END) AS phase,
+        max(CASE WHEN a.key IN (
+            'args.correlation', 'args.correlationId', 'args.Correlation ID',
+            'args.External id', 'args.external id'
+        ) THEN coalesce(a.string_value, cast(a.int_value AS TEXT)) END) AS correlation_id,
+        max(CASE WHEN a.key IN ('args.device', 'args.deviceId', 'args.Device')
+            THEN coalesce(a.string_value, cast(a.int_value AS TEXT)) END) AS device,
+        max(CASE WHEN a.key IN ('args.stream', 'args.streamId', 'args.Stream')
+            THEN coalesce(a.string_value, cast(a.int_value AS TEXT)) END) AS stream
     FROM slice AS s
     LEFT JOIN args AS a ON a.arg_set_id = s.arg_set_id
     LEFT JOIN thread_track AS tt ON tt.id = s.track_id
@@ -82,9 +90,15 @@ def _query(request: dict[str, object]) -> dict[str, object]:
         )
         operation = request["operation"]
         if operation == "extract":
-            rows = list(processor.query(_SLICE_QUERY))
+            max_rows = int(str(request["max_rows"]))
+            rows = list(
+                processor.query(
+                    f"SELECT * FROM ({_SLICE_QUERY}) AS bounded_slices LIMIT {max_rows + 1:d}"
+                )
+            )
             return {
                 "ok": True,
+                "truncated": len(rows) > max_rows,
                 "rows": [
                     _row(
                         row,
@@ -103,9 +117,12 @@ def _query(request: dict[str, object]) -> dict[str, object]:
                             "input_shapes",
                             "allocation_bytes",
                             "phase",
+                            "correlation_id",
+                            "device",
+                            "stream",
                         ),
                     )
-                    for row in rows
+                    for row in rows[:max_rows]
                 ],
             }
         if operation == "window":

--- a/tests/adapters/test_benchmark_samples.py
+++ b/tests/adapters/test_benchmark_samples.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters import BenchmarkSamplesExtractor
+from flameox.application import EvidenceQueryService, ImportArtifactRequest, ImportService
+from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.storage import Workspace
+
+
+def _write_samples(path: Path, *, synchronization: str = "event_synchronize") -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "flameox.benchmark-samples.v1",
+                "producer": "decode-benchmark",
+                "producer_version": "git:abc123",
+                "benchmarks": [
+                    {
+                        "name": "decode.token_latency",
+                        "unit": "ns",
+                        "measurement_clock": "cuda_event",
+                        "synchronization": synchronization,
+                        "scope": "workload",
+                        "phase": "steady_state",
+                        "loop_count": 100,
+                        "device": {"type": "cuda", "index": 0, "stream": "7"},
+                        "dimensions": {
+                            "batch": "1",
+                            "dtype": "bfloat16",
+                            "mode": "cuda_graph",
+                        },
+                        "warmups": [45_000],
+                        "samples": [42_100, 41_900, 42_400],
+                    }
+                ],
+            }
+        )
+    )
+
+
+def _import(workspace: Workspace, path: Path, *, producer: str | None = None) -> str:
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(
+            path=path,
+            kind=ArtifactKind.BENCHMARK_SAMPLES,
+            producer=producer,
+        )
+    )
+    return imported.run.run_id
+
+
+def test_structured_benchmark_extraction_preserves_samples_and_timing_semantics(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "accelerator-benchmark.json"
+    _write_samples(source)
+    run_id = _import(workspace, source)
+
+    result = BenchmarkSamplesExtractor(workspace).extract(run_id)
+    repeated = BenchmarkSamplesExtractor(workspace).extract(run_id)
+
+    assert result.measurement_count == 3
+    assert result.warmup_count == 1
+    assert result.producer == "decode-benchmark"
+    assert result.limitations == ()
+    assert repeated.corpus_commit_id == result.corpus_commit_id
+    queried = EvidenceQueryService(workspace).measurements(
+        run_id=run_id,
+        name_prefix="decode.",
+        include_warmups=True,
+    )
+    assert {item.value_int for item in queried.measurements} == {45_000, 42_100, 41_900, 42_400}
+    assert all(
+        item.dimensions
+        == {
+            "batch": "1",
+            "dtype": "bfloat16",
+            "mode": "cuda_graph",
+            "measurement_clock": "cuda_event",
+            "synchronization": "event_synchronize",
+            "producer": "decode-benchmark",
+            "producer_version": "git:abc123",
+            "device.type": "cuda",
+            "device.index": "0",
+            "device.stream": "7",
+        }
+        for item in queried.measurements
+    )
+    assert [item.value_int for item in queried.measurements if item.is_warmup] == [45_000]
+    assert all(item.unit == "ns" for item in queried.measurements)
+    assert queried.total == 4
+
+
+def test_structured_benchmark_reports_unknown_device_synchronization(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "accelerator-benchmark.json"
+    _write_samples(source, synchronization="unknown")
+    run_id = _import(workspace, source)
+
+    result = BenchmarkSamplesExtractor(workspace).extract(run_id)
+
+    assert result.limitations == (
+        "decode.token_latency uses asynchronous device timing with synchronization=unknown.",
+    )
+
+
+def test_structured_benchmark_reports_missing_producer_version(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "accelerator-benchmark.json"
+    _write_samples(source)
+    payload = json.loads(source.read_text())
+    del payload["producer_version"]
+    source.write_text(json.dumps(payload))
+    run_id = _import(workspace, source)
+
+    result = BenchmarkSamplesExtractor(workspace).extract(run_id)
+
+    assert result.producer_version is None
+    assert result.limitations == ("The benchmark producer version was not declared.",)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {},
+        {
+            "schema_version": "flameox.benchmark-samples.v1",
+            "producer": "fixture",
+            "benchmarks": [
+                {
+                    "name": "decode.latency",
+                    "unit": "ns",
+                    "measurement_clock": "cuda_event",
+                    "synchronization": "event_synchronize",
+                    "samples": [1.5],
+                }
+            ],
+        },
+        {
+            "schema_version": "flameox.benchmark-samples.v1",
+            "producer": "fixture",
+            "benchmarks": [
+                {
+                    "name": "decode.latency",
+                    "unit": "ns",
+                    "measurement_clock": "cuda_event",
+                    "synchronization": "event_synchronize",
+                    "samples": [True],
+                }
+            ],
+        },
+        {
+            "schema_version": "flameox.benchmark-samples.v1",
+            "producer": "fixture",
+            "benchmarks": [
+                {
+                    "name": "decode.latency",
+                    "unit": "ns",
+                    "measurement_clock": "cuda_event",
+                    "synchronization": "event_synchronize",
+                    "samples": ["1"],
+                }
+            ],
+        },
+    ),
+)
+def test_structured_benchmark_rejects_malformed_or_inexact_samples(
+    tmp_path: Path,
+    payload: dict[str, object],
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "accelerator-benchmark.json"
+    source.write_text(json.dumps(payload))
+    run_id = _import(workspace, source)
+
+    with pytest.raises(DomainError) as error:
+        BenchmarkSamplesExtractor(workspace).extract(run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_structured_benchmark_rejects_conflicting_registered_producer(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "accelerator-benchmark.json"
+    _write_samples(source)
+    run_id = _import(workspace, source, producer="different-producer")
+
+    with pytest.raises(DomainError) as error:
+        BenchmarkSamplesExtractor(workspace).extract(run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+    assert error.value.details["document_producer"] == "decode-benchmark"
+
+    payload = json.loads(source.read_text())
+    payload["benchmarks"][0]["dimensions"]["measurement_clock"] = "host_monotonic"
+    source.write_text(json.dumps(payload))
+    conflicting_dimension_run = _import(workspace, source)
+
+    with pytest.raises(DomainError) as dimension_error:
+        BenchmarkSamplesExtractor(workspace).extract(conflicting_dimension_run)
+
+    assert dimension_error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED

--- a/tests/adapters/test_nsight_systems.py
+++ b/tests/adapters/test_nsight_systems.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters import NsightSystemsExtractor
+from flameox.analysis import RecipeService
+from flameox.application import ImportArtifactRequest, ImportService
+from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.storage import Workspace
+
+
+def _nsight_fixture(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.executescript(
+            """
+CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    nameId INTEGER NOT NULL,
+    correlationId INTEGER,
+    globalTid INTEGER
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_DRIVER (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    nameId INTEGER NOT NULL,
+    correlationId INTEGER,
+    globalTid INTEGER
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    demangledName INTEGER NOT NULL,
+    correlationId INTEGER,
+    deviceId INTEGER,
+    contextId INTEGER,
+    streamId INTEGER
+);
+CREATE TABLE NVTX_EVENTS (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    globalTid INTEGER
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_MEMCPY (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    bytes INTEGER,
+    copyKind INTEGER,
+    deviceId INTEGER,
+    contextId INTEGER,
+    streamId INTEGER
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_MEMSET (
+    start INTEGER NOT NULL,
+    end INTEGER NOT NULL,
+    bytes INTEGER,
+    value INTEGER,
+    deviceId INTEGER,
+    contextId INTEGER,
+    streamId INTEGER
+);
+"""
+        )
+        connection.executemany(
+            "INSERT INTO StringIds(id, value) VALUES (?, ?)",
+            [
+                (1, "cudaLaunchKernel"),
+                (2, "cudaGraphLaunch"),
+                (3, "projection_kernel"),
+                (4, "cuCtxSynchronize"),
+            ],
+        )
+        connection.executemany(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?, ?, ?, ?, ?)",
+            [(1, 3, 1, 41, 7), (4, 6, 2, 42, 7)],
+        )
+        connection.execute("INSERT INTO CUPTI_ACTIVITY_KIND_DRIVER VALUES (6, 7, 4, 43, 7)")
+        connection.executemany(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [(10, 15, 3, 41, 0, 1, 9), (20, 24, 3, 42, 0, 1, 9)],
+        )
+        connection.execute("INSERT INTO NVTX_EVENTS VALUES (0, 30, 'decode', 7)")
+        connection.execute("INSERT INTO CUPTI_ACTIVITY_KIND_MEMCPY VALUES (7, 9, 4096, 1, 0, 1, 9)")
+        connection.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_MEMSET VALUES (9, 10, 1024, 0, 0, 1, 9)"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _minimal_nsight_fixture(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.executescript(
+            """
+CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+    start INTEGER NOT NULL, end INTEGER NOT NULL, nameId INTEGER NOT NULL
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+    start INTEGER NOT NULL, end INTEGER NOT NULL, demangledName INTEGER NOT NULL
+);
+INSERT INTO StringIds VALUES (1, 'cudaLaunchKernel');
+INSERT INTO StringIds VALUES (2, 'projection_kernel');
+INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (0, 1, 1);
+INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (2, 3, 2);
+"""
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.process
+async def test_nsight_sqlite_extracts_launch_evidence_without_nsys_installed(
+    tmp_path: Path,
+) -> None:
+    export = tmp_path / "decode.sqlite"
+    _nsight_fixture(export)
+    workspace = Workspace.initialize(tmp_path)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(
+            path=export,
+            kind=ArtifactKind.EXECUTION_TRACE,
+            producer="nsight.systems",
+            producer_version="fixture-2026.1",
+        )
+    )
+
+    with pytest.raises(DomainError) as unavailable:
+        RecipeService(workspace).accelerator_launches(imported.run.run_id)
+    assert unavailable.value.details["next_tool"] == "extract_nsight_systems"
+
+    extracted = await NsightSystemsExtractor(workspace).extract(imported.run.run_id)
+    repeated = await NsightSystemsExtractor(workspace).extract(imported.run.run_id)
+    analysis = RecipeService(workspace).accelerator_launches(
+        imported.run.run_id,
+        phase="decode",
+    )
+
+    assert repeated.corpus_commit_id == extracted.corpus_commit_id
+    assert extracted.event_count == 8
+    assert extracted.compatibility_family == "nsight-systems.sqlite.cuda.v1"
+    assert "CUPTI_ACTIVITY_KIND_RUNTIME" in extracted.observed_tables
+    assert extracted.runtime_event_count == 2
+    assert extracted.driver_event_count == 1
+    assert extracted.kernel_event_count == 2
+    assert extracted.nvtx_event_count == 1
+    assert extracted.memory_copy_event_count == 1
+    assert extracted.memory_set_event_count == 1
+    assert extracted.coverage == {
+        "cuda_runtime": True,
+        "cuda_driver": True,
+        "cuda_kernels": True,
+        "nvtx": True,
+        "memory_copies": True,
+        "memory_sets": True,
+        "correlation_ids": True,
+        "stream_identity": True,
+        "thread_identity": True,
+        "process_identity": False,
+    }
+    region = analysis.regions[0]
+    assert region.region == "decode"
+    assert region.direct_launch_count == 1
+    assert region.graph_launch_count == 1
+    assert region.kernel_count == 2
+    assert region.idle_gap_total_ns == 5
+
+
+@pytest.mark.anyio
+@pytest.mark.process
+async def test_nsight_extractor_rejects_unknown_sqlite_schema(tmp_path: Path) -> None:
+    export = tmp_path / "unknown.sqlite"
+    connection = sqlite3.connect(export)
+    connection.execute("CREATE TABLE unrelated (value TEXT)")
+    connection.close()
+    workspace = Workspace.initialize(tmp_path)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(
+            path=export,
+            kind=ArtifactKind.EXECUTION_TRACE,
+            producer="nsight.systems",
+        )
+    )
+
+    with pytest.raises(DomainError) as failure:
+        await NsightSystemsExtractor(workspace).extract(imported.run.run_id)
+
+    assert failure.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+    assert "CUDA runtime and kernel tables are required" in failure.value.message
+
+
+@pytest.mark.anyio
+@pytest.mark.process
+async def test_nsight_extractor_reports_missing_optional_tables(tmp_path: Path) -> None:
+    export = tmp_path / "minimal.sqlite"
+    _minimal_nsight_fixture(export)
+    workspace = Workspace.initialize(tmp_path)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(
+            path=export,
+            kind=ArtifactKind.EXECUTION_TRACE,
+            producer="nsight.systems",
+        )
+    )
+
+    extracted = await NsightSystemsExtractor(workspace).extract(imported.run.run_id)
+
+    assert extracted.coverage["cuda_runtime"]
+    assert extracted.coverage["cuda_kernels"]
+    assert not extracted.coverage["cuda_driver"]
+    assert not extracted.coverage["nvtx"]
+    assert not extracted.coverage["memory_copies"]
+    assert not extracted.coverage["memory_sets"]
+    assert extracted.driver_event_count == 0
+    assert extracted.memory_copy_event_count == 0
+    assert extracted.memory_set_event_count == 0

--- a/tests/adapters/test_perfetto_normalization.py
+++ b/tests/adapters/test_perfetto_normalization.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from flameox.adapters import PerfettoExtractor
+from flameox.analysis import RecipeService
+from flameox.application import ImportArtifactRequest, ImportService
+from flameox.domain import ArtifactKind
+from flameox.storage import Workspace
+
+
+@pytest.mark.anyio
+async def test_perfetto_normalization_inherits_trace_visible_sdk_phase(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trace = tmp_path / "trace.json"
+    trace.write_text('{"traceEvents": []}')
+    workspace = Workspace.initialize(tmp_path)
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(
+            path=trace,
+            kind=ArtifactKind.EXECUTION_TRACE,
+            producer="torch.profiler",
+        )
+    )
+    extractor = PerfettoExtractor(workspace)
+    monkeypatch.setattr(extractor, "_trace_processor_path", lambda: trace)
+
+    async def worker(_request: dict[str, Any]) -> dict[str, Any]:
+        def row(
+            event_id: int,
+            parent_id: int | None,
+            name: str,
+            category: str,
+            start: int,
+            duration: int,
+        ) -> dict[str, object]:
+            return {
+                "id": event_id,
+                "parent_id": parent_id,
+                "name": name,
+                "ts": start,
+                "dur": duration,
+                "track_id": 1,
+                "category": category,
+                "thread_name": "main",
+                "process_name": "fixture",
+                "filename": None,
+                "line": None,
+                "input_shapes": None,
+                "allocation_bytes": None,
+                "phase": None,
+                "correlation_id": "41" if event_id > 1 else None,
+                "device": "0" if event_id == 3 else None,
+                "stream": "9" if event_id == 3 else None,
+            }
+
+        return {
+            "ok": True,
+            "rows": [
+                row(1, None, "flameox.phase:decode", "user_annotation", 0, 100),
+                row(2, 1, "cudaLaunchKernel", "cuda_runtime", 10, 2),
+                row(3, 1, "projection_kernel", "kernel", 20, 5),
+            ],
+        }
+
+    monkeypatch.setattr(extractor, "_run_worker", worker)
+
+    extracted = await extractor.extract(imported.run.run_id)
+    repeated = await extractor.extract(imported.run.run_id)
+    result = RecipeService(workspace).accelerator_launches(
+        imported.run.run_id,
+        phase="decode",
+    )
+
+    assert repeated.corpus_commit_id == extracted.corpus_commit_id
+    assert extracted.query_version == "flameox.perfetto.trace-events.v1"
+    assert extracted.trace_processor_sha256.startswith("sha256:")
+    assert result.regions[0].direct_launch_count == 1
+    assert result.regions[0].kernel_count == 1

--- a/tests/adapters/test_perfetto_provider.py
+++ b/tests/adapters/test_perfetto_provider.py
@@ -189,3 +189,78 @@ async def test_pytorch_analysis_keeps_same_named_frames_and_mixed_phases_separat
     assert steady.allocation_bytes == 700
     assert steady.warmup is False
     assert result.warmup_time_ns == 5_000
+
+
+@pytest.mark.anyio
+@pytest.mark.optional
+@pytest.mark.requires_perfetto
+async def test_perfetto_inherits_sdk_phase_ranges_for_launch_analysis(
+    tmp_path: Path,
+) -> None:
+    binary = require_trace_processor()
+    trace = tmp_path / "scheduled-cycle.json"
+    trace.write_text(
+        json.dumps(
+            {
+                "traceEvents": [
+                    {
+                        "name": "flameox.phase:decode",
+                        "cat": "user_annotation",
+                        "ph": "X",
+                        "ts": 0,
+                        "dur": 100,
+                        "pid": 1,
+                        "tid": 1,
+                        "args": {},
+                    },
+                    {
+                        "name": "cudaLaunchKernel",
+                        "cat": "cuda_runtime",
+                        "ph": "X",
+                        "ts": 10,
+                        "dur": 2,
+                        "pid": 1,
+                        "tid": 1,
+                        "args": {"correlation": 41},
+                    },
+                    {
+                        "name": "projection_kernel",
+                        "cat": "kernel",
+                        "ph": "X",
+                        "ts": 20,
+                        "dur": 5,
+                        "pid": 1,
+                        "tid": 1,
+                        "args": {"correlation": 41, "stream": 9, "device": 0},
+                    },
+                ]
+            }
+        )
+    )
+    workspace = Workspace.initialize(tmp_path)
+    config = workspace.config.model_copy(
+        update={
+            "analysis": workspace.config.analysis.model_copy(
+                update={"trace_processor_path": str(binary)}
+            )
+        }
+    )
+    workspace.paths.config.write_text(config.to_toml())
+    imported = ImportService(workspace).import_artifact(
+        ImportArtifactRequest(
+            path=trace,
+            kind=ArtifactKind.EXECUTION_TRACE,
+            producer="torch.profiler",
+        )
+    )
+
+    await PerfettoExtractor(workspace).extract(imported.run.run_id)
+    result = RecipeService(workspace).accelerator_launches(
+        imported.run.run_id,
+        phase="decode",
+    )
+
+    region = result.regions[0]
+    assert region.region == "decode"
+    assert region.direct_launch_count == 1
+    assert region.kernel_count == 1

--- a/tests/analysis/test_accelerator_launches.py
+++ b/tests/analysis/test_accelerator_launches.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from flameox.analysis import RecipeService
+from flameox.evidence import GenerationPublisher
+from flameox.storage import Workspace
+from tests.support.analysis import run_row
+
+
+def _event(
+    run_id: str,
+    observation_id: str,
+    name: str,
+    *,
+    category: str,
+    start_ns: int,
+    duration_ns: int,
+    phase: str | None = "decode",
+    correlation_id: str | None = None,
+    stream: str | None = None,
+    track_id: int | None = 7,
+    thread: int | None = None,
+    device: str = "cuda:0",
+    context: str | None = None,
+) -> dict[str, object]:
+    value = {
+        "category": category,
+        "start_ns": start_ns,
+        "duration_ns": duration_ns,
+        "track_id": track_id,
+        "thread": thread,
+        "phase": phase,
+        "correlation_id": correlation_id,
+        "device": device,
+        "context": context,
+        "stream": stream,
+    }
+    return {
+        "observation_id": observation_id,
+        "run_id": run_id,
+        "artifact_id": None,
+        "kind": "trace.event",
+        "name": name,
+        "value_json": json.dumps(value, sort_keys=True),
+        "file": None,
+        "line_from": None,
+        "line_to": None,
+        "context": phase,
+        "evidence_level": "observed",
+    }
+
+
+def test_accelerator_launches_counts_graphs_kernels_and_per_stream_gaps(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runs": [run_row("decode-run")],
+            "observations": [
+                _event(
+                    "decode-run",
+                    "direct",
+                    "cudaLaunchKernel",
+                    category="cuda_runtime",
+                    start_ns=0,
+                    duration_ns=3,
+                    correlation_id="41",
+                ),
+                _event(
+                    "decode-run",
+                    "graph",
+                    "cudaGraphLaunch",
+                    category="cuda_runtime",
+                    start_ns=4,
+                    duration_ns=2,
+                ),
+                _event(
+                    "decode-run",
+                    "annotation-named-like-direct-launch",
+                    "cudaLaunchKernel",
+                    category="user_annotation",
+                    start_ns=7,
+                    duration_ns=1,
+                ),
+                _event(
+                    "decode-run",
+                    "annotation-named-like-graph-launch",
+                    "cudaGraphLaunch",
+                    category="user_annotation",
+                    start_ns=8,
+                    duration_ns=1,
+                ),
+                _event(
+                    "decode-run",
+                    "kernel-a",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=10,
+                    duration_ns=5,
+                    correlation_id="41",
+                    stream="9",
+                ),
+                _event(
+                    "decode-run",
+                    "kernel-b",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=20,
+                    duration_ns=4,
+                    correlation_id="42",
+                    stream="9",
+                ),
+                _event(
+                    "decode-run",
+                    "warmup-kernel",
+                    "warmup_kernel",
+                    category="kernel",
+                    start_ns=1,
+                    duration_ns=100,
+                    phase="warmup",
+                    stream="9",
+                ),
+            ],
+        },
+        publisher="accelerator-fixture",
+        publisher_version="1",
+    )
+
+    result = RecipeService(workspace).accelerator_launches(
+        "decode-run",
+        phase="decode",
+    )
+
+    assert result.total == 1
+    assert result.coverage == {
+        "runtime_launches": True,
+        "accelerator_kernels": True,
+        "phase_annotations": True,
+        "correlation_ids": True,
+        "host_to_device_correlation": True,
+        "stream_identity": True,
+    }
+    region = result.regions[0]
+    assert region.region == "decode"
+    assert region.direct_launch_count == 1
+    assert region.graph_launch_count == 1
+    assert region.kernel_count == 2
+    assert region.kernel_duration_ns == 9
+    assert region.correlated_kernel_count == 1
+    assert region.idle_gap_count == 1
+    assert region.idle_gap_total_ns == 5
+    assert region.idle_gap_max_ns == 5
+    assert region.stream_count == 1
+    assert region.streams[0].device == "cuda:0"
+    assert region.streams[0].stream == "9"
+    assert region.streams[0].idle_gap_total_ns == 5
+    assert not region.streams_truncated
+    assert [(item.name, item.count) for item in region.kernel_names] == [("projection_kernel", 2)]
+
+    missing_phase = RecipeService(workspace).accelerator_launches(
+        "decode-run",
+        phase="missing",
+    )
+    assert missing_phase.total == 0
+    assert missing_phase.coverage["phase_annotations"]
+    assert any("matched phase 'missing'" in item for item in missing_phase.limitations)
+
+
+def test_accelerator_launch_comparison_reports_descriptive_region_deltas(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runs": [run_row("eager"), run_row("graph")],
+            "observations": [
+                _event(
+                    "eager",
+                    f"eager-{index}",
+                    "cudaLaunchKernel",
+                    category="cuda_runtime",
+                    start_ns=index * 10,
+                    duration_ns=2,
+                    correlation_id=f"eager-{index}",
+                )
+                for index in range(3)
+            ]
+            + [
+                _event(
+                    "eager",
+                    f"eager-kernel-{index}",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=100 + index * 10,
+                    duration_ns=5,
+                    correlation_id=f"eager-{index}",
+                    stream="9",
+                )
+                for index in range(3)
+            ]
+            + [
+                _event(
+                    "graph",
+                    "graph-launch",
+                    "cudaGraphLaunch",
+                    category="cuda_runtime",
+                    start_ns=0,
+                    duration_ns=3,
+                    correlation_id="graph",
+                )
+            ]
+            + [
+                _event(
+                    "graph",
+                    f"graph-kernel-{index}",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=100 + index * 10,
+                    duration_ns=5,
+                    correlation_id="graph",
+                    stream="9",
+                )
+                for index in range(3)
+            ],
+        },
+        publisher="accelerator-comparison-fixture",
+        publisher_version="1",
+    )
+
+    result = RecipeService(workspace).accelerator_launches(
+        "eager",
+        comparison_input_id="graph",
+    )
+
+    assert len(result.comparisons) == 1
+    comparison = result.comparisons[0]
+    assert comparison.region == "decode"
+    assert comparison.direct_launch_count_delta == -3
+    assert comparison.graph_launch_count_delta == 1
+    assert comparison.kernel_count_delta == 0
+    assert result.comparison_coverage is not None
+    assert result.comparison_coverage["accelerator_kernels"]
+    assert result.evidence.status == "available"
+    assert any("descriptive" in limitation for limitation in result.limitations)
+
+
+def test_accelerator_launches_keep_nsight_thread_and_device_streams_separate(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runs": [run_row("nsight-run")],
+            "observations": [
+                _event(
+                    "nsight-run",
+                    "runtime-thread-7",
+                    "cudaLaunchKernel",
+                    category="cuda_runtime",
+                    start_ns=0,
+                    duration_ns=2,
+                    track_id=None,
+                    thread=7,
+                ),
+                _event(
+                    "nsight-run",
+                    "runtime-thread-8",
+                    "cudaLaunchKernel",
+                    category="cuda_runtime",
+                    start_ns=10,
+                    duration_ns=2,
+                    track_id=None,
+                    thread=8,
+                ),
+                _event(
+                    "nsight-run",
+                    "kernel-device-0",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=20,
+                    duration_ns=5,
+                    stream="9",
+                    device="0",
+                    context="1",
+                ),
+                _event(
+                    "nsight-run",
+                    "kernel-device-1",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=30,
+                    duration_ns=5,
+                    stream="9",
+                    device="1",
+                    context="1",
+                ),
+            ],
+        },
+        publisher="nsight-identity-fixture",
+        publisher_version="1",
+    )
+
+    region = RecipeService(workspace).accelerator_launches("nsight-run").regions[0]
+
+    assert region.runtime_launch_gap_count == 0
+    assert region.idle_gap_count == 0
+    assert region.stream_count == 2
+    assert {(item.device, item.context, item.stream) for item in region.streams} == {
+        ("0", "1", "9"),
+        ("1", "1", "9"),
+    }
+
+
+def test_accelerator_launches_marks_missing_runtime_or_kernel_tracks_partial(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runs": [run_row("partial-run")],
+            "observations": [
+                _event(
+                    "partial-run",
+                    "graph-only",
+                    "cudaGraphLaunch",
+                    category="cuda_runtime",
+                    start_ns=0,
+                    duration_ns=2,
+                    phase="graph-only",
+                ),
+                _event(
+                    "partial-run",
+                    "kernel-only",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=10,
+                    duration_ns=3,
+                    phase="kernel-only",
+                    stream="9",
+                ),
+            ],
+        },
+        publisher="partial-accelerator-fixture",
+        publisher_version="1",
+    )
+
+    graph_only = RecipeService(workspace).accelerator_launches(
+        "partial-run",
+        phase="graph-only",
+    )
+    kernel_only = RecipeService(workspace).accelerator_launches(
+        "partial-run",
+        phase="kernel-only",
+    )
+
+    assert graph_only.evidence.status == "partial"
+    assert graph_only.coverage["runtime_launches"]
+    assert not graph_only.coverage["accelerator_kernels"]
+    assert kernel_only.evidence.status == "partial"
+    assert not kernel_only.coverage["runtime_launches"]
+    assert kernel_only.coverage["accelerator_kernels"]
+
+
+def test_accelerator_launches_reports_unscoped_zero_duration_evidence(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runs": [run_row("unscoped-run")],
+            "observations": [
+                _event(
+                    "unscoped-run",
+                    "runtime",
+                    "cudaLaunchKernel",
+                    category="cuda_runtime",
+                    start_ns=0,
+                    duration_ns=0,
+                    phase=None,
+                ),
+                _event(
+                    "unscoped-run",
+                    "kernel",
+                    "projection_kernel",
+                    category="kernel",
+                    start_ns=0,
+                    duration_ns=0,
+                    phase=None,
+                    stream="9",
+                ),
+            ],
+        },
+        publisher="unscoped-accelerator-fixture",
+        publisher_version="1",
+    )
+
+    result = RecipeService(workspace).accelerator_launches("unscoped-run")
+
+    assert result.regions[0].region == "<unscoped>"
+    assert result.regions[0].kernel_duration_ns == 0
+    assert not result.coverage["phase_annotations"]
+    assert not result.coverage["correlation_ids"]
+    assert any("grouped as <unscoped>" in item for item in result.limitations)

--- a/tests/application/test_capture_integrations.py
+++ b/tests/application/test_capture_integrations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -30,14 +31,35 @@ def test_torch_capture_launcher_does_not_require_flameox_in_workload_venv(
     )
 
     assert Path(invocation.argv[1]).name == "torch_launcher.py"
-    assert invocation.argv[2:] == (
+    assert invocation.argv[2:4] == (
         "--output",
         str(tmp_path / "torch-trace.json"),
+    )
+    assert invocation.argv[4] == "--config"
+    assert json.loads(invocation.argv[5])["mode"] == "whole_entrypoint"
+    assert invocation.argv[6:] == (
         "--module",
         "benchmarks.benchmark_kda_decode",
         "--repeats",
         "1",
     )
+
+
+def test_torch_capture_rejects_schedule_without_explicit_sdk_steps(tmp_path: Path) -> None:
+    with pytest.raises(DomainError) as failure:
+        build_capture_invocation(
+            "torch.profiler",
+            (sys.executable, "benchmark.py"),
+            tmp_path,
+            executable=None,
+            options={
+                "mode": "whole_entrypoint",
+                "schedule": {"wait": 1, "warmup": 1, "active": 1, "repeat": 1},
+            },
+        )
+
+    assert failure.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+    assert "explicit profile.step() calls" in failure.value.remediation[0]
 
 
 @pytest.mark.process

--- a/tests/application/test_capture_torch_provider.py
+++ b/tests/application/test_capture_torch_provider.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import pytest
 
 from flameox.application import CapabilityService, CaptureService, ExecutionPolicy
-from flameox.domain import CapabilityStatus, ExecutionStatus
+from flameox.domain import (
+    CapabilityReport,
+    CapabilityStatus,
+    CaptureStatus,
+    ExecutionStatus,
+)
 from flameox.storage import Workspace
 from tests.support.capture import disable_containment
 
@@ -51,3 +56,139 @@ timeout_seconds = 30
         if registration.kind.value == "execution_trace"
     )
     assert trace.display_name == "torch-trace.json"
+
+
+@pytest.mark.anyio
+@pytest.mark.process
+async def test_torch_profiler_sdk_registers_every_scheduled_cycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    (tmp_path / "torch.py").write_text(
+        "from contextlib import nullcontext\n"
+        "from pathlib import Path\n"
+        "class ProfilerActivity:\n"
+        "    CPU = 'cpu'\n"
+        "    CUDA = 'cuda'\n"
+        "class _Profile:\n"
+        "    def __init__(self, schedule, on_trace_ready, **_):\n"
+        "        self.schedule = schedule\n"
+        "        self.on_trace_ready = on_trace_ready\n"
+        "        self.index = 0\n"
+        "    def __enter__(self): return self\n"
+        "    def __exit__(self, *_): return False\n"
+        "    def step(self):\n"
+        "        self.index += 1\n"
+        "        width = self.schedule['wait'] + self.schedule['warmup'] + "
+        "self.schedule['active']\n"
+        "        relative = self.index - self.schedule['skip_first']\n"
+        "        if relative > 0 and relative % width == 0:\n"
+        "            self.on_trace_ready(self)\n"
+        "    def export_chrome_trace(self, path):\n"
+        "        Path(path).write_text('{\\\"traceEvents\\\": []}')\n"
+        "class profiler:\n"
+        "    ProfilerActivity = ProfilerActivity\n"
+        "    @staticmethod\n"
+        "    def schedule(**values): return values\n"
+        "    @staticmethod\n"
+        "    def profile(**values): return _Profile(**values)\n"
+        "    @staticmethod\n"
+        "    def record_function(_): return nullcontext()\n"
+        "class cuda:\n"
+        "    @staticmethod\n"
+        "    def is_available(): return False\n"
+    )
+    (tmp_path / "scheduled_workload.py").write_text(
+        "from flameox.sdk import torch_profiler\n"
+        "with torch_profiler() as session:\n"
+        "    for index in range(6):\n"
+        "        with session.phase('warmup' if index < 2 else 'decode'):\n"
+        "            pass\n"
+        "        session.step()\n"
+    )
+    (tmp_path / "invalid_export.py").write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "root = Path(os.environ['FLAMEOX_TORCH_PROFILER_OUTPUT_ROOT'])\n"
+        "root.joinpath('torch-trace-cycle-0000.json').write_text('{}')\n"
+        "root.joinpath('torch-trace-cycle-0001.json').write_text('{}')\n"
+    )
+    (tmp_path / "flameox.toml").write_text(
+        """
+schema_version = 1
+[workloads.scheduled]
+argv = ["python", "scheduled_workload.py"]
+cwd = "."
+timeout_seconds = 30
+[workloads.invalid]
+argv = ["python", "invalid_export.py"]
+cwd = "."
+timeout_seconds = 30
+"""
+    )
+    disable_containment(workspace)
+    report = CapabilityReport(
+        adapter="torch.profiler",
+        status=CapabilityStatus.AVAILABLE,
+        version="fixture",
+        supported_modes=("sdk",),
+        supported_formats=("chrome-trace",),
+        permission_status="granted",
+        probe_kind="passive",
+    )
+    service = CaptureService(workspace)
+    monkeypatch.setattr(service.capabilities, "get", lambda _adapter: report)
+    plan = await service.plan(
+        workload_name="scheduled",
+        adapter="torch.profiler",
+        adapter_options={
+            "mode": "sdk",
+            "activities": ["cpu"],
+            "record_shapes": False,
+            "profile_memory": False,
+            "with_stack": False,
+            "schedule": {
+                "wait": 1,
+                "warmup": 1,
+                "active": 1,
+                "repeat": 2,
+                "skip_first": 0,
+            },
+        },
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    result = await service.execute(plan.plan_id)
+
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert plan.adapter_options["mode"] == "sdk"
+    schedule = plan.adapter_options["schedule"]
+    assert isinstance(schedule, dict)
+    assert schedule["repeat"] == 2
+    assert "without shapes, memory, stacks" in plan.expected_overhead
+    traces = [
+        registration
+        for registration in result.run.artifacts
+        if registration.kind.value == "execution_trace"
+    ]
+    assert [item.role for item in traces] == ["cycle_0000", "cycle_0001"]
+    assert [item.display_name for item in traces] == [
+        "torch-trace-cycle-0000.json",
+        "torch-trace-cycle-0001.json",
+    ]
+    manifest = next(
+        item for item in result.run.artifacts if item.role == "torch_profiler_cycle_manifest"
+    )
+    assert manifest.display_name == "torch-profiler-cycles.json"
+
+    invalid_plan = await service.plan(
+        workload_name="invalid",
+        adapter="torch.profiler",
+        adapter_options=plan.adapter_options,
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    invalid = await service.execute(invalid_plan.plan_id)
+    assert invalid.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert invalid.run.capture_status is CaptureStatus.FAILED
+    assert all(item.kind.value != "execution_trace" for item in invalid.run.artifacts)

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 381
+expected_test_count = 408
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -29,22 +29,26 @@ expected_test_count = 381
 'tests/mcp/test_workflows.py' = 'tests/mcp/test_server.py'
 
 [moved_digests]
-'tests/adapters/test_perfetto.py' = 'f10a653fb41df80732bff21b5351b1f4eacfb30dcb358f3b690fb3dc5d3fe70f'
+'tests/adapters/test_perfetto.py' = 'c4a12900de4584860227f61bc86b606fc78a76b0d533ea3aa8558dbfa422caf8'
 'tests/analysis/test_recipes.py' = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e'
 'tests/application/test_records_and_comparisons.py' = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759'
-'tests/application/test_workloads_and_capture.py' = '72520d0f76ba10ca4eec4e0b4db2370783c9e8532e0f1d52314829951f9db167'
-'tests/mcp/test_server.py' = 'ab9f9d9f2b4fa37a7ebba360ce480f9cd81e2389e6e307ab035efe3ff9ae6e26'
+'tests/application/test_workloads_and_capture.py' = '71dee8107660f1630ba0e35c5657be53c9f99a436edcad34f152ac7b996e04f9'
+'tests/mcp/test_server.py' = '4ae328b622a03523015cf982bc0d7855c2797561871882b769f935e3d9ad3342'
 'tests/test_cli_setup.py' = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561'
 
 [files]
+'tests/adapters/test_benchmark_samples.py' = { count = 8, digest = '71e398543a29c75f059be8b1ba659ee80952b9407ef0295b7fa9bfe736ad05d3' }
 'tests/adapters/test_coverage.py' = { count = 3, digest = 'a9aa85687b6f34101ebcf2d6b69c22c866f9279436bdb9cbaff2793dba714891' }
 'tests/adapters/test_memray.py' = { count = 3, digest = '929b943d44dd1e64914730a760870fb7f87154c0a036e7d6ef355ce42d858c66' }
-'tests/adapters/test_perfetto.py' = { count = 5, digest = 'f10a653fb41df80732bff21b5351b1f4eacfb30dcb358f3b690fb3dc5d3fe70f' }
+'tests/adapters/test_nsight_systems.py' = { count = 3, digest = '7ec426b7b696b756555b143d99820c6d61efd5cf2632ec2d70d10d8c496c6728' }
+'tests/adapters/test_perfetto.py' = { count = 6, digest = 'f10a653fb41df80732bff21b5351b1f4eacfb30dcb358f3b690fb3dc5d3fe70f' }
+'tests/adapters/test_perfetto_normalization.py' = { count = 1, digest = '1590a06a80ccf72735753b892d3d06ab654b42cf3c170630c5365493ddcccf52' }
 'tests/adapters/test_pyperf.py' = { count = 4, digest = 'a0b5fdf06a752d5d375254b2f05a5f6962df9a1e917181695f13ce6f24923fb5' }
 'tests/adapters/test_pytest.py' = { count = 6, digest = 'd7756e162c74611dd6c160c09586b40e4361157d3f021dc2497247a9bfed1a50' }
 'tests/adapters/test_python_startup.py' = { count = 8, digest = '8cfb0e6e9eeb98fad169198876908f40b710c9d138284860869c9f0713fd2538' }
 'tests/adapters/test_setup_runtime.py' = { count = 5, digest = '7d2b902ed64a32c461b2425a20c404583fbfd6d9996f57a1c621194620109b5b' }
 'tests/analysis/test_comparison.py' = { count = 4, digest = '311406582a5fda58dbd1e74e6f7dff58cbe2bb760536031bb160f0c50ff08fa2' }
+'tests/analysis/test_accelerator_launches.py' = { count = 5, digest = '18ccb9f28a57ca95ea14812749035748ee2d89a6b07bef45fc7376f5e12d58e3' }
 'tests/analysis/test_recipes.py' = { count = 8, digest = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e' }
 'tests/application/test_analysis_records.py' = { count = 1, digest = '7a08286f866dbeef9c9a0500cead2b3ebf6ee6546f455ed3b5cc5407ee84b69f' }
 'tests/application/test_artifact_service.py' = { count = 2, digest = '2ed111222920a42e8679d1e0281f185dc0d28406470ca888d80d0a01cd87731c' }
@@ -75,17 +79,17 @@ expected_test_count = 381
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = 'd169c20bdbb6f514887e75fe045f1a8950f946d915abc6d22d6836ac1959ab0c' }
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
 'tests/application/test_workloads.py' = { count = 4, digest = '8498d6450bad63aec49693d92b49d53555d8f134492f13f4fa8e1502adb9f758' }
-'tests/application/test_workloads_and_capture.py' = { count = 44, digest = 'e46978fe067047aa9a06ce2685fbec0f84179e220ffe112f9b9dcdfb37dcc298' }
+'tests/application/test_workloads_and_capture.py' = { count = 46, digest = 'e46978fe067047aa9a06ce2685fbec0f84179e220ffe112f9b9dcdfb37dcc298' }
 'tests/application/test_operations.py' = { count = 5, digest = '2e31c1f386284e3c91f0dc6cbabd839c98e38aa2c46f52c175fd0629e9044c5c' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
 'tests/domain/test_models.py' = { count = 11, digest = '3c66f63c2bd90a4d7af1393bd59fe08072fe9872cf2a3c0d101095ba6280e016' }
-'tests/evidence/test_publication_and_catalog.py' = { count = 17, digest = '904a72fd43176a273a70dcd092d849e8dd68e1231f468228e138baeadc1170e1' }
+'tests/evidence/test_publication_and_catalog.py' = { count = 18, digest = 'c2041778f149b58dd083ca85ca0a2f0d3fd588b01b214dc0febb9cd8f4179a4f' }
 'tests/execution/test_broker.py' = { count = 9, digest = '6be6c693f711f82a7de7387e1672b1226b3de6c005c87b73c3a6030c81f8786e' }
 'tests/golden/test_configuration_observations.py' = { count = 1, digest = '5cd37d54fc034cd103b3acbad18e1a9771b64e76fe4ec892c068ef36c94179f4' }
 'tests/golden/test_memory_regression.py' = { count = 1, digest = '7898013cd64ec203e28d00b6549f002586a2d23f0c06eba6f1c979478f1aac1e' }
 'tests/golden/test_reverse_scan.py' = { count = 1, digest = '11e8db62d67d86b3e2be63a8e3425dbd7927329f4d405a3d6718251286a20bea' }
 'tests/mcp/test_agent_workflows.py' = { count = 6, digest = 'a2acbf5c684611b29f8b69aca1ab5f1f0743e36c32d807a7206826de1e481011' }
-'tests/mcp/test_server.py' = { count = 31, digest = 'ab9f9d9f2b4fa37a7ebba360ce480f9cd81e2389e6e307ab035efe3ff9ae6e26' }
+'tests/mcp/test_server.py' = { count = 37, digest = 'ab9f9d9f2b4fa37a7ebba360ce480f9cd81e2389e6e307ab035efe3ff9ae6e26' }
 'tests/performance/test_catalog_scale.py' = { count = 4, digest = '1c7587225525c2e0cc877bf62105c1d2447ec5d230e0a9d0eaef0ae7322e9214' }
 'tests/security/test_offline.py' = { count = 1, digest = 'a9de75a583146be9fccb27627ae4fdd6d6f3265912dad9423fe97415ba833fd3' }
 'tests/storage/test_artifacts_and_runs.py' = { count = 14, digest = '0f27557254a46c2635bf5cfd47766e05d84e3bb38becf8d8bf6271cd2ebbfc2e' }

--- a/tests/evidence/test_publication_and_catalog.py
+++ b/tests/evidence/test_publication_and_catalog.py
@@ -71,6 +71,41 @@ def test_publication_is_visible_only_through_new_corpus_commit(tmp_path: Path) -
         ).fetchone() == (0,)
 
 
+def test_idempotent_publication_reuses_or_supersedes_exact_operation(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    publisher = GenerationPublisher(workspace)
+
+    first = publisher.publish_rows_idempotent(
+        {"runs": [run_row("normalized-run")]},
+        publisher="extractor",
+        publisher_version="1",
+        input_run_ids=("source-run",),
+        operation_identity={"tool_digest": "sha256:first"},
+    )
+    repeated = publisher.publish_rows_idempotent(
+        {"runs": [run_row("normalized-run")]},
+        publisher="extractor",
+        publisher_version="1",
+        input_run_ids=("source-run",),
+        operation_identity={"tool_digest": "sha256:first"},
+    )
+    changed = publisher.publish_rows_idempotent(
+        {"runs": [run_row("normalized-run")]},
+        publisher="extractor",
+        publisher_version="1",
+        input_run_ids=("source-run",),
+        operation_identity={"tool_digest": "sha256:second"},
+    )
+
+    assert repeated.commit.commit_id == first.commit.commit_id
+    assert repeated.manifest.generation_id == first.manifest.generation_id
+    assert changed.manifest.supersedes == (first.manifest.generation_id,)
+    assert changed.manifest.operation_digest != first.manifest.operation_digest
+    assert len(workspace.corpus.read_head().generation_manifests) == 1
+    with Catalog(workspace).open_snapshot() as snapshot:
+        assert snapshot.execute("SELECT count(*) FROM runs").fetchone() == (1,)
+
+
 def test_rogue_parquet_file_is_invisible_without_manifest(tmp_path: Path) -> None:
     workspace = Workspace.initialize(tmp_path)
     catalog = Catalog(workspace)

--- a/tests/mcp/test_contracts.py
+++ b/tests/mcp/test_contracts.py
@@ -105,6 +105,89 @@ async def test_every_mcp_tool_has_bounded_object_schemas_and_annotations(
 
 
 @pytest.mark.anyio
+async def test_accelerator_tools_advertise_bounded_v2_schemas(tmp_path: Path) -> None:
+    Workspace.initialize(tmp_path)
+    async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+
+    launches = tools["analyze_accelerator_launches"].input_schema["properties"]
+    assert launches["run_or_artifact"]["minLength"] == 1
+    assert launches["run_or_artifact"]["maxLength"] == 200
+    assert launches["limit"] == {
+        "description": "Maximum regions and kernel names to return.",
+        "maximum": 1000,
+        "minimum": 1,
+        "title": "Limit",
+        "type": "integer",
+    }
+    for name in ("extract_benchmark_samples", "extract_nsight_systems"):
+        run_id = tools[name].input_schema["properties"]["run_id"]
+        assert run_id["minLength"] == 1
+        assert run_id["maxLength"] == 200
+
+    perfetto = tools["extract_perfetto"].input_schema["properties"]
+    assert perfetto["run_id"]["minLength"] == 1
+    assert perfetto["artifact_id"]["anyOf"][0]["minLength"] == 1
+    profiler = tools["plan_capture"].input_schema["$defs"]["TorchProfilerCaptureOptions"]
+    assert profiler["additionalProperties"] is False
+    schedule = tools["plan_capture"].input_schema["$defs"]["TorchProfilerSchedule"]
+    assert schedule["additionalProperties"] is False
+    assert schedule["properties"]["repeat"]["maximum"] == 100
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "expected_fields"),
+    [
+        (
+            "analyze_accelerator_launches",
+            {"run_or_artifact": "run", "limit": True},
+            ("limit",),
+        ),
+        ("extract_benchmark_samples", {"run_id": ""}, ("run_id",)),
+        ("extract_nsight_systems", {"run_id": ""}, ("run_id",)),
+        ("extract_perfetto", {"run_id": "run", "artifact_id": ""}, ("artifact_id",)),
+        (
+            "plan_capture",
+            {
+                "workload_name": "workload",
+                "adapter": "torch.profiler",
+                "parameters": {},
+                "torch_profiler_options": {
+                    "mode": "sdk",
+                    "record_shapes": 1,
+                    "schedule": {"active": True},
+                },
+            },
+            (
+                "torch_profiler_options.record_shapes",
+                "torch_profiler_options.schedule.active",
+            ),
+        ),
+    ],
+)
+async def test_accelerator_tools_return_typed_errors_for_invalid_wire_values(
+    tmp_path: Path,
+    tool_name: str,
+    arguments: dict[str, object],
+    expected_fields: tuple[str, ...],
+) -> None:
+    Workspace.initialize(tmp_path)
+    async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+        result = await client.call_tool(tool_name, arguments)
+
+    assert result.is_error is True
+    assert result.structured_content is not None
+    assert result.structured_content["error"]["code"] == "INVALID_ARGUMENTS"
+    fields = result.structured_content["error"]["details"]["fields"]
+    assert set(expected_fields) <= {item["field"] for item in fields}
+    assert not list(
+        Draft202012Validator(tools[tool_name].output_schema).iter_errors(result.structured_content)
+    )
+
+
+@pytest.mark.anyio
 async def test_mcp_domain_errors_remain_structured(tmp_path: Path) -> None:
     async with Client(create_server(tmp_path), raise_exceptions=True) as client:
         result = await client.call_tool("workspace_status", {})

--- a/tests/mcp/test_workflows.py
+++ b/tests/mcp/test_workflows.py
@@ -148,7 +148,7 @@ async def test_mcp_inspect_instructions_match_initialize_metadata(tmp_path: Path
     inspected = json.loads(cli.stdout)
     assert inspected["schema_version"] == 1
     assert inspected["instructions"] == initialize_instructions
-    assert len(inspected["tools"]) == 66
+    assert len(inspected["tools"]) == 69
 
 
 @pytest.mark.anyio

--- a/tests/ownership.toml
+++ b/tests/ownership.toml
@@ -28,7 +28,11 @@ markers = ["integration", "optional", "requires_memray"]
 [[ownership]]
 owner = "adapters"
 lane = "adapters"
-paths = ["tests/adapters/test_pyperf.py", "tests/adapters/test_python_startup.py"]
+paths = [
+  "tests/adapters/test_benchmark_samples.py",
+  "tests/adapters/test_pyperf.py",
+  "tests/adapters/test_python_startup.py",
+]
 markers = ["unit"]
 
 
@@ -507,6 +511,24 @@ markers = ["integration", "process", "serial"]
 owner = "execution-recipes"
 lane = "analysis"
 paths = ["tests/analysis/test_execution_recipes.py"]
+markers = ["integration"]
+
+[[ownership]]
+owner = "accelerator-launch-recipes"
+lane = "analysis"
+paths = ["tests/analysis/test_accelerator_launches.py"]
+markers = ["integration"]
+
+[[ownership]]
+owner = "nsight-systems-adapter"
+lane = "process"
+paths = ["tests/adapters/test_nsight_systems.py"]
+markers = ["integration", "process", "serial"]
+
+[[ownership]]
+owner = "perfetto-phase-normalization"
+lane = "adapters"
+paths = ["tests/adapters/test_perfetto_normalization.py"]
 markers = ["integration"]
 
 [[ownership]]

--- a/uv.lock
+++ b/uv.lock
@@ -676,8 +676,8 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5.4,<1.6" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.130" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.2" },
-    { name = "mcp", specifier = "==2.0.0b2" },
-    { name = "mcp-types", specifier = "==2.0.0b2" },
+    { name = "mcp", specifier = "==2.0.0" },
+    { name = "mcp-types", specifier = "==2.0.0" },
     { name = "memray", marker = "extra == 'all'", specifier = ">=1.17" },
     { name = "memray", marker = "extra == 'memory'", specifier = ">=1.17" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15" },
@@ -1128,7 +1128,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "2.0.0b2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1137,7 +1137,6 @@ dependencies = [
     { name = "mcp-types" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1147,22 +1146,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/aa/c5d38e0199304494be6370667d04d93d8681d9bdc864d56678250dbd3f3b/mcp-2.0.0b2.tar.gz", hash = "sha256:0528d0d38ae798fbff251616ec687faaaa8f5309571e0b2bc553c530fa10b8b1", size = 1590650, upload-time = "2026-07-14T16:47:57.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/90/187d6283a304acc6954987992ef17e2515739a649f148dc8b67b302e1bbd/mcp-2.0.0b2-py3-none-any.whl", hash = "sha256:9c50ae5afa08960ab76d50aa3adab3184952d9bea7ef87f4a4a5ba68bdefcf0a", size = 334286, upload-time = "2026-07-14T16:47:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [[package]]
 name = "mcp-types"
-version = "2.0.0b2"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/21/db529130ac8edd1d844fc322862afeceaf2b7f610a591fa528002b022e07/mcp_types-2.0.0b2.tar.gz", hash = "sha256:094fa7160106819ab39a1586179c3a9f070bfd833d0a6f8fcb30a54a986cc402", size = 65877, upload-time = "2026-07-14T16:47:59.198Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/e1/c466ceacdaa929396d35ad45176398acd0c416fead0970d3ad22618a19d7/mcp_types-2.0.0b2-py3-none-any.whl", hash = "sha256:35c9c33abb90a77dc6ad1daecaa6407c788c2f32d14d52dad8f843c4f008eae2", size = 68944, upload-time = "2026-07-14T16:47:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -2004,20 +2003,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2139,15 +2124,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Flameox can now carry an accelerator launch investigation from bounded capture or import through normalized evidence and curated analysis. The new workflow adds scheduled `torch.profiler` capture, producer-neutral benchmark samples, maintained Nsight Systems SQLite extraction, and a shared launch/idle-gap analysis over Perfetto or Nsight trace events.

This progresses #80, #81, #82, and #83. It intentionally does not close them: the Nsight compatibility fixture is not yet pinned to a certified vendor release, the local Perfetto provider was unavailable for live optional validation, and several broader acceptance cases remain on the issues.

## Approach

```text
scheduled torch capture ─┐
Perfetto-compatible trace ├─> immutable artifact ─> bounded normalization ─> launch analysis
Nsight SQLite export ─────┘                                  │
structured samples ─────────> immutable artifact ─> measurements
                                                            │
                                                      CLI and MCP
```

- Bind Torch activities, feature flags, mode, and schedule into the capture-plan digest. SDK mode exposes only explicit `step()` and trace-visible phase ranges, writes each cycle to a distinct path, and registers a validated cycle manifest.
- Normalize Perfetto and supported Nsight CUDA/NVTX tables into one versioned `trace.event` contract with source clock, correlation, stream, phase, coverage, truncation, and extractor provenance.
- Add an idempotent generation-publication path keyed by exact inputs and operation identity. Changed extraction identities supersede prior normalized generations without rewriting them.
- Add bounded direct-launch, graph-launch, kernel, runtime-gap, and per-stream idle-gap summaries. Missing runtime or accelerator tracks remain typed partial evidence, and comparisons stay descriptive rather than claiming equivalent work.
- Add `flameox.benchmark-samples.v1` for exact raw samples with declared clock, synchronization, device, phase, dimensions, and producer identity.
- Expose the workflows through the existing CLI, MCP, and materialized-analysis surfaces, and move the exact MCP pins from `2.0.0b2` to stable `2.0.0`.

Suggested review order: capture schemas and publication identity; Torch SDK/capture lifecycle; Perfetto and Nsight normalization; launch analysis and public surfaces; tests and documentation.

## Commands run

```console
uv run ruff check src tests tools
uv run ruff format --check src tests tools
uv run mypy src tests tools
uv run python tools/test.py core        # 297 passed, 111 deselected; 68.56% coverage
uv run python tools/test.py process     # 85 passed
uv run python tools/test.py collection  # 408 node IDs preserved
uv run python tools/test.py ownership   # 81 ownership records validated
uv run lint-imports                     # 2 contracts kept
uv run python tools/test.py optional-torch     # 2 passed
uv run python tools/test.py optional-perfetto  # 7 skipped: local provider unavailable
```

## Compatibility

- Existing whole-entrypoint Torch capture remains the default. Schedules require explicit SDK mode and workload-owned step boundaries.
- `CapturePlan.adapter_options` defaults to an empty object, and `GenerationManifest.operation_digest` is optional, so existing serialized plans and manifests remain readable.
- Nsight support is import-only for official SQLite exports registered as `nsight.systems`; Flameox does not parse `.nsys-rep` or require `nsys` during extraction.
- Perfetto and Nsight outputs remain bounded and curated; no arbitrary SQL surface is added.
- The stable MCP 2.0 template-resource context limitation remains documented, and resource handlers retain the server-local lifespan closure until the upstream fix is available in the pinned release.
