### PR TITLE
feat(inference): add SGLang profiling support

### DIFF
--- a/src/flameox/adapters/__init__.py
+++ b/src/flameox/adapters/__init__.py
@@ -81,6 +81,8 @@ __all__ = [
     "PythonStartupExtractor",
     "RuntimeInstallation",
     "SetupClient",
+    "SglangResultDocument",
+    "SglangResultParser",
     "TorchProfilerCaptureOptions",
     "TorchProfilerSchedule",
     "ToxiproxyApiError",

--- a/src/flameox/adapters/inference.py
+++ b/src/flameox/adapters/inference.py
@@ -1107,7 +1107,7 @@ class SglangResultDocument(ContractModel):
     request_throughput: Annotated[float, Field(ge=0)] | None = None
     input_throughput: Annotated[float, Field(ge=0)] | None = None
     output_throughput: Annotated[float, Field(ge=0)] | None = None
-    total_throughput: Annotated[float, Field(ge=0)] | None = None
+    total_token_throughput: Annotated[float, Field(ge=0)] | None = None
     accept_length: Annotated[float, Field(ge=0)] | None = None
     concurrency: Annotated[float, Field(ge=0)] | None = None
     mean_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
@@ -1204,17 +1204,33 @@ class SglangResultParser:
                 if key == "duration"
                 else "count"
             )
+            dimensions = {
+                "producer": "sglang.bench_serving",
+                "completed": str(document.completed),
+            }
+            aggregation = "aggregate"
+            if key.startswith("mean_"):
+                aggregation = "mean"
+                dimensions["stat"] = "mean"
+            elif key.startswith("median_"):
+                aggregation = "median"
+                dimensions["stat"] = "median"
+            elif key.startswith("std_"):
+                aggregation = "std"
+                dimensions["stat"] = "std"
+            elif key.startswith("p") and "_" in key:
+                percentile = key.split("_", 1)[0][1:]
+                if percentile.isdigit():
+                    aggregation = "percentile"
+                    dimensions.update({"stat": "percentile", "percentile": percentile})
             rows.append(
                 VllmMeasurementRow(
                     measurement_id=digest_model({"name": f"sglang.{key}", "value": value}),
                     name=f"sglang.{key}",
                     value_float=value,
                     unit=unit,
-                    aggregation="aggregate",
-                    dimensions={
-                        "producer": "sglang.bench_serving",
-                        "completed": str(document.completed),
-                    },
+                    aggregation=aggregation,
+                    dimensions=dimensions,
                 )
             )
         return document, rows

--- a/src/flameox/adapters/inference.py
+++ b/src/flameox/adapters/inference.py
@@ -1094,6 +1094,132 @@ class VllmResultParser:
         return rows
 
 
+class SglangResultDocument(ContractModel):
+    """Safe aggregate subset of SGLang 0.5.16 ``bench_serving`` JSONL output."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    duration: Annotated[float, Field(ge=0)]
+    completed: Annotated[int, Field(ge=0)]
+    total_input_tokens: Annotated[int, Field(ge=0)]
+    total_output_tokens: Annotated[int, Field(ge=0)]
+    num_prompts: Annotated[int, Field(gt=0)] | None = None
+    request_throughput: Annotated[float, Field(ge=0)] | None = None
+    input_throughput: Annotated[float, Field(ge=0)] | None = None
+    output_throughput: Annotated[float, Field(ge=0)] | None = None
+    total_throughput: Annotated[float, Field(ge=0)] | None = None
+    accept_length: Annotated[float, Field(ge=0)] | None = None
+    concurrency: Annotated[float, Field(ge=0)] | None = None
+    mean_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
+    median_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
+    std_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
+    p90_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
+    p95_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
+    p99_e2e_latency_ms: Annotated[float, Field(ge=0)] | None = None
+    mean_ttft_ms: Annotated[float, Field(ge=0)] | None = None
+    median_ttft_ms: Annotated[float, Field(ge=0)] | None = None
+    std_ttft_ms: Annotated[float, Field(ge=0)] | None = None
+    p90_ttft_ms: Annotated[float, Field(ge=0)] | None = None
+    p95_ttft_ms: Annotated[float, Field(ge=0)] | None = None
+    p99_ttft_ms: Annotated[float, Field(ge=0)] | None = None
+    mean_tpot_ms: Annotated[float, Field(ge=0)] | None = None
+    median_tpot_ms: Annotated[float, Field(ge=0)] | None = None
+    std_tpot_ms: Annotated[float, Field(ge=0)] | None = None
+    p90_tpot_ms: Annotated[float, Field(ge=0)] | None = None
+    p95_tpot_ms: Annotated[float, Field(ge=0)] | None = None
+    p99_tpot_ms: Annotated[float, Field(ge=0)] | None = None
+    mean_itl_ms: Annotated[float, Field(ge=0)] | None = None
+    median_itl_ms: Annotated[float, Field(ge=0)] | None = None
+    std_itl_ms: Annotated[float, Field(ge=0)] | None = None
+    p90_itl_ms: Annotated[float, Field(ge=0)] | None = None
+    p95_itl_ms: Annotated[float, Field(ge=0)] | None = None
+    p99_itl_ms: Annotated[float, Field(ge=0)] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_sensitive_details(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            raise ValueError("SGLang result must be a JSON object")
+        sensitive = {"input_lens", "output_lens", "ttfts", "itls", "generated_texts", "errors"}
+        if sensitive & value.keys() or any(isinstance(item, list) for item in value.values()):
+            raise ValueError("SGLang detailed output is not accepted")
+        return value
+
+    @field_validator("*")
+    @classmethod
+    def finite_numbers(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError("SGLang metrics must be JSON numbers")
+        if not math.isfinite(float(value)):
+            raise ValueError("SGLang metrics must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def counts_are_consistent(self) -> SglangResultDocument:
+        if self.num_prompts is not None and self.completed > self.num_prompts:
+            raise ValueError("SGLang completed count exceeds num_prompts")
+        return self
+
+
+class SglangResultParser:
+    """Parse exactly one bounded, aggregate-only SGLang 0.5.16 JSONL record.
+
+    SGLang's optional detailed output carries prompts, generations and error
+    text.  It is intentionally rejected before any normalization occurs.
+    """
+
+    max_document_bytes = 1024 * 1024
+    _measurement_fields = tuple(
+        name for name in SglangResultDocument.model_fields if name not in {"num_prompts"}
+    )
+
+    def parse(self, path: Path) -> tuple[SglangResultDocument, list[VllmMeasurementRow]]:
+        try:
+            if path.stat().st_size > self.max_document_bytes:
+                raise ValueError("SGLang result exceeds size bound")
+            lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+            if len(lines) != 1:
+                raise ValueError("SGLang output must contain exactly one non-empty JSONL record")
+            payload = json.loads(lines[0])
+            document = SglangResultDocument.model_validate(payload)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The artifact is not a valid aggregate SGLang JSONL result.",
+            ) from exc
+        rows: list[VllmMeasurementRow] = []
+        for key in self._measurement_fields:
+            value = getattr(document, key)
+            if value is None:
+                continue
+            value = float(value)
+            unit = (
+                "ms"
+                if key.endswith("_ms")
+                else "tokens/sec"
+                if key.endswith("throughput")
+                else "s"
+                if key == "duration"
+                else "count"
+            )
+            rows.append(
+                VllmMeasurementRow(
+                    measurement_id=digest_model({"name": f"sglang.{key}", "value": value}),
+                    name=f"sglang.{key}",
+                    value_float=value,
+                    unit=unit,
+                    aggregation="aggregate",
+                    dimensions={
+                        "producer": "sglang.bench_serving",
+                        "completed": str(document.completed),
+                    },
+                )
+            )
+        return document, rows
+
+
 class InferenceExtractionResult(ContractModel):
     schema_version: Literal[1] = 1
     run_id: str
@@ -1244,6 +1370,66 @@ class InferenceArtifactExtractor:
             input_artifact_ids=(registration.artifact_id,),
             operation_identity={
                 "kind": "vllm_bench",
+                "parser_version": self.version,
+                "evidence_run_id": target_run,
+            },
+        )
+        return InferenceExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            evidence_run_id=target_run,
+            measurement_count=len(rows),
+            corpus_commit_id=published.commit.commit_id,
+        )
+
+    def extract_sglang_result(
+        self, run_id: str, *, evidence_run_id: str | None = None
+    ) -> InferenceExtractionResult:
+        """Publish scalar-only measurements from a preserved SGLang JSONL result."""
+        registration = self._registration(run_id, ArtifactKind.INFERENCE_RESULT)
+        stored = self.artifacts.get(registration.artifact_id)
+        target_run = evidence_run_id or run_id
+        _document, measurements = SglangResultParser().parse(stored.payload_path)
+        rows = [
+            {
+                "measurement_id": digest_model(
+                    {
+                        "run_id": target_run,
+                        "artifact_id": registration.artifact_id,
+                        "row": row.model_dump(mode="json"),
+                    }
+                ),
+                "run_id": target_run,
+                "artifact_id": registration.artifact_id,
+                "name": row.name,
+                "value_int": None,
+                "value_float": row.value_float,
+                "unit": row.unit,
+                "aggregation": row.aggregation,
+                "scope": "workload",
+                "trial_id": None,
+                "worker_id": None,
+                "worker_run_index": None,
+                "value_index": None,
+                "loop_count": None,
+                "is_warmup": False,
+                "block_id": None,
+                "variant_id": None,
+                "order_in_block": None,
+                "phase": "steady_state",
+                "dimensions": row.dimensions,
+                "evidence_level": row.evidence_level,
+            }
+            for row in measurements
+        ]
+        published = self.publisher.publish_rows_idempotent(
+            {"measurements": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=tuple(dict.fromkeys((run_id, target_run))),
+            input_artifact_ids=(registration.artifact_id,),
+            operation_identity={
+                "kind": "sglang_bench_serving",
                 "parser_version": self.version,
                 "evidence_run_id": target_run,
             },

--- a/src/flameox/analysis/inference_protocol.py
+++ b/src/flameox/analysis/inference_protocol.py
@@ -33,7 +33,7 @@ _NonEmptyStr = Annotated[str, StringConstraints(min_length=1, max_length=500)]
 class TraceIdentity(ContractModel):
     """Identity of the replayed inference trace input."""
 
-    format: Literal["mooncake", "aiperf", "vllm", "custom"] | None = None
+    format: Literal["mooncake", "aiperf", "vllm", "sglang.bench_serving", "custom"] | None = None
     producer: _Identifier
     producer_version: _NonEmptyStr | None = None
     artifact_digest: _Digest | None = None
@@ -70,7 +70,7 @@ class ModelIdentity(ContractModel):
 class ServerConfigIdentity(ContractModel):
     """vLLM / serving server configuration identity."""
 
-    backend: Literal["vllm", "openai-chat", "custom"]
+    backend: Literal["vllm", "sglang", "openai-chat", "custom"]
     endpoint: _NonEmptyStr | None = None
     kv_transfer_config: dict[str, str] = Field(default_factory=dict)
     cache_backend: Literal["none", "mooncake", "lmcache", "vllm_paged", "custom"] = "vllm_paged"

--- a/src/flameox/application/inference.py
+++ b/src/flameox/application/inference.py
@@ -50,8 +50,10 @@ from flameox.application.imports import ImportArtifactRequest, ImportService
 from flameox.application.inference_providers import (
     AIPerfProfileRequest,
     ExistingServerProbe,
+    SglangBenchServingRequest,
     VllmBenchServeRequest,
     discover_inference_tool,
+    discover_sglang,
     probe_existing_vllm_server,
 )
 from flameox.application.oracle_receipts import parse_oracle_receipt
@@ -96,6 +98,7 @@ from flameox.storage import ArtifactStore, RunStore, Workspace
 _PROVIDER_TOOL: dict[str, Literal["aiperf", "vllm"]] = {
     "aiperf": "aiperf",
     "vllm_bench": "vllm",
+    "sglang_bench": "vllm",
 }
 _MAX_RESULT_LIMITATIONS = 16
 
@@ -107,8 +110,8 @@ class InferenceReplayPlan(ContractModel):
     plan_id: str
     scenario_name: str
     server_name: str
-    provider: Literal["aiperf", "vllm_bench"]
-    server_provider: Literal["vllm"] = "vllm"
+    provider: Literal["aiperf", "vllm_bench", "sglang_bench"]
+    server_provider: Literal["vllm", "sglang"] = "vllm"
     server_mode: Literal["managed", "existing_local"]
     base_url: str
     model: Annotated[str, Field(min_length=1, max_length=500)]
@@ -140,6 +143,9 @@ class InferenceReplayPlan(ContractModel):
     seed: Annotated[int, Field(ge=0, le=2**31 - 1)] = 0
     speedup_ratio: Annotated[float, Field(gt=0, le=100)] = 1.0
     semantic_oracle_workload: str | None = None
+    random_input_len: Annotated[int, Field(gt=0, le=1_000_000)] | None = None
+    random_output_len: Annotated[int, Field(gt=0, le=1_000_000)] | None = None
+    random_range_ratio: Annotated[float, Field(gt=0, le=1)] | None = None
     timeout_seconds: Annotated[float, Field(gt=0, le=86_400)]
     deadline_at: datetime
     exploratory_reason: Annotated[str, Field(min_length=1, max_length=500)]
@@ -156,7 +162,7 @@ class InferenceReplayResult(ContractModel):
     plan_id: str
     scenario_name: str
     server_name: str
-    provider: Literal["aiperf", "vllm_bench"]
+    provider: Literal["aiperf", "vllm_bench", "sglang_bench"]
     argv: Annotated[tuple[str, ...], Field(max_length=1_024)]
     output_path: str | None = None
     output_path_retained: bool = False
@@ -223,7 +229,11 @@ class InferenceReplayService:
         deadline = self._deadline(timeout_seconds, scenario, server)
         deadline_at = utc_now() + timedelta(seconds=deadline)
         tool = _PROVIDER_TOOL[scenario.provider]
-        discovery = discover_inference_tool(tool)
+        discovery = (
+            discover_sglang(Path(server.benchmark_python))
+            if scenario.provider == "sglang_bench" and server.benchmark_python is not None
+            else discover_inference_tool(tool)
+        )
         probe: ExistingServerProbe | None = None
         if server.mode == "existing_local" and discovery.available:
             probe = probe_existing_vllm_server(
@@ -245,6 +255,8 @@ class InferenceReplayService:
                 )
         server_executable_digest, server_version = self._server_tool_identity(server)
         output_path = self._output_path(scenario_name, new_id())
+        if scenario.provider == "sglang_bench":
+            output_path = output_path.with_suffix(".jsonl")
         request = (
             self._build_request(
                 scenario,
@@ -313,6 +325,9 @@ class InferenceReplayService:
             seed=scenario.seed,
             speedup_ratio=scenario.speedup_ratio,
             semantic_oracle_workload=scenario.semantic_oracle_workload,
+            random_input_len=scenario.random_input_len,
+            random_output_len=scenario.random_output_len,
+            random_range_ratio=scenario.random_range_ratio,
             timeout_seconds=deadline,
             deadline_at=deadline_at,
             exploratory_reason=(
@@ -854,6 +869,9 @@ class InferenceReplayService:
         return scenario, server
 
     def _server_tool_identity(self, server: InferenceServerConfig) -> tuple[str | None, str | None]:
+        if server.provider == "sglang" and server.benchmark_python is not None:
+            discovery = discover_sglang(Path(server.benchmark_python))
+            return discovery.executable_digest, discovery.version
         if server.mode != "managed" or server.workload is None:
             return None, None
         command = self.workloads.resolve(server.workload).command
@@ -901,7 +919,11 @@ class InferenceReplayService:
                 "Inference configuration changed after this plan was created.",
                 remediation=("Plan the inference scenario again, then retry execution.",),
             )
-        provider = discover_inference_tool(_PROVIDER_TOOL[plan.provider])
+        provider = (
+            discover_sglang(Path(plan.tool_executable))
+            if plan.provider == "sglang_bench" and plan.tool_executable is not None
+            else discover_inference_tool(_PROVIDER_TOOL[plan.provider])
+        )
         if not plan.tool_available or not plan.argv:
             raise DomainError(
                 ErrorCode.CAPABILITY_UNAVAILABLE,
@@ -962,7 +984,7 @@ class InferenceReplayService:
         executable: Path,
         *,
         output_path: Path,
-    ) -> AIPerfProfileRequest | VllmBenchServeRequest:
+    ) -> AIPerfProfileRequest | VllmBenchServeRequest | SglangBenchServingRequest:
         # AIPerf's fixed_schedule requires a Mooncake trace; without a declared
         # trace_artifact_id the replay uses the tool's default schedule.
         fixed_schedule = scenario.trace_artifact_id is not None
@@ -989,6 +1011,27 @@ class InferenceReplayService:
                 seed=scenario.seed,
                 request_count=scenario.num_prompts if trace_path is None else None,
                 speedup_ratio=scenario.speedup_ratio,
+            )
+        if scenario.provider == "sglang_bench":
+            assert server.benchmark_python is not None
+            assert scenario.random_input_len is not None
+            assert scenario.random_output_len is not None
+            return SglangBenchServingRequest(
+                benchmark_python=Path(server.benchmark_python),
+                base_url=server.base_url,
+                model=server.model,
+                tokenizer=server.tokenizer,
+                endpoint_type=scenario.endpoint_type,
+                streaming=scenario.streaming,
+                num_prompts=scenario.num_prompts,
+                random_input_len=scenario.random_input_len,
+                random_output_len=scenario.random_output_len,
+                random_range_ratio=scenario.random_range_ratio or 1.0,
+                request_rate=scenario.request_rate,
+                max_concurrency=scenario.concurrency,
+                warmup_request_count=scenario.warmup_request_count,
+                seed=scenario.seed,
+                result_path=output_path,
             )
         return VllmBenchServeRequest(
             executable=executable,
@@ -1193,6 +1236,8 @@ class InferenceReplayService:
                     if plan.trace_artifact_id is not None
                     else "aiperf"
                     if plan.provider == "aiperf"
+                    else "sglang.bench_serving"
+                    if plan.provider == "sglang_bench"
                     else "vllm"
                 ),
                 producer=(
@@ -1225,7 +1270,7 @@ class InferenceReplayService:
                 quantization=plan.quantization or "none",
             ),
             server=ServerConfigIdentity(
-                backend="vllm",
+                backend=plan.server_provider,
                 endpoint=(
                     "/v1/chat/completions" if plan.endpoint_type == "chat" else "/v1/completions"
                 ),
@@ -1454,13 +1499,15 @@ class InferenceReplayService:
         extractor = InferenceArtifactExtractor(self.workspace)
         limitations: list[str] = []
         try:
-            if plan.provider == "vllm_bench":
+            if plan.provider in {"vllm_bench", "sglang_bench"}:
                 if preserved:
-                    result = extractor.extract_vllm_result(
-                        preserved[0][1], evidence_run_id=evidence_run_id
-                    )
+                    result = (
+                        extractor.extract_sglang_result
+                        if plan.provider == "sglang_bench"
+                        else extractor.extract_vllm_result
+                    )(preserved[0][1], evidence_run_id=evidence_run_id)
                     return result.limitations
-                return ("vLLM benchmark result JSON was not emitted.",)
+                return ("Inference benchmark result was not emitted.",)
             export = next((item for item in preserved if item[0] == "profile_export.jsonl"), None)
             inputs = next((item for item in preserved if item[0] == "inputs.json"), None)
             if export is None:
@@ -1524,7 +1571,9 @@ class InferenceReplayService:
                         media_type=self._provider_media_type(path),
                         sensitivity=(
                             Sensitivity.SENSITIVE
-                            if plan.provider == "aiperf" or is_oracle or is_server_output
+                            if plan.provider in {"aiperf", "sglang_bench"}
+                            or is_oracle
+                            or is_server_output
                             else Sensitivity.INTERNAL
                         ),
                         role=(

--- a/src/flameox/application/inference.py
+++ b/src/flameox/application/inference.py
@@ -230,7 +230,7 @@ class InferenceReplayService:
         deadline_at = utc_now() + timedelta(seconds=deadline)
         tool = _PROVIDER_TOOL[scenario.provider]
         discovery = (
-            discover_sglang(Path(server.benchmark_python))
+            discover_sglang(Path(server.benchmark_python), broker=self.broker)
             if scenario.provider == "sglang_bench" and server.benchmark_python is not None
             else discover_inference_tool(tool)
         )
@@ -869,18 +869,16 @@ class InferenceReplayService:
         return scenario, server
 
     def _server_tool_identity(self, server: InferenceServerConfig) -> tuple[str | None, str | None]:
-        if server.provider == "sglang" and server.benchmark_python is not None:
-            discovery = discover_sglang(Path(server.benchmark_python))
-            return discovery.executable_digest, discovery.version
         if server.mode != "managed" or server.workload is None:
             return None, None
         command = self.workloads.resolve(server.workload).command
         executable = self._resolve_server_executable(command)
         executable_digest = self._executable_digest(executable)
-        discovery = discover_inference_tool("vllm")
+        discovery = discover_inference_tool("vllm") if server.provider == "vllm" else None
         version = (
             discovery.version
-            if discovery.executable is not None
+            if discovery is not None
+            and discovery.executable is not None
             and executable.resolve() == discovery.executable.resolve()
             else None
         )
@@ -920,7 +918,7 @@ class InferenceReplayService:
                 remediation=("Plan the inference scenario again, then retry execution.",),
             )
         provider = (
-            discover_sglang(Path(plan.tool_executable))
+            discover_sglang(Path(plan.tool_executable), broker=self.broker)
             if plan.provider == "sglang_bench" and plan.tool_executable is not None
             else discover_inference_tool(_PROVIDER_TOOL[plan.provider])
         )
@@ -1204,6 +1202,9 @@ class InferenceReplayService:
                     "streaming": plan.streaming,
                     "model": plan.model,
                     "tokenizer": plan.tokenizer,
+                    "random_input_len": plan.random_input_len,
+                    "random_output_len": plan.random_output_len,
+                    "random_range_ratio": plan.random_range_ratio,
                 }
             )
         managed_command_digest = None
@@ -1245,6 +1246,8 @@ class InferenceReplayService:
                     if plan.trace_artifact_id is not None
                     else "aiperf"
                     if plan.provider == "aiperf"
+                    else "sglang.bench_serving"
+                    if plan.provider == "sglang_bench"
                     else "vllm"
                 ),
                 producer_version=(
@@ -1271,6 +1274,7 @@ class InferenceReplayService:
             ),
             server=ServerConfigIdentity(
                 backend=plan.server_provider,
+                cache_backend="custom" if plan.server_provider == "sglang" else "vllm_paged",
                 endpoint=(
                     "/v1/chat/completions" if plan.endpoint_type == "chat" else "/v1/completions"
                 ),

--- a/src/flameox/application/inference_profiling.py
+++ b/src/flameox/application/inference_profiling.py
@@ -148,6 +148,12 @@ class InferenceProfilingService:
                 ErrorCode.EXECUTION_REFUSED,
                 "Inference profiling requires a Flameox-managed server workload.",
             )
+        if server.provider == "sglang" and profiler != "torch_profiler":
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "SGLang profiling supports only its stage-separated Torch profiler in v1.",
+                remediation=("Use profiler='torch_profiler' for the declared SGLang server.",),
+            )
         workload = self.workloads.resolve(server.workload)
         replay = InferenceReplayService(self.workspace, broker=self.broker)
         server_executable_digest, server_version = replay._server_tool_identity(server)

--- a/src/flameox/application/inference_profiling.py
+++ b/src/flameox/application/inference_profiling.py
@@ -12,7 +12,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from flameox.analysis.inference_protocol import InferenceProtocolIdentity, ProfilerState
 from flameox.application.evidence_query import EvidenceQueryService
@@ -53,10 +53,22 @@ from flameox.models import ContractModel
 from flameox.storage import ArtifactStore, RunStore, Workspace
 
 
+class SglangProfileOptions(ContractModel):
+    """The only SGLang 0.5.16 profiler request Flameox permits in v1."""
+
+    start_step: Literal[5] = 5
+    num_steps: Literal[2] = 2
+    activities: tuple[Literal["CPU"], Literal["GPU"]] = ("CPU", "GPU")
+    profile_by_stage: Literal[True] = True
+    record_shapes: Literal[True] = True
+    with_stack: Literal[True] = True
+
+
 class InferenceProfilingPlan(ContractModel):
     schema_version: Literal[1] = 1
     plan_id: str
     server_name: str
+    server_provider: Literal["vllm", "sglang"] = "vllm"
     profiler: Literal["torch_profiler", "nsight_systems"]
     base_url: str
     server_argv: tuple[str, ...]
@@ -70,6 +82,19 @@ class InferenceProfilingPlan(ContractModel):
     server_version: str | None = None
     diagnostic_only: Literal[True] = True
     limitations: tuple[str, ...]
+    sglang_profile_id: Annotated[str, Field(min_length=1, max_length=100)] | None = None
+    sglang_profile_options: SglangProfileOptions | None = None
+
+    @model_validator(mode="after")
+    def sglang_profile_contract_is_consistent(self) -> InferenceProfilingPlan:
+        requires_sglang_options = (
+            self.server_provider == "sglang" and self.profiler == "torch_profiler"
+        )
+        if requires_sglang_options != (self.sglang_profile_options is not None):
+            raise ValueError("SGLang Torch profiling requires fixed SGLang profile options")
+        if requires_sglang_options != (self.sglang_profile_id is not None):
+            raise ValueError("SGLang Torch profiling requires a generated profile id")
+        return self
 
 
 class InferenceProfilingResult(ContractModel):
@@ -130,12 +155,20 @@ class InferenceProfilingService:
         output_root = self.workspace.paths.staging / f"inference-profile-{server_name}" / new_id()
         environment = dict(workload.command.env_overrides)
         limitations: tuple[str, ...]
-        if profiler == "torch_profiler":
+        if profiler == "torch_profiler" and server.provider == "vllm":
             output_path = output_root / "torch"
             environment["VLLM_TORCH_PROFILER_DIR"] = str(output_path)
             argv = native_argv
             limitations = (
                 "Diagnostic profile; measurements must come from a separate unprofiled run.",
+            )
+        elif profiler == "torch_profiler":
+            output_path = output_root / "torch"
+            argv = native_argv
+            limitations = (
+                "Diagnostic profile; measurements must come from a separate unprofiled run.",
+                "SGLang captures separate prefill/decode traces; kernel dominance supports a "
+                "hypothesis, not a bandwidth conclusion.",
             )
         else:
             if nsys_executable is None:
@@ -169,8 +202,14 @@ class InferenceProfilingService:
                 "The native .nsys-rep must be exported with official nsys export "
                 "before extraction.",
             )
+        sglang_profile_options = (
+            SglangProfileOptions()
+            if server.provider == "sglang" and profiler == "torch_profiler"
+            else None
+        )
+        sglang_profile_id = new_id() if sglang_profile_options is not None else None
         environment_names = set(environment)
-        if profiler == "torch_profiler":
+        if profiler == "torch_profiler" and server.provider == "vllm":
             environment_names.add("VLLM_TORCH_PROFILER_DIR")
         environment_digest = digest_model(workload.command.env_overrides)
         identity = {
@@ -184,6 +223,9 @@ class InferenceProfilingService:
                 replay._executable_digest(nsys_executable) if nsys_executable else None
             ),
             "configuration_id": digest_model(project.model_dump(mode="json")),
+            "server_provider": server.provider,
+            "sglang_profile_id": sglang_profile_id,
+            "sglang_profile_options": sglang_profile_options,
         }
         plan_id = digest_model(identity)
         if expected_plan_id is not None and expected_plan_id != plan_id:
@@ -196,6 +238,7 @@ class InferenceProfilingService:
         return InferenceProfilingPlan(
             plan_id=plan_id,
             server_name=server_name,
+            server_provider=server.provider,
             profiler=profiler,
             base_url=server.base_url,
             server_argv=argv,
@@ -208,6 +251,8 @@ class InferenceProfilingService:
             server_executable_digest=server_executable_digest,
             server_version=server_version,
             limitations=limitations,
+            sglang_profile_id=sglang_profile_id,
+            sglang_profile_options=sglang_profile_options,
         )
 
     async def capture(  # noqa: C901 - one lifecycle boundary owns every terminal transition
@@ -239,7 +284,7 @@ class InferenceProfilingService:
                 "Managed server environment identity changed after profiling was planned.",
                 remediation=("Plan the inference profile again, then retry capture.",),
             )
-        if plan.profiler == "torch_profiler":
+        if plan.profiler == "torch_profiler" and plan.server_provider == "vllm":
             server_environment["VLLM_TORCH_PROFILER_DIR"] = str(plan.output_path)
         server_digest, server_version = replay._server_tool_identity(server)
         if server_digest != plan.server_executable_digest or server_version != plan.server_version:
@@ -319,14 +364,22 @@ class InferenceProfilingService:
             limitations = list(run.limitations)
             benchmark_exit_code: int | None = None
             benchmark_process = None
-            control = VllmProfilerControlClient(plan.base_url)
+            control = InferenceProfilerControlClient(plan.base_url, provider=plan.server_provider)
             try:
                 try:
                     control.timeout_seconds = min(
                         control.timeout_seconds,
                         max(0.01, (deadline_at - utc_now()).total_seconds()),
                     )
-                    await asyncio.to_thread(control.start)
+                    if plan.server_provider == "sglang":
+                        await asyncio.to_thread(
+                            control.start,
+                            output_dir=plan.output_path,
+                            profile_id=plan.sglang_profile_id,
+                            options=plan.sglang_profile_options,
+                        )
+                    else:
+                        await asyncio.to_thread(control.start)
                     remaining = (deadline_at - utc_now()).total_seconds()
                     if remaining <= 0:
                         raise DomainError(ErrorCode.PROCESS_TIMEOUT, "Profiling deadline expired.")
@@ -811,7 +864,13 @@ class InferenceProfilingService:
                             Sensitivity.SENSITIVE if server_output else Sensitivity.INTERNAL
                         ),
                         role=("inference_server_output" if server_output else "inference_profile"),
-                        producer="nsys" if plan.profiler == "nsight_systems" else "torch_profiler",
+                        producer=(
+                            "nsys"
+                            if plan.profiler == "nsight_systems"
+                            else "sglang.torch_profiler"
+                            if plan.server_provider == "sglang"
+                            else "torch_profiler"
+                        ),
                         allow_external_path=True,
                     )
                 )
@@ -897,25 +956,55 @@ class InferenceProfilingService:
         return None
 
 
-class VllmProfilerControlClient:
-    """Bounded client for vLLM's start/stop profiler control endpoints."""
+class InferenceProfilerControlClient:
+    """Provider-aware bounded client for vLLM and SGLang profiler endpoints."""
 
-    def __init__(self, base_url: str, *, timeout_seconds: float = 5.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        provider: Literal["vllm", "sglang"] = "vllm",
+        timeout_seconds: float = 5.0,
+    ) -> None:
         self.base_url = _loopback_http_url(base_url)
+        self.provider = provider
         if timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
         self.timeout_seconds = timeout_seconds
 
-    def start(self) -> None:
-        self._post("/start_profile")
+    def start(
+        self,
+        *,
+        output_dir: Path | None = None,
+        profile_id: str | None = None,
+        options: SglangProfileOptions | None = None,
+    ) -> None:
+        payload: bytes = b""
+        if self.provider == "sglang":
+            if output_dir is None or profile_id is None or options is None:
+                raise ValueError("SGLang profiling requires generated profile options")
+            payload = json.dumps(
+                {
+                    "output_dir": str(output_dir),
+                    "profile_id": profile_id,
+                    **options.model_dump(mode="json"),
+                },
+                separators=(",", ":"),
+            ).encode()
+        self._post("/start_profile", payload)
 
     def stop(self) -> None:
-        self._post("/stop_profile")
+        self._post("/stop_profile", b"")
 
-    def _post(self, path: Literal["/start_profile", "/stop_profile"]) -> None:
+    def _post(self, path: Literal["/start_profile", "/stop_profile"], payload: bytes) -> None:
         try:
             with urlopen(
-                Request(f"{self.base_url}{path}", data=b"", method="POST"),
+                Request(
+                    f"{self.base_url}{path}",
+                    data=payload,
+                    method="POST",
+                    headers={"Content-Type": "application/json"} if payload else {},
+                ),
                 timeout=self.timeout_seconds,
             ) as response:
                 if not 200 <= response.status < 300:
@@ -923,5 +1012,9 @@ class VllmProfilerControlClient:
         except (HTTPError, URLError, TimeoutError, OSError) as exc:
             raise DomainError(
                 ErrorCode.PROCESS_FAILED,
-                f"vLLM profiler control failed at {path}.",
+                f"{self.provider} profiler control failed at {path}.",
             ) from exc
+
+
+# Backwards-compatible import name for callers that only target vLLM.
+VllmProfilerControlClient = InferenceProfilerControlClient

--- a/src/flameox/application/inference_profiling.py
+++ b/src/flameox/application/inference_profiling.py
@@ -23,7 +23,7 @@ from flameox.application.evidence_rows import (
 )
 from flameox.application.imports import ImportArtifactRequest, ImportService
 from flameox.application.inference import InferenceReplayService
-from flameox.application.inference_providers import _loopback_http_url
+from flameox.application.inference_providers import _loopback_http_url, discover_sglang
 from flameox.application.run_rows import run_row
 from flameox.application.source import collect_partial_source_state
 from flameox.application.workloads import WorkloadService
@@ -80,6 +80,7 @@ class InferenceProfilingPlan(ContractModel):
     configuration_id: str
     server_executable_digest: str | None = None
     server_version: str | None = None
+    benchmark_executable_digest: str | None = None
     diagnostic_only: Literal[True] = True
     limitations: tuple[str, ...]
     sglang_profile_id: Annotated[str, Field(min_length=1, max_length=100)] | None = None
@@ -157,6 +158,13 @@ class InferenceProfilingService:
         workload = self.workloads.resolve(server.workload)
         replay = InferenceReplayService(self.workspace, broker=self.broker)
         server_executable_digest, server_version = replay._server_tool_identity(server)
+        sglang_discovery = (
+            discover_sglang(Path(server.benchmark_python), broker=self.broker)
+            if server.provider == "sglang" and server.benchmark_python is not None
+            else None
+        )
+        if sglang_discovery is not None:
+            server_version = sglang_discovery.version
         native_argv = workload.command.argv
         output_root = self.workspace.paths.staging / f"inference-profile-{server_name}" / new_id()
         environment = dict(workload.command.env_overrides)
@@ -213,7 +221,6 @@ class InferenceProfilingService:
             if server.provider == "sglang" and profiler == "torch_profiler"
             else None
         )
-        sglang_profile_id = new_id() if sglang_profile_options is not None else None
         environment_names = set(environment)
         if profiler == "torch_profiler" and server.provider == "vllm":
             environment_names.add("VLLM_TORCH_PROFILER_DIR")
@@ -230,8 +237,16 @@ class InferenceProfilingService:
             ),
             "configuration_id": digest_model(project.model_dump(mode="json")),
             "server_provider": server.provider,
-            "sglang_profile_id": sglang_profile_id,
-            "sglang_profile_options": sglang_profile_options,
+            "server_executable_digest": server_executable_digest,
+            "benchmark_executable_digest": (
+                sglang_discovery.executable_digest if sglang_discovery is not None else None
+            ),
+            "server_version": server_version,
+            "sglang_profile_options": (
+                sglang_profile_options.model_dump(mode="json")
+                if sglang_profile_options is not None
+                else None
+            ),
         }
         plan_id = digest_model(identity)
         if expected_plan_id is not None and expected_plan_id != plan_id:
@@ -256,8 +271,12 @@ class InferenceProfilingService:
             configuration_id=digest_model(project.model_dump(mode="json")),
             server_executable_digest=server_executable_digest,
             server_version=server_version,
+            benchmark_executable_digest=(
+                sglang_discovery.executable_digest if sglang_discovery is not None else None
+            ),
             limitations=limitations,
-            sglang_profile_id=sglang_profile_id,
+            # This is a server-side operation token, not a source of plan churn.
+            sglang_profile_id=(f"flameox-{plan_id[7:31]}" if sglang_profile_options else None),
             sglang_profile_options=sglang_profile_options,
         )
 
@@ -293,7 +312,17 @@ class InferenceProfilingService:
         if plan.profiler == "torch_profiler" and plan.server_provider == "vllm":
             server_environment["VLLM_TORCH_PROFILER_DIR"] = str(plan.output_path)
         server_digest, server_version = replay._server_tool_identity(server)
-        if server_digest != plan.server_executable_digest or server_version != plan.server_version:
+        if server.provider == "sglang" and server.benchmark_python is not None:
+            sglang_discovery = discover_sglang(Path(server.benchmark_python), broker=self.broker)
+            server_version = sglang_discovery.version
+            benchmark_digest = sglang_discovery.executable_digest
+        else:
+            benchmark_digest = None
+        if (
+            server_digest != plan.server_executable_digest
+            or server_version != plan.server_version
+            or benchmark_digest != plan.benchmark_executable_digest
+        ):
             raise DomainError(
                 ErrorCode.REVISION_CONFLICT,
                 "Managed server executable identity changed after profiling was planned.",

--- a/src/flameox/application/inference_providers.py
+++ b/src/flameox/application/inference_providers.py
@@ -12,7 +12,6 @@ import hashlib
 import json
 import os
 import shutil
-import subprocess
 import sys
 import time
 from importlib.metadata import PackageNotFoundError, version
@@ -27,6 +26,7 @@ from urllib.response import addinfourl
 from pydantic import Field, field_validator, model_validator
 
 from flameox.domain import DomainError, ErrorCode
+from flameox.execution import ExecutionRequest, SubprocessBroker
 from flameox.models import ContractModel
 
 _MAX_PROBE_RESPONSE_BYTES = 1024 * 1024
@@ -218,6 +218,8 @@ class SglangBenchServingRequest(ContractModel):
             raise ValueError(
                 "sglang bench_serving non-streaming response mode is unsupported in v1"
             )
+        if urlsplit(self.base_url).path not in ("", "/"):
+            raise ValueError("sglang bench_serving requires a root base_url in v1")
         return self
 
     def argv(self) -> tuple[str, ...]:
@@ -272,28 +274,33 @@ class InferenceToolDiscovery(ContractModel):
     remediation: tuple[str, ...] = ()
 
 
-def discover_sglang(benchmark_python: Path) -> InferenceToolDiscovery:
+def discover_sglang(
+    benchmark_python: Path, *, broker: SubprocessBroker | None = None
+) -> InferenceToolDiscovery:
     """Discover SGLang through its declared launcher, never Flameox's PATH."""
     executable = benchmark_python.resolve()
     digest = _digest_executable(executable)
     tool_version: str | None = None
     if executable.is_file() and os.access(executable, os.X_OK):
         try:
-            completed = subprocess.run(
-                (
-                    str(executable),
-                    "-c",
-                    "from importlib.metadata import version; print(version('sglang'))",
-                ),
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=5,
+            outcome = (broker or SubprocessBroker()).run_sync(
+                ExecutionRequest(
+                    argv=(
+                        str(executable),
+                        "-c",
+                        "from importlib.metadata import version; print(version('sglang'))",
+                    ),
+                    cwd=executable.parent,
+                    environment_allowlist=("PATH",),
+                    allowed_working_roots=(executable.parent,),
+                    timeout_seconds=5,
+                    max_output_bytes=1024,
+                )
             )
-            if completed.returncode == 0:
-                candidate = completed.stdout.strip()
+            if outcome.process.exit_code == 0:
+                candidate = outcome.stdout.decode("utf-8", errors="strict").strip()
                 tool_version = candidate if candidate else None
-        except (OSError, subprocess.SubprocessError):
+        except (DomainError, OSError, UnicodeDecodeError):
             pass
     compatible = tool_version == "0.5.16"
     return InferenceToolDiscovery(
@@ -307,8 +314,12 @@ def discover_sglang(benchmark_python: Path) -> InferenceToolDiscovery:
         if compatible
         else "SGLang 0.5.16 is required in benchmark_python.",
         remediation=(
-            "Install sglang==0.5.16 in the declared benchmark_python runtime; "
-            "Flameox does not install it.",
+            ()
+            if compatible
+            else (
+                "Install sglang==0.5.16 in the declared benchmark_python runtime; "
+                "Flameox does not install it.",
+            )
         ),
     )
 

--- a/src/flameox/application/inference_providers.py
+++ b/src/flameox/application/inference_providers.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import shutil
+import subprocess
 import sys
 import time
 from importlib.metadata import PackageNotFoundError, version
@@ -185,8 +186,83 @@ class VllmBenchServeRequest(ContractModel):
         return tuple(values)
 
 
+class SglangBenchServingRequest(ContractModel):
+    """Bounded SGLang 0.5.16 ``bench_serving`` random-workload invocation."""
+
+    benchmark_python: Path
+    base_url: str
+    model: Annotated[str, Field(min_length=1, max_length=500)]
+    tokenizer: Annotated[str, Field(min_length=1, max_length=500)] | None = None
+    result_path: Path
+    endpoint_type: Literal["chat", "completions"] = "chat"
+    streaming: bool = True
+    num_prompts: Annotated[int, Field(gt=0, le=10_000_000)]
+    random_input_len: Annotated[int, Field(gt=0, le=1_000_000)]
+    random_output_len: Annotated[int, Field(gt=0, le=1_000_000)]
+    random_range_ratio: Annotated[float, Field(gt=0, le=1)] = 1.0
+    request_rate: Annotated[float, Field(gt=0, le=1_000_000)] | None = None
+    max_concurrency: Annotated[int, Field(gt=0, le=100_000)] | None = None
+    warmup_request_count: Annotated[int, Field(ge=0, le=1_000_000)] = 0
+    seed: Annotated[int, Field(ge=0, le=2**31 - 1)] = 0
+
+    @field_validator("base_url")
+    @classmethod
+    def valid_url(cls, value: str) -> str:
+        return _loopback_http_url(value)
+
+    @model_validator(mode="after")
+    def valid_launcher_and_streaming(self) -> SglangBenchServingRequest:
+        if not self.benchmark_python.is_absolute():
+            raise ValueError("benchmark_python must be absolute")
+        if not self.streaming:
+            raise ValueError(
+                "sglang bench_serving non-streaming response mode is unsupported in v1"
+            )
+        return self
+
+    def argv(self) -> tuple[str, ...]:
+        parsed = urlsplit(self.base_url)
+        assert parsed.hostname is not None
+        values = [
+            str(self.benchmark_python),
+            "-m",
+            "sglang.bench_serving",
+            "--backend",
+            "sglang-oai-chat" if self.endpoint_type == "chat" else "sglang-oai",
+            "--host",
+            parsed.hostname,
+            "--port",
+            str(parsed.port or 80),
+            "--model",
+            self.model,
+            "--dataset-name",
+            "random",
+            "--random-input-len",
+            str(self.random_input_len),
+            "--random-output-len",
+            str(self.random_output_len),
+            "--random-range-ratio",
+            str(self.random_range_ratio),
+            "--num-prompts",
+            str(self.num_prompts),
+            "--seed",
+            str(self.seed),
+            "--output-file",
+            str(self.result_path),
+        ]
+        if self.tokenizer is not None:
+            values.extend(("--tokenizer", self.tokenizer))
+        if self.request_rate is not None:
+            values.extend(("--request-rate", str(self.request_rate)))
+        if self.max_concurrency is not None:
+            values.extend(("--max-concurrency", str(self.max_concurrency)))
+        if self.warmup_request_count:
+            values.extend(("--warmup-requests", str(self.warmup_request_count)))
+        return tuple(values)
+
+
 class InferenceToolDiscovery(ContractModel):
-    tool: Literal["aiperf", "vllm"]
+    tool: Literal["aiperf", "vllm", "sglang"]
     executable: Path | None
     available: bool
     version: str | None = None
@@ -194,6 +270,58 @@ class InferenceToolDiscovery(ContractModel):
     compatible: bool = False
     compatibility_reason: str | None = None
     remediation: tuple[str, ...] = ()
+
+
+def discover_sglang(benchmark_python: Path) -> InferenceToolDiscovery:
+    """Discover SGLang through its declared launcher, never Flameox's PATH."""
+    executable = benchmark_python.resolve()
+    digest = _digest_executable(executable)
+    tool_version: str | None = None
+    if executable.is_file() and os.access(executable, os.X_OK):
+        try:
+            completed = subprocess.run(
+                (
+                    str(executable),
+                    "-c",
+                    "from importlib.metadata import version; print(version('sglang'))",
+                ),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if completed.returncode == 0:
+                candidate = completed.stdout.strip()
+                tool_version = candidate if candidate else None
+        except (OSError, subprocess.SubprocessError):
+            pass
+    compatible = tool_version == "0.5.16"
+    return InferenceToolDiscovery(
+        tool="sglang",
+        executable=executable if executable.is_file() else None,
+        available=executable.is_file() and os.access(executable, os.X_OK) and compatible,
+        version=tool_version,
+        executable_digest=digest,
+        compatible=compatible,
+        compatibility_reason=None
+        if compatible
+        else "SGLang 0.5.16 is required in benchmark_python.",
+        remediation=(
+            "Install sglang==0.5.16 in the declared benchmark_python runtime; "
+            "Flameox does not install it.",
+        ),
+    )
+
+
+def _digest_executable(executable: Path) -> str | None:
+    digest = hashlib.sha256()
+    try:
+        with executable.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return f"sha256:{digest.hexdigest()}"
 
 
 def discover_inference_tool(tool: Literal["aiperf", "vllm"]) -> InferenceToolDiscovery:
@@ -209,14 +337,7 @@ def discover_inference_tool(tool: Literal["aiperf", "vllm"]) -> InferenceToolDis
     tool_version: str | None = None
     executable_digest: str | None = None
     if executable is not None:
-        digest = hashlib.sha256()
-        try:
-            with executable.open("rb") as stream:
-                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                    digest.update(chunk)
-            executable_digest = f"sha256:{digest.hexdigest()}"
-        except OSError:
-            executable_digest = None
+        executable_digest = _digest_executable(executable)
         try:
             tool_version = version(tool)
         except PackageNotFoundError:

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -391,6 +391,8 @@ class InferenceScenarioConfig(ContractModel):
                 raise ValueError("sglang_bench non-streaming response mode is unsupported in v1")
             if self.random_input_len is None or self.random_output_len is None:
                 raise ValueError("sglang_bench requires random_input_len and random_output_len")
+            if self.burstiness is not None:
+                raise ValueError("sglang_bench burstiness is unsupported in v1")
         elif any(
             value is not None
             for value in (self.random_input_len, self.random_output_len, self.random_range_ratio)

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -318,7 +318,8 @@ class InferenceServerConfig(ContractModel):
     endpoint Flameox probes but never starts.
     """
 
-    provider: Literal["vllm"] = "vllm"
+    provider: Literal["vllm", "sglang"] = "vllm"
+    benchmark_python: str | None = None
     mode: Literal["managed", "existing_local"]
     workload: str | None = None
     base_url: str = "http://127.0.0.1:8000"
@@ -330,6 +331,13 @@ class InferenceServerConfig(ContractModel):
 
     @model_validator(mode="after")
     def mode_fields_are_consistent(self) -> InferenceServerConfig:
+        if self.provider == "sglang":
+            if self.benchmark_python is None or not Path(self.benchmark_python).is_absolute():
+                raise ValueError(
+                    "sglang inference servers require an absolute benchmark_python launcher"
+                )
+        elif self.benchmark_python is not None:
+            raise ValueError("benchmark_python is only supported by sglang inference servers")
         if self.mode == "managed":
             if self.workload is None:
                 raise ValueError("managed inference servers require a workload")
@@ -356,7 +364,7 @@ class InferenceScenarioConfig(ContractModel):
     """
 
     server: str
-    provider: Literal["aiperf", "vllm_bench"]
+    provider: Literal["aiperf", "vllm_bench", "sglang_bench"]
     endpoint_type: Literal["chat", "completions"] = "chat"
     streaming: bool = True
     trace_artifact_id: Digest | None = None
@@ -368,6 +376,9 @@ class InferenceScenarioConfig(ContractModel):
     seed: Annotated[int, Field(ge=0, le=2**31 - 1)] = 0
     speedup_ratio: Annotated[float, Field(gt=0, le=100)] = 1.0
     semantic_oracle_workload: str | None = None
+    random_input_len: Annotated[int, Field(gt=0, le=1_000_000)] | None = None
+    random_output_len: Annotated[int, Field(gt=0, le=1_000_000)] | None = None
+    random_range_ratio: Annotated[float, Field(gt=0, le=1)] | None = None
 
     @model_validator(mode="after")
     def trace_requires_aiperf(self) -> InferenceScenarioConfig:
@@ -375,6 +386,16 @@ class InferenceScenarioConfig(ContractModel):
             raise ValueError("trace_artifact_id is only supported by the aiperf provider")
         if self.provider == "vllm_bench" and not self.streaming:
             raise ValueError("vllm_bench non-streaming response mode is unsupported in v1")
+        if self.provider == "sglang_bench":
+            if not self.streaming:
+                raise ValueError("sglang_bench non-streaming response mode is unsupported in v1")
+            if self.random_input_len is None or self.random_output_len is None:
+                raise ValueError("sglang_bench requires random_input_len and random_output_len")
+        elif any(
+            value is not None
+            for value in (self.random_input_len, self.random_output_len, self.random_range_ratio)
+        ):
+            raise ValueError("random workload fields are only supported by sglang_bench")
         if self.burstiness is not None and self.request_rate is None:
             raise ValueError("burstiness requires request_rate")
         return self
@@ -467,6 +488,12 @@ class ProjectConfig(ContractModel):
             raise ValueError(
                 "inference scenarios reference unknown servers: " + ", ".join(missing_servers)
             )
+        for scenario in self.inference_scenarios.values():
+            server = self.inference_servers[scenario.server]
+            if scenario.provider == "sglang_bench" and server.provider != "sglang":
+                raise ValueError("sglang_bench scenarios require an sglang inference server")
+            if scenario.provider != "sglang_bench" and server.provider == "sglang":
+                raise ValueError("sglang inference servers require an sglang_bench scenario")
         missing_oracles = sorted(
             {
                 scenario.semantic_oracle_workload

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -336,6 +336,8 @@ class InferenceServerConfig(ContractModel):
                 raise ValueError(
                     "sglang inference servers require an absolute benchmark_python launcher"
                 )
+            if urlsplit(self.base_url).path not in ("", "/"):
+                raise ValueError("sglang inference servers require a root base_url in v1")
         elif self.benchmark_python is not None:
             raise ValueError("benchmark_python is only supported by sglang inference servers")
         if self.mode == "managed":

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -2248,7 +2248,7 @@ def extract_inference_trace(
 def extract_inference_result(
     run_id: Annotated[str, typer.Argument(help="Import run containing provider result data.")],
     provider: Annotated[
-        Literal["aiperf", "vllm_bench"],
+        Literal["aiperf", "vllm_bench", "sglang_bench"],
         typer.Option("--provider", help="Maintained provider artifact schema."),
     ],
     workspace: WorkspaceOption = None,
@@ -2260,6 +2260,8 @@ def extract_inference_result(
         result = (
             extractor.extract_aiperf_result(run_id)
             if provider == "aiperf"
+            else extractor.extract_sglang_result(run_id)
+            if provider == "sglang_bench"
             else extractor.extract_vllm_result(run_id)
         )
     except DomainError as error:

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -937,6 +937,8 @@ def inference_configure_server(
     name: str,
     mode: Literal["managed", "existing_local"],
     model: str,
+    provider: Annotated[Literal["vllm", "sglang"], typer.Option("--provider")] = "vllm",
+    benchmark_python: Annotated[str | None, typer.Option("--benchmark-python")] = None,
     operation: Literal["create", "replace"] = "create",
     workload: Annotated[str | None, typer.Option("--workload")] = None,
     base_url: Annotated[str, typer.Option("--base-url")] = "http://127.0.0.1:8000",
@@ -958,6 +960,8 @@ def inference_configure_server(
                 operation=operation,
                 expected_configuration_id=expected_configuration_id,
                 config=InferenceServerConfig(
+                    provider=provider,
+                    benchmark_python=benchmark_python,
                     mode=mode,
                     workload=workload,
                     base_url=base_url,
@@ -980,7 +984,7 @@ def inference_configure_server(
 def inference_configure_scenario(
     name: str,
     server: str,
-    provider: Literal["aiperf", "vllm_bench"],
+    provider: Literal["aiperf", "vllm_bench", "sglang_bench"],
     operation: Literal["create", "replace"] = "create",
     endpoint_type: Literal["chat", "completions"] = "chat",
     streaming: bool = True,
@@ -994,6 +998,11 @@ def inference_configure_scenario(
     speedup_ratio: Annotated[float, typer.Option("--speedup-ratio", min=0.001)] = 1.0,
     semantic_oracle_workload: Annotated[
         str | None, typer.Option("--semantic-oracle-workload")
+    ] = None,
+    random_input_len: Annotated[int | None, typer.Option("--random-input-len", min=1)] = None,
+    random_output_len: Annotated[int | None, typer.Option("--random-output-len", min=1)] = None,
+    random_range_ratio: Annotated[
+        float | None, typer.Option("--random-range-ratio", min=0.001, max=1.0)
     ] = None,
     expected_configuration_id: Annotated[
         str | None, typer.Option("--expected-configuration-id")
@@ -1022,6 +1031,9 @@ def inference_configure_scenario(
                     seed=seed,
                     speedup_ratio=speedup_ratio,
                     semantic_oracle_workload=semantic_oracle_workload,
+                    random_input_len=random_input_len,
+                    random_output_len=random_output_len,
+                    random_range_ratio=random_range_ratio,
                 ),
             )
         )

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -3101,7 +3101,7 @@ def create_server(
     @server.tool(name="extract_inference_result", annotations=ADDITIVE)
     async def extract_inference_result_tool(
         run_id: Annotated[str, Field(min_length=1, max_length=200)],
-        provider: Literal["aiperf", "vllm_bench"],
+        provider: Literal["aiperf", "vllm_bench", "sglang_bench"],
         ctx: Context[AppContext],
     ) -> Annotated[CallToolResult, ToolPayload[InferenceExtractionResult]]:
         """Extract prompt-free AIPerf requests or vLLM aggregate measurements."""
@@ -3112,6 +3112,10 @@ def create_server(
                         ctx.request_context.lifespan_context.require_workspace()
                     ).extract_aiperf_result(run_id)
                     if provider == "aiperf"
+                    else InferenceArtifactExtractor(
+                        ctx.request_context.lifespan_context.require_workspace()
+                    ).extract_sglang_result(run_id)
+                    if provider == "sglang_bench"
                     else InferenceArtifactExtractor(
                         ctx.request_context.lifespan_context.require_workspace()
                     ).extract_vllm_result(run_id)

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -1016,6 +1016,11 @@ def create_server(
         ],
         model: Annotated[str, Field(min_length=1, max_length=500)],
         ctx: Context[AppContext],
+        provider: Literal["vllm", "sglang"] = "vllm",
+        benchmark_python: Annotated[
+            str | None,
+            Field(description="Absolute SGLang Python launcher; required only for sglang."),
+        ] = None,
         workload: Annotated[
             str | None,
             Field(description="Declared workload that starts vLLM; required for managed mode."),
@@ -1042,6 +1047,8 @@ def create_server(
                     operation=operation,
                     expected_configuration_id=expected_configuration_id,
                     config=InferenceServerConfig(
+                        provider=provider,
+                        benchmark_python=benchmark_python,
                         mode=mode,
                         workload=workload,
                         base_url=base_url,
@@ -1065,7 +1072,7 @@ def create_server(
         ],
         operation: Literal["create", "replace"],
         server_name: Annotated[str, Field(min_length=1, max_length=100)],
-        provider: Literal["aiperf", "vllm_bench"],
+        provider: Literal["aiperf", "vllm_bench", "sglang_bench"],
         ctx: Context[AppContext],
         endpoint_type: Literal["chat", "completions"] = "chat",
         streaming: bool = True,
@@ -1093,6 +1100,9 @@ def create_server(
                 description="Declared workload with an oracle contract, not an ordinary workload.",
             ),
         ] = None,
+        random_input_len: Annotated[int | None, Field(gt=0, le=1_000_000)] = None,
+        random_output_len: Annotated[int | None, Field(gt=0, le=1_000_000)] = None,
+        random_range_ratio: Annotated[float | None, Field(gt=0, le=1)] = None,
         expected_configuration_id: Annotated[
             str | None, Field(pattern=r"^sha256:[0-9a-f]{64}$")
         ] = None,
@@ -1120,6 +1130,9 @@ def create_server(
                         seed=seed,
                         speedup_ratio=speedup_ratio,
                         semantic_oracle_workload=semantic_oracle_workload,
+                        random_input_len=random_input_len,
+                        random_output_len=random_output_len,
+                        random_range_ratio=random_range_ratio,
                     ),
                 )
             )

--- a/tests/adapters/test_inference_artifacts.py
+++ b/tests/adapters/test_inference_artifacts.py
@@ -1499,7 +1499,10 @@ def test_sglang_result_parser_emits_safe_optional_scalar_metrics(tmp_path: Path)
                 "total_input_tokens": 8,
                 "total_output_tokens": 4,
                 "request_throughput": 2.0,
+                "total_token_throughput": 12.0,
                 "accept_length": 3.5,
+                "mean_ttft_ms": 4.0,
+                "p95_ttft_ms": 9.0,
             }
         )
         + "\n",
@@ -1511,7 +1514,12 @@ def test_sglang_result_parser_emits_safe_optional_scalar_metrics(tmp_path: Path)
     values = {row.name: row.value_float for row in rows}
     assert values["sglang.accept_length"] == 3.5
     assert values["sglang.request_throughput"] == 2.0
+    assert values["sglang.total_token_throughput"] == 12.0
     assert all(row.dimensions["producer"] == "sglang.bench_serving" for row in rows)
+    by_name = {row.name: row for row in rows}
+    assert by_name["sglang.mean_ttft_ms"].aggregation == "mean"
+    assert by_name["sglang.p95_ttft_ms"].aggregation == "percentile"
+    assert by_name["sglang.p95_ttft_ms"].dimensions["percentile"] == "95"
 
 
 @pytest.mark.parametrize("payload", ["", "{}\n{}\n", '{"duration": NaN}\n'])

--- a/tests/adapters/test_inference_artifacts.py
+++ b/tests/adapters/test_inference_artifacts.py
@@ -12,6 +12,7 @@ from flameox.adapters import (
     InferenceArtifactExtractor,
     MooncakeRequestRow,
     MooncakeTraceParser,
+    SglangResultParser,
     VllmResultParser,
 )
 from flameox.application import EvidenceQueryService, ImportArtifactRequest, ImportService
@@ -1465,3 +1466,60 @@ def test_aiperf_extractor_enforces_independent_request_row_cap(
     assert workspace.config.storage.max_rows_per_generation > 1
     assert result.request_count == 1
     assert result.limitations == ("AIPerf request evidence truncated at 1 rows.",)
+
+
+def test_sglang_result_parser_rejects_sensitive_detailed_output(tmp_path: Path) -> None:
+    result_path = tmp_path / "result.jsonl"
+    result_path.write_text(
+        json.dumps(
+            {
+                "duration": 1.0,
+                "completed": 1,
+                "total_input_tokens": 4,
+                "total_output_tokens": 2,
+                "request_throughput": 1.0,
+                "generated_texts": ["secret"],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(DomainError, match="aggregate SGLang JSONL"):
+        SglangResultParser().parse(result_path)
+
+
+def test_sglang_result_parser_emits_safe_optional_scalar_metrics(tmp_path: Path) -> None:
+    result_path = tmp_path / "result.jsonl"
+    result_path.write_text(
+        json.dumps(
+            {
+                "duration": 1.0,
+                "completed": 2,
+                "total_input_tokens": 8,
+                "total_output_tokens": 4,
+                "request_throughput": 2.0,
+                "accept_length": 3.5,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    _document, rows = SglangResultParser().parse(result_path)
+
+    values = {row.name: row.value_float for row in rows}
+    assert values["sglang.accept_length"] == 3.5
+    assert values["sglang.request_throughput"] == 2.0
+    assert all(row.dimensions["producer"] == "sglang.bench_serving" for row in rows)
+
+
+@pytest.mark.parametrize("payload", ["", "{}\n{}\n", '{"duration": NaN}\n'])
+def test_sglang_result_parser_rejects_malformed_or_multiple_records(
+    tmp_path: Path, payload: str
+) -> None:
+    result_path = tmp_path / "result.jsonl"
+    result_path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(DomainError, match="aggregate SGLang JSONL"):
+        SglangResultParser().parse(result_path)

--- a/tests/application/test_inference.py
+++ b/tests/application/test_inference.py
@@ -192,9 +192,7 @@ def test_sglang_protocol_identity_binds_random_shape_and_provenance(
         version="0.5.16",
         executable_digest="sha256:" + "c" * 64,
     )
-    monkeypatch.setattr(
-        inference_module, "discover_sglang", lambda _launcher, *, broker: discovery
-    )
+    monkeypatch.setattr(inference_module, "discover_sglang", lambda _launcher, *, broker: discovery)
     monkeypatch.setattr(
         inference_module,
         "probe_existing_vllm_server",

--- a/tests/application/test_inference.py
+++ b/tests/application/test_inference.py
@@ -7,6 +7,7 @@ import pytest
 
 from flameox.adapters.inference import InferenceArtifactExtractor
 from flameox.analysis.inference_protocol import InferenceProtocolIdentity
+from flameox.application.environment import collect_environment
 from flameox.application.evidence_query import EvidenceQueryService
 from flameox.application.inference import (
     InferenceReplayResult,
@@ -161,6 +162,56 @@ def test_plan_existing_local_vllm_bench_uses_shorter_default_deadline(
     assert plan.argv[0] == "/tools/vllm"
     assert "bench" in plan.argv and "serve" in plan.argv
     assert plan.timeout_seconds == 600.0  # vllm_bench default deadline
+
+
+def test_sglang_protocol_identity_binds_random_shape_and_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    launcher = tmp_path / "sglang-python"
+    launcher.write_text("launcher")
+    launcher.chmod(0o755)
+    (tmp_path / "flameox.toml").write_text(
+        "schema_version = 1\n"
+        "[inference_servers.local]\n"
+        'provider = "sglang"\n'
+        f'benchmark_python = "{launcher}"\n'
+        'mode = "existing_local"\nbase_url = "http://127.0.0.1:8000"\nmodel = "model"\n'
+        "[inference_scenarios.replay]\n"
+        'server = "local"\nprovider = "sglang_bench"\n'
+        "random_input_len = 4\nrandom_output_len = 2\nrandom_range_ratio = 0.5\n"
+    )
+    from flameox.application import inference as inference_module
+    from flameox.application.inference_providers import ExistingServerProbe, InferenceToolDiscovery
+
+    discovery = InferenceToolDiscovery(
+        tool="sglang",
+        executable=launcher,
+        available=True,
+        compatible=True,
+        version="0.5.16",
+        executable_digest="sha256:" + "c" * 64,
+    )
+    monkeypatch.setattr(
+        inference_module, "discover_sglang", lambda _launcher, *, broker: discovery
+    )
+    monkeypatch.setattr(
+        inference_module,
+        "probe_existing_vllm_server",
+        lambda *_args, **_kwargs: ExistingServerProbe(
+            base_url="http://127.0.0.1:8000", health_ready=True, model_ids=("model",)
+        ),
+    )
+    service = InferenceReplayService(workspace, broker=RecordingBroker())
+    plan = service.plan("replay")
+    reshaped = plan.model_copy(update={"random_input_len": 8})
+
+    identity = service._protocol_identity(plan, environment=collect_environment())
+    reshaped_identity = service._protocol_identity(reshaped, environment=collect_environment())
+
+    assert identity.trace.producer == "sglang.bench_serving"
+    assert identity.server.cache_backend == "custom"
+    assert identity.trace.artifact_digest != reshaped_identity.trace.artifact_digest
 
 
 def test_each_replay_plan_uses_an_isolated_output_directory(

--- a/tests/application/test_inference_configuration.py
+++ b/tests/application/test_inference_configuration.py
@@ -102,6 +102,18 @@ def test_sglang_scenario_requires_random_workload_and_sglang_server() -> None:
         )
 
 
+def test_sglang_scenario_rejects_dropped_burstiness() -> None:
+    with pytest.raises(ValidationError, match="burstiness is unsupported"):
+        InferenceScenarioConfig(
+            server="local",
+            provider="sglang_bench",
+            random_input_len=4,
+            random_output_len=2,
+            request_rate=1,
+            burstiness=0.5,
+        )
+
+
 def test_sglang_config_rejects_non_cuda_v1_escape_hatches() -> None:
     with pytest.raises(ValidationError, match="extra_forbidden"):
         InferenceServerConfig.model_validate(

--- a/tests/application/test_inference_configuration.py
+++ b/tests/application/test_inference_configuration.py
@@ -83,6 +83,17 @@ def test_sglang_server_requires_an_absolute_benchmark_launcher(launcher: str | N
         )
 
 
+def test_sglang_server_rejects_non_root_base_url() -> None:
+    with pytest.raises(ValidationError, match="root base_url"):
+        InferenceServerConfig(
+            provider="sglang",
+            benchmark_python="/opt/sglang/bin/python",
+            mode="existing_local",
+            base_url="http://127.0.0.1:8000/api",
+            model="model",
+        )
+
+
 def test_sglang_scenario_requires_random_workload_and_sglang_server() -> None:
     with pytest.raises(ValidationError, match="requires random_input_len"):
         InferenceScenarioConfig(server="local", provider="sglang_bench")

--- a/tests/application/test_inference_configuration.py
+++ b/tests/application/test_inference_configuration.py
@@ -72,6 +72,49 @@ def test_managed_inference_server_rejects_localhost_name() -> None:
         )
 
 
+@pytest.mark.parametrize("launcher", [None, "python", "relative/python"])
+def test_sglang_server_requires_an_absolute_benchmark_launcher(launcher: str | None) -> None:
+    with pytest.raises(ValidationError, match="absolute benchmark_python"):
+        InferenceServerConfig(
+            provider="sglang",
+            benchmark_python=launcher,
+            mode="existing_local",
+            model="model",
+        )
+
+
+def test_sglang_scenario_requires_random_workload_and_sglang_server() -> None:
+    with pytest.raises(ValidationError, match="requires random_input_len"):
+        InferenceScenarioConfig(server="local", provider="sglang_bench")
+    with pytest.raises(ValidationError, match="require an sglang inference server"):
+        ProjectConfig.model_validate(
+            {
+                "inference_servers": {"local": {"mode": "existing_local", "model": "model"}},
+                "inference_scenarios": {
+                    "replay": {
+                        "server": "local",
+                        "provider": "sglang_bench",
+                        "random_input_len": 4,
+                        "random_output_len": 2,
+                    }
+                },
+            }
+        )
+
+
+def test_sglang_config_rejects_non_cuda_v1_escape_hatches() -> None:
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        InferenceServerConfig.model_validate(
+            {
+                "provider": "sglang",
+                "benchmark_python": "/opt/sglang/bin/python",
+                "mode": "existing_local",
+                "model": "model",
+                "rocm": True,
+            }
+        )
+
+
 def test_structured_inference_configuration_preserves_existing_sections(tmp_path: Path) -> None:
     workspace = Workspace.initialize(tmp_path)
     (tmp_path / "flameox.toml").write_text(

--- a/tests/application/test_inference_profiling.py
+++ b/tests/application/test_inference_profiling.py
@@ -248,6 +248,50 @@ def test_torch_profile_plan_uses_managed_workload_and_trace_directory(tmp_path: 
     assert plan.plan_id == second.plan_id
 
 
+def test_sglang_torch_plan_has_stable_identity_and_derived_profile_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    launcher = tmp_path / "sglang-python"
+    launcher.write_text("launcher")
+    launcher.chmod(0o755)
+    (tmp_path / "serve.py").write_text("print('serve')")
+    (tmp_path / "flameox.toml").write_text(
+        "schema_version = 1\n"
+        '[workloads.serve]\nargv = ["python", "serve.py"]\n'
+        "[inference_servers.local]\n"
+        'provider = "sglang"\n'
+        f'benchmark_python = "{launcher}"\n'
+        'mode = "managed"\nworkload = "serve"\n'
+        'base_url = "http://127.0.0.1:8000"\nmodel = "model"\n'
+        "[inference_scenarios.profile]\n"
+        'server = "local"\nprovider = "sglang_bench"\n'
+        "random_input_len = 4\nrandom_output_len = 2\n"
+    )
+
+    discovery = InferenceToolDiscovery(
+        tool="sglang",
+        executable=launcher,
+        available=True,
+        compatible=True,
+        version="0.5.16",
+        executable_digest="sha256:" + "b" * 64,
+    )
+    monkeypatch.setattr(
+        "flameox.application.inference_profiling.discover_sglang",
+        lambda _launcher, *, broker: discovery,
+    )
+
+    service = InferenceProfilingService(workspace)
+    first = service.plan("local", profiler="torch_profiler")
+    second = service.plan("local", profiler="torch_profiler")
+
+    assert first.plan_id == second.plan_id
+    assert first.sglang_profile_id == second.sglang_profile_id
+    assert first.sglang_profile_id == f"flameox-{first.plan_id[7:31]}"
+    assert first.benchmark_executable_digest == discovery.executable_digest
+
+
 def test_nsight_plan_wraps_server_with_documented_cuda_capture_range(tmp_path: Path) -> None:
     nsys = tmp_path / "nsys"
     nsys.write_text("#!/bin/sh\n")

--- a/tests/application/test_inference_profiling.py
+++ b/tests/application/test_inference_profiling.py
@@ -11,7 +11,9 @@ import pytest
 
 from flameox.application.inference import InferenceReplayService
 from flameox.application.inference_profiling import (
+    InferenceProfilerControlClient,
     InferenceProfilingService,
+    SglangProfileOptions,
     VllmProfilerControlClient,
 )
 from flameox.application.inference_providers import InferenceToolDiscovery
@@ -297,6 +299,47 @@ def test_profiler_control_uses_only_start_and_stop_endpoints(
         ("POST", "http://127.0.0.1:8000/start_profile"),
         ("POST", "http://127.0.0.1:8000/stop_profile"),
     ]
+
+
+def test_sglang_profiler_control_posts_only_fixed_profile_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payloads: list[tuple[str, bytes]] = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def fake_urlopen(request: object, *, timeout: float) -> Response:
+        del timeout
+        payloads.append((request.full_url, request.data))  # type: ignore[attr-defined]
+        return Response()
+
+    monkeypatch.setattr("flameox.application.inference_profiling.urlopen", fake_urlopen)
+    client = InferenceProfilerControlClient("http://127.0.0.1:8000", provider="sglang")
+    client.start(
+        output_dir=tmp_path / "traces",
+        profile_id="profile-id",
+        options=SglangProfileOptions(),
+    )
+    client.stop()
+
+    assert json.loads(payloads[0][1]) == {
+        "output_dir": str(tmp_path / "traces"),
+        "profile_id": "profile-id",
+        "start_step": 5,
+        "num_steps": 2,
+        "activities": ["CPU", "GPU"],
+        "profile_by_stage": True,
+        "record_shapes": True,
+        "with_stack": True,
+    }
+    assert payloads[1] == ("http://127.0.0.1:8000/stop_profile", b"")
 
 
 def test_torch_profile_preserves_compressed_trace_for_perfetto(tmp_path: Path) -> None:

--- a/tests/application/test_inference_providers.py
+++ b/tests/application/test_inference_providers.py
@@ -11,6 +11,7 @@ from flameox.application.inference_providers import (
     SglangBenchServingRequest,
     VllmBenchServeRequest,
     discover_inference_tool,
+    discover_sglang,
     probe_existing_vllm_server,
 )
 
@@ -176,3 +177,48 @@ def test_sglang_bench_uses_fixed_module_random_workload_and_safe_output(tmp_path
     assert "sglang-oai-chat" in argv
     assert "--output-details" not in argv
     assert argv[argv.index("--output-file") + 1] == str(tmp_path / "result.jsonl")
+
+
+def test_sglang_bench_rejects_base_url_paths(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="root base_url"):
+        SglangBenchServingRequest(
+            benchmark_python=Path("/opt/sglang/bin/python"),
+            base_url="http://127.0.0.1:8000/api",
+            model="model",
+            result_path=tmp_path / "result.jsonl",
+            num_prompts=1,
+            random_input_len=4,
+            random_output_len=2,
+        )
+
+
+def test_sglang_discovery_uses_the_bounded_broker(tmp_path: Path) -> None:
+    from flameox.domain import ProcessResult
+    from flameox.execution import ExecutionOutcome, ExecutionRequest, SubprocessBroker
+
+    executable = tmp_path / "python"
+    executable.write_text("launcher")
+    executable.chmod(0o755)
+
+    class Broker(SubprocessBroker):
+        def __init__(self) -> None:
+            self.request: ExecutionRequest | None = None
+
+        def run_sync(self, request: ExecutionRequest, **_kwargs: object) -> ExecutionOutcome:
+            self.request = request
+            return ExecutionOutcome(
+                process=ProcessResult(exit_code=0),
+                stdout=b"0.5.16\n",
+                stderr=b"",
+                resolved_executable=executable,
+                containment="process_group",
+            )
+
+    broker = Broker()
+    discovery = discover_sglang(executable, broker=broker)
+
+    assert discovery.available is True
+    assert discovery.remediation == ()
+    assert broker.request is not None
+    assert broker.request.timeout_seconds == 5
+    assert broker.request.max_output_bytes == 1024

--- a/tests/application/test_inference_providers.py
+++ b/tests/application/test_inference_providers.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from flameox.application.inference_providers import (
     AIPerfProfileRequest,
+    SglangBenchServingRequest,
     VllmBenchServeRequest,
     discover_inference_tool,
     probe_existing_vllm_server,
@@ -153,3 +154,25 @@ def test_aiperf_discovery_rejects_unsupported_version(
     assert result.compatible is False
     assert result.executable_digest is not None
     assert result.compatibility_reason is not None
+
+
+def test_sglang_bench_uses_fixed_module_random_workload_and_safe_output(tmp_path: Path) -> None:
+    request = SglangBenchServingRequest(
+        benchmark_python=Path("/opt/sglang/bin/python"),
+        base_url="http://127.0.0.1:8000",
+        model="model",
+        tokenizer="tokenizer",
+        result_path=tmp_path / "result.jsonl",
+        num_prompts=3,
+        random_input_len=16,
+        random_output_len=8,
+        random_range_ratio=0.5,
+        endpoint_type="chat",
+    )
+
+    argv = request.argv()
+
+    assert argv[:3] == ("/opt/sglang/bin/python", "-m", "sglang.bench_serving")
+    assert "sglang-oai-chat" in argv
+    assert "--output-details" not in argv
+    assert argv[argv.index("--output-file") + 1] == str(tmp_path / "result.jsonl")

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 774
+expected_test_count = 779
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -67,11 +67,11 @@ expected_test_count = 774
 'tests/application/test_evidence_scope.py' = { count = 2, digest = 'e3e51e28f67c6512e3943f88f469d937f88d5f7f88317a34868640e55b9f590b' }
 'tests/application/test_experiments.py' = { count = 11, digest = 'ef1d24a47a9ed83b4e069315bdf7057f7e2028ef840bcbd22b662d1442dae3ad' }
 'tests/application/test_faults.py' = { count = 5, digest = '9330626143cdfb60660c3466aea29491ddce50d1cecd1e04fe4b4b7b11d2fe8a' }
-'tests/application/test_inference.py' = { count = 21, digest = '4468d9e77b17369d65a0268b876b233c6d6702d72d4768c9127729a997398622' }
+'tests/application/test_inference.py' = { count = 22, digest = '696d8052fed45f7eef19344604fd58aa7a7deb5c2d819038c5800fbebb111f88' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }
-'tests/application/test_inference_configuration.py' = { count = 14, digest = 'b10d4a20b8e828b5d167c83c034b9034597cbf6e8c7356efeba069c6d769b011' }
-'tests/application/test_inference_profiling.py' = { count = 13, digest = 'adde209038aa940aeda4bc40a89fbfa3476d2daaaba318554d051a9ad93e30d9' }
-'tests/application/test_inference_providers.py' = { count = 8, digest = '7400ea5a05fc8a61e5acd86886c53bf2691774ae0306b3026c6d9f6433c07648' }
+'tests/application/test_inference_configuration.py' = { count = 15, digest = 'a42719a7942420c094474f5265f37d9b505e88cab3ad2ae13d918b5cec928ea8' }
+'tests/application/test_inference_profiling.py' = { count = 14, digest = 'a6e5535fe44590c12e8ef2b07ae8d4dad077a5c9f30c562826c34c03e097fb15' }
+'tests/application/test_inference_providers.py' = { count = 10, digest = 'fa30971121d0ac947c4f289d9efca31e1c650b2ab369aecc6f7980ce3c189a6f' }
 'tests/application/test_native_reducer_properties.py' = { count = 5, digest = '8b23a4c091126f78fd10281093021fafe36f426cfb3441e0460200f30149b315' }
 'tests/application/test_gc.py' = { count = 8, digest = '2ef5cddb403f867124821c2cfde9df70896e2cd8d284c2e563b6455f0ad998d4' }
 'tests/application/test_integrity.py' = { count = 1, digest = 'c44a2cb51b7f5a90c106b4a59e9661551a47ae8d0a21df308387618b99e277aa' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 773
+expected_test_count = 774
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -69,7 +69,7 @@ expected_test_count = 773
 'tests/application/test_faults.py' = { count = 5, digest = '9330626143cdfb60660c3466aea29491ddce50d1cecd1e04fe4b4b7b11d2fe8a' }
 'tests/application/test_inference.py' = { count = 21, digest = '4468d9e77b17369d65a0268b876b233c6d6702d72d4768c9127729a997398622' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }
-'tests/application/test_inference_configuration.py' = { count = 13, digest = 'b8d40ad500d52a5d77f7327e9a5a8ac8d7a9977afa9d640c77946df525f58459' }
+'tests/application/test_inference_configuration.py' = { count = 14, digest = 'b10d4a20b8e828b5d167c83c034b9034597cbf6e8c7356efeba069c6d769b011' }
 'tests/application/test_inference_profiling.py' = { count = 13, digest = 'adde209038aa940aeda4bc40a89fbfa3476d2daaaba318554d051a9ad93e30d9' }
 'tests/application/test_inference_providers.py' = { count = 8, digest = '7400ea5a05fc8a61e5acd86886c53bf2691774ae0306b3026c6d9f6433c07648' }
 'tests/application/test_native_reducer_properties.py' = { count = 5, digest = '8b23a4c091126f78fd10281093021fafe36f426cfb3441e0460200f30149b315' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 761
+expected_test_count = 773
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -38,7 +38,7 @@ expected_test_count = 761
 
 [files]
 'tests/adapters/test_benchmark_samples.py' = { count = 8, digest = '71e398543a29c75f059be8b1ba659ee80952b9407ef0295b7fa9bfe736ad05d3' }
-'tests/adapters/test_inference_artifacts.py' = { count = 81, digest = '01ceb08084722c74a2a51ff8f1b962b1739dfb7bde945ae41679135b16ec1fff' }
+'tests/adapters/test_inference_artifacts.py' = { count = 86, digest = '9a9ccc9c7cfa6204fa5dc02a04b1b23c4899b5b719ed98ce846608d80a43d739' }
 'tests/adapters/test_coverage.py' = { count = 3, digest = 'a9aa85687b6f34101ebcf2d6b69c22c866f9279436bdb9cbaff2793dba714891' }
 'tests/adapters/test_memray.py' = { count = 3, digest = '929b943d44dd1e64914730a760870fb7f87154c0a036e7d6ef355ce42d858c66' }
 'tests/adapters/test_nsight_systems.py' = { count = 4, digest = 'd6762bee4c5f04bbd6d4fdb78fddd891aa59d08b06311b895cf46f968c756570' }
@@ -69,9 +69,9 @@ expected_test_count = 761
 'tests/application/test_faults.py' = { count = 5, digest = '9330626143cdfb60660c3466aea29491ddce50d1cecd1e04fe4b4b7b11d2fe8a' }
 'tests/application/test_inference.py' = { count = 21, digest = '4468d9e77b17369d65a0268b876b233c6d6702d72d4768c9127729a997398622' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }
-'tests/application/test_inference_configuration.py' = { count = 8, digest = 'bc644f302729b0b5c59a3a9d338cb286003c196f2594bfd04f7337f1f1840cc9' }
-'tests/application/test_inference_profiling.py' = { count = 12, digest = '19e0537f2d10eda999aa1aa87e222d3c71e3dc073333482b4c5bbfce54031a2c' }
-'tests/application/test_inference_providers.py' = { count = 7, digest = 'ac136d9606c331e5fcd44640fdbe23ce2e820d4ff68b710a189fd0c5c91ded70' }
+'tests/application/test_inference_configuration.py' = { count = 13, digest = 'b8d40ad500d52a5d77f7327e9a5a8ac8d7a9977afa9d640c77946df525f58459' }
+'tests/application/test_inference_profiling.py' = { count = 13, digest = 'adde209038aa940aeda4bc40a89fbfa3476d2daaaba318554d051a9ad93e30d9' }
+'tests/application/test_inference_providers.py' = { count = 8, digest = '7400ea5a05fc8a61e5acd86886c53bf2691774ae0306b3026c6d9f6433c07648' }
 'tests/application/test_native_reducer_properties.py' = { count = 5, digest = '8b23a4c091126f78fd10281093021fafe36f426cfb3441e0460200f30149b315' }
 'tests/application/test_gc.py' = { count = 8, digest = '2ef5cddb403f867124821c2cfde9df70896e2cd8d284c2e563b6455f0ad998d4' }
 'tests/application/test_integrity.py' = { count = 1, digest = 'c44a2cb51b7f5a90c106b4a59e9661551a47ae8d0a21df308387618b99e277aa' }


### PR DESCRIPTION
## Summary

Adds first-class local SGLang 0.5.16 inference benchmarking and stage-separated profiler capture. The implementation binds SGLang discovery to a declared Python launcher, preserves native JSONL and trace artifacts, and publishes only bounded scalar evidence.

## What changed

- Adds `sglang` inference-server and `sglang_bench` scenario configuration through TOML, CLI, and MCP.
- Builds the fixed `sglang.bench_serving` random-workload command with OpenAI-compatible chat/completions backend mapping and no detailed output.
- Validates one aggregate JSONL record through typed SGLang result and profiler-option contracts.
- Uses SGLang `/start_profile` and `/stop_profile` with fixed prefill/decode capture options, then feeds preserved traces through the existing Perfetto route.

## Validation

- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest -q tests/adapters/test_inference_artifacts.py tests/application/test_inference_configuration.py tests/application/test_inference_profiling.py tests/application/test_inference_providers.py tests/application/test_inference.py tests/analysis/test_inference_protocol.py`

The GPU integration lane requires an explicitly configured local tiny SGLang model, CUDA, Torch, and `sglang==0.5.16`; it was not available in this environment.