### PR TITLE
feat: preserve declared workloads and guide capability setup

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -218,7 +218,8 @@ evidence completeness. Separate compilation/warm-up from steady state.
 The adapter has three explicit capability tiers:
 
 - trace import for an existing Chrome/Perfetto-compatible export;
-- whole-entrypoint launcher mode for a declared Python script or module, with no
+- whole-entrypoint launcher mode for a declared Python script, module, or inline
+  `python -c` program, with no
   promise of application-specific phase separation;
 - SDK/recipe mode for user-instrumented steps, phases, schedules, and semantic
   annotations.
@@ -236,7 +237,9 @@ artifact ID; cycle roles survive normalization and keep regions separate.
 
 Arbitrary non-Python commands cannot be transparently wrapped by
 `torch.profiler`; the adapter must report that limitation instead of pretending
-to provide operator evidence. `with_modules` is treated as a TorchScript-only
+to provide operator evidence. Declared inline programs run through a stable
+synthetic filename and remain bound to the workload's exact argv; callers do
+not need to create a checkout script. `with_modules` is treated as a TorchScript-only
 capability unless current upstream behavior proves otherwise; FLOP coverage is
 operator-limited. Scheduled captures must register every exported cycle or
 explicitly state that only the final cycle was retained.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -164,9 +164,11 @@ flameox experiment trial <trial-id> [--experiment-id <experiment-id>]
 `flameox.toml` is the project-owned workload declaration. Its strict schema is
 `[workloads.<name>]` with an argument array `argv`, project-relative `cwd`,
 positive `timeout_seconds`, bounded `parameters` choices, an environment map,
-optional `oracle`, `requirements`, `writable_paths`, and `identity`. Templates
-may reference only plain scalar parameter names such as `{size}`; shell strings,
-shell expansion, and trailing `-- <argv...>` forms are unsupported.
+optional `oracle`, `requirements`, `writable_paths`, and `identity`. An exact
+plain scalar token such as `{size}` renders from a declared parameter; other
+braces in an argument, including JSON and Python literals, remain literal.
+Unknown exact tokens such as `{missing}` are rejected. Shell strings, shell
+expansion, and trailing `-- <argv...>` forms are unsupported.
 
 MCP's `configure_workload` is the direct agent path for this schema. It accepts
 the same typed fields, supports explicit `create` and `replace` operations, and
@@ -366,11 +368,11 @@ initialize_workspace
   → configure_workload (when missing)
   → list_declared_workflows (no arguments lists workloads; use kind='experiment' for experiments)
   → get_declared_workflow
-  → list_capabilities
-  → start_capability_setup (when setup_adapters is non-empty)
-  → prepare_adapter (when setup_third_party_adapters is non-empty)
+  → list_capabilities(adapter='<selected adapter>')
+  → start_capability_setup (when the scoped setup_adapters is non-empty)
+  → prepare_adapter (when the scoped setup_third_party_adapters is non-empty)
   → prepare_workload_dependencies (when the workload declares missing Python distributions)
-  → list_capabilities
+  → list_capabilities(adapter='<selected adapter>')
   → plan_capture (preflight_mode='auto')
   → execute_capture_plan
 ```
@@ -433,11 +435,19 @@ usage, active captures, and warnings.
 
 Read-only. Returns adapter capabilities, installed versions, required
 permissions, unavailable features, remediation, and typed managed setup
-actions. `setup_adapters` is the bounded list of missing providers FlameOx can
-install; `setup_third_party_adapters` identifies installed entry points that
-need exact identity approval through `prepare_adapter`. Call the relevant setup
-tool and then call `list_capabilities` again. The default call performs only
-passive inspection.
+actions. Pass the adapter selected for the capture or analysis workflow to
+scope mutation guidance to that goal. In a scoped result, `setup_adapters` is
+the bounded list of missing providers FlameOx can install and
+`setup_third_party_adapters` identifies installed entry points that need exact
+identity approval through `prepare_adapter`. Call the relevant setup tool and
+then call `list_capabilities(adapter=...)` again.
+
+Omit `adapter` for a complete inventory. The inventory keeps
+`available_setup_adapters` and `available_setup_third_party_adapters` as
+informational lists, but returns no `next_tool` or prescriptive setup list;
+each capability's own setup field remains the source of the exact action. This
+prevents broad discovery from turning into an instruction to install unrelated
+providers.
 Active executable probes are separately requested, bounded, and executed
 through the subprocess broker; merely listing capabilities does not run a
 project-controlled binary found on `PATH`. The `active_cached` mode uses a
@@ -458,7 +468,11 @@ Mutating but non-executing. This compatibility entry point starts a durable
 operation and returns its operation ID instead of holding an MCP request open.
 Use `start_capability_setup` with an explicit idempotency key for new callers,
 `get_capability_setup` to reconnect and poll, and `cancel_capability_setup` to
-request cleanup. The operation accepts only adapter names reported by
+request cleanup. While setup is `starting` or `running`, its status includes a
+bounded `poll_after_ms` and a `recovery` action with the exact
+`get_capability_setup(operation_id=...)` call. Follow that delay and action;
+terminal states omit polling guidance and retain their terminal recovery. The
+operation accepts only adapter names reported by
 `list_capabilities` as managed setup actions: `coverage`, `memray`, `perfetto`,
 `py-spy`, `pytest`, and `torch.profiler`. It installs the published FlameOx
 extra into the active managed Python runtime and stages the pinned user-space
@@ -538,7 +552,17 @@ arguments.
 Python profiler adapters keep the declared workload interpreter and working
 directory, including for `python -m` workloads, while invoking FlameOx's
 standalone launcher directly. They do not require FlameOx to be importable from
-the workload virtualenv and do not enable `PYTHONPATH` overrides.
+the workload virtualenv and do not enable `PYTHONPATH` overrides. The
+`torch.profiler` whole-entrypoint adapter also accepts declared `python -c`
+workloads; it executes the exact inline program through a FlameOx-owned
+synthetic filename and records that bound argv in the plan. Undeclared commands
+and arbitrary replacement argv remain unsupported.
+
+Workload templates recognize only exact plain scalar tokens such as `{size}`.
+Other braces in an argv item, including JSON and Python literals, are passed
+through unchanged. An exact `{unknown}` token is still rejected unless that
+parameter is declared. Existing doubled-brace escapes continue to collapse to a
+single literal brace.
 
 #### `plan_experiment` and `run_experiment`
 

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -391,7 +391,7 @@ def _torch_capture_invocation(
     *,
     options: dict[str, object] | None,
 ) -> CaptureInvocation:
-    python, target = _python_target(workload_argv)
+    python, target = _torch_python_target(workload_argv)
     selected = torch_profiler_options(options)
     config = selected.model_dump(mode="json")
     config["expected_cycles"] = selected.expected_cycles
@@ -459,7 +459,9 @@ def _torch_capture_invocation(
                 "FLAMEOX_TORCH_PROFILER_OUTPUT_ROOT": str(output_root),
             },
         )
-    if target[0] == "-m":
+    if target[0] == "-c":
+        launcher_target = (f"--inline-code={target[1]}", *target[2:])
+    elif target[0] == "-m":
         if len(target) < 2:
             raise DomainError(
                 ErrorCode.INVALID_CAPTURE_PLAN,
@@ -505,6 +507,37 @@ def _python_target(
             "Inline Python commands cannot be wrapped by this adapter.",
             remediation=("Declare a script or `python -m module` workload.",),
         )
+    return workload_argv[0], arguments
+
+
+def _torch_python_target(
+    workload_argv: tuple[str, ...],
+) -> tuple[str, tuple[str, ...]]:
+    """Resolve Python targets supported by the torch whole-entrypoint launcher."""
+    if not workload_argv:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "The declared Python workload command is missing.",
+        )
+    executable = Path(workload_argv[0]).name
+    if not executable.startswith("python"):
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "This adapter can launch only a declared Python script, module, or inline command.",
+        )
+    arguments = workload_argv[1:]
+    if not arguments:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "The declared Python workload target is missing.",
+        )
+    if arguments[0] == "-c" and len(arguments) < 2:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "The inline Python program is missing.",
+        )
+    if arguments[0] != "-c":
+        return _python_target(workload_argv)
     return workload_argv[0], arguments
 
 

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -460,7 +460,7 @@ def _torch_capture_invocation(
             },
         )
     if target[0] == "-c":
-        launcher_target = (f"--inline-code={target[1]}", *target[2:])
+        launcher_target = (f"--inline-code={target[1]}", "--", *target[2:])
     elif target[0] == "-m":
         if len(target) < 2:
             raise DomainError(

--- a/src/flameox/application/capabilities.py
+++ b/src/flameox/application/capabilities.py
@@ -49,6 +49,9 @@ class CapabilityList(ContractModel):
     capabilities: tuple[CapabilityReport, ...]
     setup_adapters: tuple[str, ...] = ()
     setup_third_party_adapters: tuple[str, ...] = ()
+    available_setup_adapters: tuple[str, ...] = ()
+    available_setup_third_party_adapters: tuple[str, ...] = ()
+    recommendation_scope: str | None = None
     latest_setup: CapabilitySetupReceipt | None = None
     next_tool: Literal["prepare_capabilities", "prepare_adapter", "list_capabilities"] | None = None
 
@@ -129,6 +132,12 @@ class CapabilityService:
         self._active_cache: dict[str, CapabilityReport] = {}
 
     def list(self) -> CapabilityList:
+        return self._list()
+
+    def list_for_adapter(self, adapter: str) -> CapabilityList:
+        return self._list(recommendation_adapter=adapter)
+
+    def _list(self, *, recommendation_adapter: str | None = None) -> CapabilityList:
         system = platform.system().lower()
         architecture = platform.machine().lower()
         reports: list[CapabilityReport] = []
@@ -324,23 +333,36 @@ class CapabilityService:
                         setup_verification=("pending" if not descriptor.approved else "passive"),
                     )
                 )
-        return self._finish(reports, latest_setup=self._read_setup_receipt())
+        return self._finish(
+            reports,
+            latest_setup=self._read_setup_receipt(),
+            recommendation_adapter=recommendation_adapter,
+        )
 
-    async def list_active(self, *, refresh: bool = False) -> CapabilityList:
+    async def list_active(
+        self,
+        *,
+        refresh: bool = False,
+        recommendation_adapter: str | None = None,
+    ) -> CapabilityList:
         passive = self.list()
         reports: list[CapabilityReport] = []
         for report in passive.capabilities:
-            adapter = builtin_adapter(report.adapter)
+            definition = builtin_adapter(report.adapter)
             version_args = (
-                adapter.version_args
-                if adapter is not None
+                definition.version_args
+                if definition is not None
                 else _CONTAINMENT_VERSION_ARGS.get(report.adapter, ())
             )
             if not version_args or report.executable is None:
                 reports.append(report)
                 continue
             reports.append(await self.probe(report.adapter, refresh=refresh))
-        return self._finish(reports, latest_setup=passive.latest_setup)
+        return self._finish(
+            reports,
+            latest_setup=passive.latest_setup,
+            recommendation_adapter=recommendation_adapter,
+        )
 
     async def probe(self, adapter: str, *, refresh: bool = False) -> CapabilityReport:
         if not refresh and adapter in self._active_cache:
@@ -865,8 +887,9 @@ class CapabilityService:
         reports: Sequence[CapabilityReport],
         *,
         latest_setup: CapabilitySetupReceipt | None = None,
+        recommendation_adapter: str | None = None,
     ) -> CapabilityList:
-        setup_adapters = tuple(
+        available_setup_adapters = tuple(
             sorted(
                 item.adapter
                 for item in reports
@@ -874,7 +897,7 @@ class CapabilityService:
                 and isinstance(item.setup, CapabilitySetup)
             )
         )
-        setup_third_party_adapters = tuple(
+        available_setup_third_party_adapters = tuple(
             sorted(
                 item.adapter
                 for item in reports
@@ -882,10 +905,30 @@ class CapabilityService:
                 and isinstance(item.setup, AdapterSetup)
             )
         )
+        scoped_reports = (
+            tuple(item for item in reports if item.adapter == recommendation_adapter)
+            if recommendation_adapter is not None
+            else ()
+        )
+        setup_adapters = tuple(
+            item.adapter
+            for item in scoped_reports
+            if item.status is not CapabilityStatus.AVAILABLE
+            and isinstance(item.setup, CapabilitySetup)
+        )
+        setup_third_party_adapters = tuple(
+            item.adapter
+            for item in scoped_reports
+            if item.status is not CapabilityStatus.AVAILABLE
+            and isinstance(item.setup, AdapterSetup)
+        )
         return CapabilityList(
             capabilities=tuple(reports),
             setup_adapters=setup_adapters,
             setup_third_party_adapters=setup_third_party_adapters,
+            available_setup_adapters=available_setup_adapters,
+            available_setup_third_party_adapters=available_setup_third_party_adapters,
+            recommendation_scope=recommendation_adapter,
             latest_setup=latest_setup,
             next_tool=(
                 "prepare_capabilities"

--- a/src/flameox/application/operations.py
+++ b/src/flameox/application/operations.py
@@ -108,12 +108,31 @@ class OperationStatus(ContractModel):
     failure_details: dict[str, Any] | None
     terminal_receipt: dict[str, Any] | None
     recovery: OperationRecovery | None
+    poll_after_ms: int | None = Field(default=None, ge=100, le=30_000)
     created_at: datetime
     updated_at: datetime
 
     @classmethod
     def from_record(cls, record: OperationRecord) -> OperationStatus:
-        return cls.model_validate(record.model_dump(exclude={"owner_id", "owner_heartbeat_at"}))
+        payload = record.model_dump(exclude={"owner_id", "owner_heartbeat_at"})
+        if record.operation == "capability.setup" and record.state in {"starting", "running"}:
+            payload["poll_after_ms"] = _capability_setup_poll_after_ms(record.phase)
+            payload["recovery"] = OperationRecovery(
+                action="poll",
+                tool="get_capability_setup",
+                arguments={"operation_id": record.operation_id},
+            ).model_dump()
+        else:
+            payload["poll_after_ms"] = None
+        return cls.model_validate(payload)
+
+
+def _capability_setup_poll_after_ms(phase: str) -> int:
+    if phase == "validating_request":
+        return 250
+    if phase == "verifying":
+        return 500
+    return 1_000
 
 
 class OperationStore:

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -330,7 +330,7 @@ class WorkloadInspection(WorkloadDefinition):
     adapter_options_truncated: bool = False
 
 
-_TEMPLATE_FIELD = re.compile(r"(?<!\{)\{([A-Za-z_][A-Za-z0-9_]*)\}(?!\})")
+_TEMPLATE_FIELD = re.compile(r"(?<!\{)\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
 
 def _template_fields(value: str) -> set[str]:

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
-import string
 import tomllib
 from pathlib import Path, PurePath
 from typing import Annotated, Literal, cast
@@ -330,36 +330,47 @@ class WorkloadInspection(WorkloadDefinition):
     adapter_options_truncated: bool = False
 
 
+_TEMPLATE_FIELD = re.compile(r"(?<!\{)\{([A-Za-z_][A-Za-z0-9_]*)\}(?!\})")
+
+
 def _template_fields(value: str) -> set[str]:
-    fields: set[str] = set()
-    try:
-        parsed = string.Formatter().parse(value)
-        for _, field_name, format_spec, conversion in parsed:
-            if field_name is None:
-                continue
-            if (
-                not field_name.isidentifier()
-                or format_spec
-                or conversion is not None
-                or "." in field_name
-                or "[" in field_name
-            ):
-                raise ValueError("only plain scalar placeholders such as {length} are allowed")
-            fields.add(field_name)
-    except ValueError as exc:
-        raise ValueError(f"invalid workload template {value!r}: {exc}") from exc
-    return fields
+    """Return only the explicit scalar placeholders in a workload value.
+
+    Workload arguments are ordinary argv strings, so braces that are not an
+    exact ``{parameter}`` token remain literal. Doubled braces retain the
+    formatter-compatible escape for existing declarations.
+    """
+    return set(_TEMPLATE_FIELD.findall(value))
 
 
 def _render(value: str, parameters: dict[str, Scalar]) -> str:
-    _template_fields(value)
-    try:
-        return value.format_map(parameters)
-    except KeyError as exc:
+    fields = _template_fields(value)
+    missing = fields - set(parameters)
+    if missing:
         raise DomainError(
             ErrorCode.INVALID_CAPTURE_PLAN,
-            f"Missing workload parameter {exc.args[0]!r}.",
-        ) from exc
+            f"Missing workload parameter {sorted(missing)[0]!r}.",
+        )
+
+    rendered: list[str] = []
+    index = 0
+    while index < len(value):
+        if value.startswith("{{", index):
+            rendered.append("{")
+            index += 2
+            continue
+        if value.startswith("}}", index):
+            rendered.append("}")
+            index += 2
+            continue
+        match = _TEMPLATE_FIELD.match(value, index)
+        if match is not None:
+            rendered.append(str(parameters[match.group(1)]))
+            index = match.end()
+            continue
+        rendered.append(value[index])
+        index += 1
+    return "".join(rendered)
 
 
 class WorkloadService:

--- a/src/flameox/collectors/torch_launcher.py
+++ b/src/flameox/collectors/torch_launcher.py
@@ -40,6 +40,9 @@ def main() -> None:
     target.add_argument("--inline-code")
     parser.add_argument("arguments", nargs=argparse.REMAINDER)
     options = parser.parse_args()
+    workload_arguments = list(options.arguments)
+    if workload_arguments[:1] == ["--"]:
+        workload_arguments = workload_arguments[1:]
     diagnostic_path = Path(options.output).resolve().parent / "torch-profiler-diagnostics.json"
     _write_diagnostic(diagnostic_path, phase="wrapper_startup", status="started")
     phase = "wrapper_startup"
@@ -80,7 +83,8 @@ def main() -> None:
         if options.inline_code is not None:
             target_name = "<flameox-inline-python>"
         assert target_name is not None
-        sys.argv = [target_name, *options.arguments]
+        argv0 = "-c" if options.inline_code is not None else target_name
+        sys.argv = [argv0, *workload_arguments]
         phase = "profiler_initialization"
         _write_diagnostic(diagnostic_path, phase=phase, status="running")
         with torch.profiler.profile(

--- a/src/flameox/collectors/torch_launcher.py
+++ b/src/flameox/collectors/torch_launcher.py
@@ -37,13 +37,14 @@ def main() -> None:
     target = parser.add_mutually_exclusive_group(required=True)
     target.add_argument("--module")
     target.add_argument("--script")
+    target.add_argument("--inline-code")
     parser.add_argument("arguments", nargs=argparse.REMAINDER)
     options = parser.parse_args()
     diagnostic_path = Path(options.output).resolve().parent / "torch-profiler-diagnostics.json"
     _write_diagnostic(diagnostic_path, phase="wrapper_startup", status="started")
     phase = "wrapper_startup"
     try:
-        if options.module is not None:
+        if options.module is not None or options.inline_code is not None:
             sys.path.insert(0, str(Path.cwd()))
             script_path = None
         else:
@@ -76,6 +77,8 @@ def main() -> None:
         output = Path(options.output)
         output.parent.mkdir(parents=True, exist_ok=True)
         target_name = options.module or options.script
+        if options.inline_code is not None:
+            target_name = "<flameox-inline-python>"
         assert target_name is not None
         sys.argv = [target_name, *options.arguments]
         phase = "profiler_initialization"
@@ -92,6 +95,14 @@ def main() -> None:
             _write_diagnostic(diagnostic_path, phase=phase, status="running")
             if options.module is not None:
                 runpy.run_module(options.module, run_name="__main__", alter_sys=True)
+            elif options.inline_code is not None:
+                namespace = {
+                    "__name__": "__main__",
+                    "__file__": target_name,
+                    "__package__": None,
+                    "__cached__": None,
+                }
+                exec(compile(options.inline_code, target_name, "exec"), namespace, namespace)
             else:
                 assert script_path is not None
                 runpy.run_path(str(script_path), run_name="__main__")

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -790,10 +790,13 @@ def create_server(
             "with the validated argument array; it writes the canonical project definition but "
             "never executes it. After that, use list_declared_workflows (no arguments lists "
             "workloads) → "
-            "get_declared_workflow → list_capabilities → start_capability_setup (when the result "
-            "names setup_adapters) → prepare_adapter (for an unapproved installed third-party "
+            "get_declared_workflow → list_capabilities(adapter='<selected adapter>') → "
+            "start_capability_setup (when the scoped result names setup_adapters) → "
+            "prepare_adapter "
+            "(for an unapproved installed third-party "
             "adapter) → prepare_workload_dependencies (when a named workload declares missing "
-            "Python distributions) → list_capabilities → plan_capture(preflight_mode='auto', "
+            "Python distributions) → list_capabilities(adapter='<selected adapter>') → "
+            "plan_capture(preflight_mode='auto', "
             "capture_mode='auto') "
             "→ execute_capture_plan "
             "for short work, "
@@ -952,20 +955,33 @@ def create_server(
     async def list_capabilities_tool(
         ctx: Context[AppContext],
         mode: Literal["passive", "active_cached", "active_refresh"] = "passive",
+        adapter: Annotated[
+            str | None,
+            Field(
+                min_length=1,
+                max_length=100,
+                description=(
+                    "Selected capture adapter whose setup recommendation should be returned. "
+                    "Omit this for the read-only global inventory."
+                ),
+            ),
+        ] = None,
     ) -> Annotated[CallToolResult, ToolPayload[CapabilityList]]:
-        """List capabilities and exact managed setup actions.
+        """List capabilities and setup actions scoped to a selected capture adapter.
 
-        If setup_adapters is non-empty, call prepare_capabilities with those adapter names. If
-        setup_third_party_adapters is non-empty, call prepare_adapter with the exact
-        adapter/distribution identity from the capability report. Then call list_capabilities
-        again. Managed setup never executes a workload.
+        Omit adapter for a complete read-only inventory. In that mode, the per-capability setup
+        fields and available_setup_adapters are informational only; select an adapter and call
+        this tool again before mutating the managed environment. Managed setup never executes a
+        workload.
         """
         service = ctx.request_context.lifespan_context.capabilities
-        result = (
-            service.list()
-            if mode == "passive"
-            else await service.list_active(refresh=mode == "active_refresh")
-        )
+        if mode == "passive":
+            result = service.list() if adapter is None else service.list_for_adapter(adapter)
+        else:
+            result = await service.list_active(
+                refresh=mode == "active_refresh",
+                recommendation_adapter=adapter,
+            )
         return _success(
             result,
             f"Found {sum(item.status.value == 'available' for item in result.capabilities)} of "
@@ -976,7 +992,11 @@ def create_server(
                 else (
                     "Call prepare_adapter for the reported adapter/distribution pairs."
                     if result.setup_third_party_adapters
-                    else "No managed capability setup is pending."
+                    else (
+                        "Select an adapter and call list_capabilities(adapter=...) before setup."
+                        if adapter is None
+                        else "No managed capability setup is pending for this adapter."
+                    )
                 )
             ),
         )

--- a/tests/application/test_capabilities.py
+++ b/tests/application/test_capabilities.py
@@ -19,6 +19,7 @@ from flameox.application.capabilities import (
     SetupVerification,
 )
 from flameox.application.dependencies import WorkloadDependencyService
+from flameox.application.operations import OperationRecord, OperationStatus
 from flameox.domain import (
     CapabilityReport,
     CapabilitySetup,
@@ -552,6 +553,63 @@ def test_list_capabilities_exposes_latest_setup_receipt(tmp_path: Path) -> None:
     assert result.latest_setup.requested == ("torch.profiler", "perfetto")
     assert result.latest_setup.completed == ("torch.profiler",)
     assert result.latest_setup.phase == "staging_trace_processor"
+
+
+def test_capability_recommendations_are_scoped_to_selected_adapter(tmp_path: Path) -> None:
+    service = CapabilityService(Workspace.initialize(tmp_path))
+    torch = CapabilityReport(
+        adapter="torch.profiler",
+        status=CapabilityStatus.UNAVAILABLE,
+        setup=CapabilitySetup(
+            extra="torch",
+            method="prepare_capabilities",
+            next_tool="prepare_capabilities",
+            requirement="torch>=2.7",
+        ),
+    )
+    assert isinstance(torch.setup, CapabilitySetup)
+    pyspy = torch.model_copy(
+        update={
+            "adapter": "py-spy",
+            "setup": torch.setup.model_copy(update={"extra": "cpu", "requirement": "py-spy"}),
+        }
+    )
+
+    inventory = service._finish((torch, pyspy))
+    selected = service._finish((torch, pyspy), recommendation_adapter="torch.profiler")
+
+    assert inventory.setup_adapters == ()
+    assert inventory.available_setup_adapters == ("py-spy", "torch.profiler")
+    assert inventory.next_tool is None
+    assert selected.recommendation_scope == "torch.profiler"
+    assert selected.setup_adapters == ("torch.profiler",)
+    assert selected.next_tool == "prepare_capabilities"
+
+
+def test_running_capability_setup_status_contains_exact_poll_action(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    record = OperationRecord(
+        operation_id="op-1234",
+        operation="capability.setup",
+        workspace_id=workspace.identity.workspace_id,
+        request_digest="sha256:" + "1" * 64,
+        request={"adapters": ["perfetto"]},
+        idempotency_digest="sha256:" + "2" * 64,
+        state="running",
+        phase="staging_trace_processor",
+    )
+
+    status = OperationStatus.from_record(record)
+
+    assert status.poll_after_ms == 1_000
+    assert status.recovery is not None
+    assert status.recovery.action == "poll"
+    assert status.recovery.tool == "get_capability_setup"
+    assert status.recovery.arguments == {"operation_id": "op-1234"}
+
+    terminal = OperationStatus.from_record(record.model_copy(update={"state": "terminal"}))
+    assert terminal.poll_after_ms is None
+    assert terminal.recovery is None
 
 
 @pytest.mark.anyio

--- a/tests/application/test_capture_integrations.py
+++ b/tests/application/test_capture_integrations.py
@@ -82,6 +82,7 @@ def test_torch_capture_launcher_binds_declared_inline_python(tmp_path: Path) -> 
 
     assert invocation.argv[6:] == (
         "--inline-code=print('inline')",
+        "--",
         "argument",
     )
 
@@ -107,7 +108,15 @@ def test_torch_capture_launcher_runs_declared_inline_python(tmp_path: Path) -> N
     )
     invocation = build_capture_invocation(
         "torch.profiler",
-        (sys.executable, "-c", "from pathlib import Path; Path('ran').write_text(__file__)"),
+        (
+            sys.executable,
+            "-c",
+            "import json, sys; from pathlib import Path; "
+            "Path('ran').write_text(json.dumps({'file': __file__, "
+            "'argv0': sys.argv[0], 'args': sys.argv[1:]}))",
+            "--size",
+            "4",
+        ),
         tmp_path,
         executable=None,
     )
@@ -121,7 +130,11 @@ def test_torch_capture_launcher_runs_declared_inline_python(tmp_path: Path) -> N
     )
 
     assert completed.returncode == 0, completed.stderr
-    assert (tmp_path / "ran").read_text() == "<flameox-inline-python>"
+    assert json.loads((tmp_path / "ran").read_text()) == {
+        "file": "<flameox-inline-python>",
+        "argv0": "-c",
+        "args": ["--size", "4"],
+    }
     assert (tmp_path / "torch-trace.json").read_text() == "trace"
 
 

--- a/tests/application/test_capture_integrations.py
+++ b/tests/application/test_capture_integrations.py
@@ -72,6 +72,59 @@ def test_torch_capture_launcher_does_not_require_flameox_in_workload_venv(
     )
 
 
+def test_torch_capture_launcher_binds_declared_inline_python(tmp_path: Path) -> None:
+    invocation = build_capture_invocation(
+        "torch.profiler",
+        (sys.executable, "-c", "print('inline')", "argument"),
+        tmp_path,
+        executable=None,
+    )
+
+    assert invocation.argv[6:] == (
+        "--inline-code=print('inline')",
+        "argument",
+    )
+
+
+@pytest.mark.process
+def test_torch_capture_launcher_runs_declared_inline_python(tmp_path: Path) -> None:
+    (tmp_path / "torch.py").write_text(
+        "from pathlib import Path\n"
+        "class ProfilerActivity:\n"
+        "    CPU = 'cpu'\n"
+        "    CUDA = 'cuda'\n"
+        "class _Profile:\n"
+        "    def __enter__(self): return self\n"
+        "    def __exit__(self, *_): return False\n"
+        "    def export_chrome_trace(self, path): Path(path).write_text('trace')\n"
+        "class profiler:\n"
+        "    ProfilerActivity = ProfilerActivity\n"
+        "    @staticmethod\n"
+        "    def profile(**_): return _Profile()\n"
+        "class cuda:\n"
+        "    @staticmethod\n"
+        "    def is_available(): return False\n"
+    )
+    invocation = build_capture_invocation(
+        "torch.profiler",
+        (sys.executable, "-c", "from pathlib import Path; Path('ran').write_text(__file__)"),
+        tmp_path,
+        executable=None,
+    )
+
+    completed = subprocess.run(
+        invocation.argv,
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert (tmp_path / "ran").read_text() == "<flameox-inline-python>"
+    assert (tmp_path / "torch-trace.json").read_text() == "trace"
+
+
 def test_torch_capture_rejects_schedule_without_explicit_sdk_steps(tmp_path: Path) -> None:
     with pytest.raises(DomainError) as failure:
         build_capture_invocation(

--- a/tests/application/test_workloads.py
+++ b/tests/application/test_workloads.py
@@ -19,12 +19,13 @@ def _request(
     *,
     operation: Literal["create", "replace"] = "create",
     argv: tuple[str, ...] = ("python", "-c", "print('ok')"),
+    parameters: dict[str, tuple[str | int | float | bool, ...]] | None = None,
     expected_configuration_id: str | None = None,
 ) -> ConfigureWorkloadRequest:
     return ConfigureWorkloadRequest(
         name=name,
         operation=operation,
-        config=WorkloadConfig(argv=argv),
+        config=WorkloadConfig(argv=argv, parameters=parameters or {}),
         expected_configuration_id=expected_configuration_id,
     )
 
@@ -47,6 +48,32 @@ def test_configure_workload_is_idempotent_and_records_configuration_source(tmp_p
     assert second.changed_paths == ()
     assert (tmp_path / "flameox.toml").read_text() == config_text
     assert service.list_declared(kind="workload", limit=10).workflows[0].name == "probe"
+
+
+def test_literal_braces_round_trip_while_declared_placeholders_render(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+    service.configure(
+        _request(
+            "json",
+            argv=("python", "-c", 'print({"key": "{size}"})'),
+            parameters={"size": (4,)},
+        )
+    )
+
+    instance = service.resolve("json", {"size": 4})
+
+    assert instance.command.argv[-1] == 'print({"key": "4"})'
+
+
+def test_unknown_plain_placeholder_is_still_rejected(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+
+    with pytest.raises(ValueError, match="template fields are not declared parameters"):
+        service.configure(_request("unknown", argv=("python", "-c", "print({missing})")))
 
 
 def test_replace_requires_current_configuration_digest_and_preserves_unrelated_state(

--- a/tests/application/test_workloads.py
+++ b/tests/application/test_workloads.py
@@ -68,6 +68,22 @@ def test_literal_braces_round_trip_while_declared_placeholders_render(
     assert instance.command.argv[-1] == 'print({"key": "4"})'
 
 
+def test_placeholder_renders_before_escaped_closing_brace(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+    service.configure(
+        _request(
+            "json",
+            argv=("python", "-c", 'print({{"batch": {batch}}})'),
+            parameters={"batch": (4,)},
+        )
+    )
+
+    instance = service.resolve("json", {"batch": 4})
+
+    assert instance.command.argv[-1] == 'print({"batch": 4})'
+
+
 def test_unknown_plain_placeholder_is_still_rejected(tmp_path: Path) -> None:
     workspace = Workspace.initialize(tmp_path)
     service = WorkloadService(workspace)

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 467
+expected_test_count = 473
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -32,7 +32,7 @@ expected_test_count = 467
 'tests/adapters/test_perfetto.py' = 'c4a12900de4584860227f61bc86b606fc78a76b0d533ea3aa8558dbfa422caf8'
 'tests/analysis/test_recipes.py' = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e'
 'tests/application/test_records_and_comparisons.py' = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759'
-'tests/application/test_workloads_and_capture.py' = '31f94350fcbe4e65bf7814c7df232ad81192de97b14342e7b4236697dcc51b86'
+'tests/application/test_workloads_and_capture.py' = 'd56c5777dc9316d79faa2feb95a39b049a37397963d95e03a913a0105b145f1b'
 'tests/mcp/test_server.py' = '4cef12ed096f768acd9208daf678cd1fbc2fbc9e39e65f26aa4b96c2b7093168'
 'tests/test_cli_setup.py' = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561'
 
@@ -53,7 +53,7 @@ expected_test_count = 467
 'tests/application/test_analysis_records.py' = { count = 1, digest = '7a08286f866dbeef9c9a0500cead2b3ebf6ee6546f455ed3b5cc5407ee84b69f' }
 'tests/application/test_artifact_service.py' = { count = 2, digest = '2ed111222920a42e8679d1e0281f185dc0d28406470ca888d80d0a01cd87731c' }
 'tests/application/test_async_work.py' = { count = 1, digest = '5c21ab9d048e8676c0b086ff6859e87b28da82ab793c2b70de975f592355067e' }
-'tests/application/test_capabilities.py' = { count = 17, digest = 'ab5a1b26dfe655f3e9bcea46c2753f835e024ae98135c9ac76a7e26df708f725' }
+'tests/application/test_capabilities.py' = { count = 19, digest = 'ea35dd6589d4092b0f65e09afe38232bdb7f79e5d1bb4aa720670e3aa77d0389' }
 'tests/application/test_capture_native_outputs.py' = { count = 5, digest = '73ffb01416e94a3044feeecb6f11f1fb452f0b1595ecc8b3ac3ef4f749918f77' }
 'tests/application/test_comparison_samples.py' = { count = 2, digest = 'f28179055d031cfb2d74b5f002c1c19278a64a46c5d0c02e32f91a4e9fef23df' }
 'tests/application/test_detached.py' = { count = 8, digest = '25178dcfc15e9ce50eff6595814d67d223ab1550e4a0a6873862ec0e5414b0d7' }
@@ -78,8 +78,8 @@ expected_test_count = 467
 'tests/application/test_summaries.py' = { count = 4, digest = '350d1cb8ae547c947cf6e5b492f01a2c75e832af5d239731a87d6b30daa04905' }
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = 'd169c20bdbb6f514887e75fe045f1a8950f946d915abc6d22d6836ac1959ab0c' }
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
-'tests/application/test_workloads.py' = { count = 4, digest = '8498d6450bad63aec49693d92b49d53555d8f134492f13f4fa8e1502adb9f758' }
-'tests/application/test_workloads_and_capture.py' = { count = 52, digest = '31f94350fcbe4e65bf7814c7df232ad81192de97b14342e7b4236697dcc51b86' }
+'tests/application/test_workloads.py' = { count = 6, digest = 'd32f77c2accbe8d0ade7aaccf72e764ad1f8a0f7945f9e783a12768f1fdf46d1' }
+'tests/application/test_workloads_and_capture.py' = { count = 54, digest = 'd56c5777dc9316d79faa2feb95a39b049a37397963d95e03a913a0105b145f1b' }
 'tests/application/test_operations.py' = { count = 6, digest = 'e380fb2d3b13d1814af7bce5428a549fd6bdf0f08ce5e5d2c28709ae4da7fd51' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
 'tests/domain/test_models.py' = { count = 11, digest = '3c66f63c2bd90a4d7af1393bd59fe08072fe9872cf2a3c0d101095ba6280e016' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 473
+expected_test_count = 474
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -78,7 +78,7 @@ expected_test_count = 473
 'tests/application/test_summaries.py' = { count = 4, digest = '350d1cb8ae547c947cf6e5b492f01a2c75e832af5d239731a87d6b30daa04905' }
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = 'd169c20bdbb6f514887e75fe045f1a8950f946d915abc6d22d6836ac1959ab0c' }
 'tests/application/test_viewers.py' = { count = 8, digest = '17e9b4ec485fff59f49c11bc9a513e28da97e4d6d0af6e945ba548ab72aef663' }
-'tests/application/test_workloads.py' = { count = 6, digest = 'd32f77c2accbe8d0ade7aaccf72e764ad1f8a0f7945f9e783a12768f1fdf46d1' }
+'tests/application/test_workloads.py' = { count = 7, digest = '565d1709a0fc0498d41f687c030e641af5db5664557b591b4f2cc85bce07cd84' }
 'tests/application/test_workloads_and_capture.py' = { count = 54, digest = 'd56c5777dc9316d79faa2feb95a39b049a37397963d95e03a913a0105b145f1b' }
 'tests/application/test_operations.py' = { count = 6, digest = 'e380fb2d3b13d1814af7bce5428a549fd6bdf0f08ce5e5d2c28709ae4da7fd51' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }

--- a/tests/mcp/test_contracts.py
+++ b/tests/mcp/test_contracts.py
@@ -344,14 +344,25 @@ async def test_mcp_modes_make_capability_and_integrity_choices_explicit(tmp_path
     async with Client(create_server(tmp_path), raise_exceptions=True) as client:
         tools = {tool.name: tool for tool in (await client.list_tools()).tools}
         passive = await client.call_tool("list_capabilities", {"mode": "passive"})
+        scoped = await client.call_tool(
+            "list_capabilities",
+            {"mode": "passive", "adapter": "torch.profiler"},
+        )
         invalid = await client.call_tool("list_capabilities", {"refresh": True})
         standard = await client.call_tool("validate_workspace", {"mode": "standard"})
 
     capability_mode = tools["list_capabilities"].input_schema["properties"]["mode"]
+    assert "adapter" in tools["list_capabilities"].input_schema["properties"]
     integrity_mode = tools["validate_workspace"].input_schema["properties"]["mode"]
     assert capability_mode["enum"] == ["passive", "active_cached", "active_refresh"]
     assert integrity_mode["enum"] == ["standard", "full"]
     assert passive.is_error is False
+    assert passive.structured_content is not None
+    assert passive.structured_content["result"]["setup_adapters"] == []
+    assert passive.structured_content["result"]["next_tool"] is None
+    assert scoped.is_error is False
+    assert scoped.structured_content is not None
+    assert scoped.structured_content["result"]["recommendation_scope"] == "torch.profiler"
     assert invalid.is_error is True
     assert isinstance(invalid.content[0], TextContent)
     assert "refresh" in invalid.content[0].text


### PR DESCRIPTION
Fixes #99.
Fixes #100.
Fixes #101.
Fixes #102.

## Description

Agents investigating a declared workload could still hit four avoidable workflow breaks:

- `torch.profiler` rejected a declared `python -c` workload even though command-based adapters accepted it.
- Literal JSON and Python braces were parsed as formatter syntax instead of remaining ordinary argv data.
- Detached capability setup returned an operation ID without a machine-readable polling delay or poll action.
- Global capability discovery recommended setup for every unavailable managed provider, including providers unrelated to the selected workflow.

## Approach

- Add an inline-code target to the existing Torch whole-entrypoint launcher. The exact declared program remains in the capture plan and runs under the stable synthetic filename `<flameox-inline-python>`; arbitrary commands and non-Python entrypoints remain unsupported.
- Replace formatter-wide brace parsing with exact plain-token substitution. Declared `{parameter}` values still render, literal braces round-trip, doubled-brace escapes remain compatible, and unknown exact tokens are rejected.
- Add bounded `poll_after_ms` guidance and an exact `get_capability_setup(operation_id=...)` recovery action to active detached setup statuses. Terminal statuses do not expose polling guidance.
- Add adapter-scoped capability discovery through `list_capabilities(adapter=...)`. Unscoped discovery remains read-only and exposes the complete inventory without a blanket setup recommendation.

## Commands run

- `uv run pytest -q` — 342 passed, 131 deselected
- `uv run ruff check src tests tools` — passed
- `uv run ruff format --check src tests tools` — passed
- `uv run mypy src tests tools` — passed

## Compatibility

The existing named-workload, no-arbitrary-command, and managed-setup safety boundaries remain unchanged. The capability result adds inventory and recommendation-scope fields; callers following setup guidance should select the adapter first and use the scoped setup fields. Inline support is limited to `torch.profiler` whole-entrypoint mode.