### PR TITLE
fix(inference): preserve provider schedule contracts

### DIFF
--- a/src/flameox/application/inference.py
+++ b/src/flameox/application/inference.py
@@ -327,7 +327,11 @@ class InferenceReplayService:
             semantic_oracle_workload=scenario.semantic_oracle_workload,
             random_input_len=scenario.random_input_len,
             random_output_len=scenario.random_output_len,
-            random_range_ratio=scenario.random_range_ratio,
+            random_range_ratio=(
+                scenario.random_range_ratio or 1.0
+                if scenario.provider == "sglang_bench"
+                else scenario.random_range_ratio
+            ),
             timeout_seconds=deadline,
             deadline_at=deadline_at,
             exploratory_reason=(
@@ -1041,6 +1045,7 @@ class InferenceReplayService:
             request_rate=scenario.request_rate,
             burstiness=scenario.burstiness,
             max_concurrency=scenario.concurrency,
+            warmup_request_count=scenario.warmup_request_count,
             seed=scenario.seed,
             result_path=output_path,
         )

--- a/src/flameox/application/inference_providers.py
+++ b/src/flameox/application/inference_providers.py
@@ -139,6 +139,7 @@ class VllmBenchServeRequest(ContractModel):
     request_rate: Annotated[float, Field(gt=0, le=1_000_000)] | None = None
     burstiness: Annotated[float, Field(gt=0, le=1_000_000)] | None = None
     max_concurrency: Annotated[int, Field(gt=0, le=100_000)] | None = None
+    warmup_request_count: Annotated[int, Field(ge=0, le=1_000_000)] = 0
     seed: Annotated[int, Field(ge=0, le=2**31 - 1)] = 0
 
     @field_validator("base_url")
@@ -183,6 +184,7 @@ class VllmBenchServeRequest(ContractModel):
             values.extend(("--burstiness", str(self.burstiness)))
         if self.max_concurrency is not None:
             values.extend(("--max-concurrency", str(self.max_concurrency)))
+        values.extend(("--num-warmups", str(self.warmup_request_count)))
         return tuple(values)
 
 
@@ -258,8 +260,7 @@ class SglangBenchServingRequest(ContractModel):
             values.extend(("--request-rate", str(self.request_rate)))
         if self.max_concurrency is not None:
             values.extend(("--max-concurrency", str(self.max_concurrency)))
-        if self.warmup_request_count:
-            values.extend(("--warmup-requests", str(self.warmup_request_count)))
+        values.extend(("--warmup-requests", str(self.warmup_request_count)))
         return tuple(values)
 
 

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -388,6 +388,14 @@ class InferenceScenarioConfig(ContractModel):
             raise ValueError("trace_artifact_id is only supported by the aiperf provider")
         if self.provider == "vllm_bench" and not self.streaming:
             raise ValueError("vllm_bench non-streaming response mode is unsupported in v1")
+        if self.provider != "aiperf" and self.speedup_ratio != 1.0:
+            raise ValueError("speedup_ratio is only supported by aiperf trace replays")
+        if (
+            self.provider == "aiperf"
+            and self.trace_artifact_id is None
+            and self.speedup_ratio != 1.0
+        ):
+            raise ValueError("speedup_ratio requires an aiperf trace_artifact_id")
         if self.provider == "sglang_bench":
             if not self.streaming:
                 raise ValueError("sglang_bench non-streaming response mode is unsupported in v1")

--- a/tests/application/test_inference.py
+++ b/tests/application/test_inference.py
@@ -179,7 +179,7 @@ def test_sglang_protocol_identity_binds_random_shape_and_provenance(
         'mode = "existing_local"\nbase_url = "http://127.0.0.1:8000"\nmodel = "model"\n'
         "[inference_scenarios.replay]\n"
         'server = "local"\nprovider = "sglang_bench"\n'
-        "random_input_len = 4\nrandom_output_len = 2\nrandom_range_ratio = 0.5\n"
+        "random_input_len = 4\nrandom_output_len = 2\n"
     )
     from flameox.application import inference as inference_module
     from flameox.application.inference_providers import ExistingServerProbe, InferenceToolDiscovery
@@ -209,6 +209,7 @@ def test_sglang_protocol_identity_binds_random_shape_and_provenance(
 
     assert identity.trace.producer == "sglang.bench_serving"
     assert identity.server.cache_backend == "custom"
+    assert plan.random_range_ratio == 1.0
     assert identity.trace.artifact_digest != reshaped_identity.trace.artifact_digest
 
 

--- a/tests/application/test_inference_configuration.py
+++ b/tests/application/test_inference_configuration.py
@@ -125,6 +125,32 @@ def test_sglang_scenario_rejects_dropped_burstiness() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("provider", "trace_artifact_id", "random_input_len", "random_output_len", "message"),
+    [
+        ("aiperf", None, None, None, "requires an aiperf trace_artifact_id"),
+        ("vllm_bench", None, None, None, "only supported by aiperf trace replays"),
+        ("sglang_bench", None, 4, 2, "only supported by aiperf trace replays"),
+    ],
+)
+def test_inference_scenario_rejects_speedup_when_provider_cannot_apply_it(
+    provider: str,
+    trace_artifact_id: str | None,
+    random_input_len: int | None,
+    random_output_len: int | None,
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        InferenceScenarioConfig(
+            server="local",
+            provider=provider,  # type: ignore[arg-type]
+            trace_artifact_id=trace_artifact_id,
+            random_input_len=random_input_len,
+            random_output_len=random_output_len,
+            speedup_ratio=2.0,
+        )
+
+
 def test_sglang_config_rejects_non_cuda_v1_escape_hatches() -> None:
     with pytest.raises(ValidationError, match="extra_forbidden"):
         InferenceServerConfig.model_validate(

--- a/tests/application/test_inference_providers.py
+++ b/tests/application/test_inference_providers.py
@@ -94,6 +94,7 @@ def test_vllm_bench_argv_requires_structured_result_file(tmp_path: Path) -> None
     assert request.argv()[request.argv().index("--endpoint") + 1] == "/v1/chat/completions"
     assert "--endpoint-type" not in request.argv()
     assert "--streaming" not in request.argv()
+    assert request.argv()[request.argv().index("--num-warmups") + 1] == "0"
 
 
 def test_vllm_bench_refuses_unsupported_non_streaming_mode(tmp_path: Path) -> None:
@@ -177,6 +178,7 @@ def test_sglang_bench_uses_fixed_module_random_workload_and_safe_output(tmp_path
     assert "sglang-oai-chat" in argv
     assert "--output-details" not in argv
     assert argv[argv.index("--output-file") + 1] == str(tmp_path / "result.jsonl")
+    assert argv[argv.index("--warmup-requests") + 1] == "0"
 
 
 def test_sglang_bench_rejects_base_url_paths(tmp_path: Path) -> None:

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 779
+expected_test_count = 782
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -69,7 +69,7 @@ expected_test_count = 779
 'tests/application/test_faults.py' = { count = 5, digest = '9330626143cdfb60660c3466aea29491ddce50d1cecd1e04fe4b4b7b11d2fe8a' }
 'tests/application/test_inference.py' = { count = 22, digest = '696d8052fed45f7eef19344604fd58aa7a7deb5c2d819038c5800fbebb111f88' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }
-'tests/application/test_inference_configuration.py' = { count = 15, digest = 'a42719a7942420c094474f5265f37d9b505e88cab3ad2ae13d918b5cec928ea8' }
+'tests/application/test_inference_configuration.py' = { count = 18, digest = '92011694e0d0b47b5d5fa817db7272ca323324ab849cecc8d4f77fbfa30397d8' }
 'tests/application/test_inference_profiling.py' = { count = 14, digest = 'a6e5535fe44590c12e8ef2b07ae8d4dad077a5c9f30c562826c34c03e097fb15' }
 'tests/application/test_inference_providers.py' = { count = 10, digest = 'fa30971121d0ac947c4f289d9efca31e1c650b2ab369aecc6f7980ce3c189a6f' }
 'tests/application/test_native_reducer_properties.py' = { count = 5, digest = '8b23a4c091126f78fd10281093021fafe36f426cfb3441e0460200f30149b315' }


### PR DESCRIPTION
## Problem

Inference scenarios could record schedule settings that a provider did not actually receive: `speedup_ratio` was accepted outside AIPerf trace replays, vLLM dropped warmup counts, SGLang let its one-request warmup default replace a configured zero, and an implicit SGLang random range ratio was not reflected in the plan identity.

## Change

Validate `speedup_ratio` only where AIPerf can apply it, emit explicit warmup values for vLLM and SGLang, and canonicalize SGLang's default random range ratio in the replay plan.

## Regression coverage

The added tests reject unsupported speed scaling, verify each provider argv carries the effective warmup value, and confirm the SGLang plan records its effective random range ratio.

## Validation

- `uv run pytest -q tests/application/test_inference_configuration.py tests/application/test_inference_providers.py tests/application/test_inference.py` — 50 passed
- `uv run ruff check src tests` — passed
- `uv run ruff format --check src tests tools` — passed
- `uv run mypy src tests` — passed
- `uv run python tools/test.py collection` — preserved 782 node IDs