### PR TITLE
feat(experiments): compare runtime resource metrics

### DIFF
--- a/docs/investigations.md
+++ b/docs/investigations.md
@@ -216,6 +216,18 @@ before confirmatory collection. Adaptive stopping is allowed only when its rule
 and statistical method are predeclared. Profiling and operator scans may select
 a candidate mechanism, but the confirmation experiment uses fresh measurements.
 
+Performance experiments may use the closed runtime-resource metric catalog:
+`runtime_resource.peak_rss_bytes`, `runtime_resource.minimum_free_bytes`, or
+`runtime_resource.staging_growth_bytes`. These resolve to bytes-valued
+resource-summary evidence rather than measurement-table rows. Flameox reuses
+the existing NumPy/SciPy paired-comparison path after reducing each realized
+block to one resource value. Comparisons require matching resource sampling
+intervals; peak RSS additionally requires the same non-null sampling backend.
+Missing or explicitly unavailable resource evidence leaves an incomplete pair,
+never a zero or imputed value. Writable-root growth is deliberately not a
+catalog metric because comparing it requires a compatible root-identity
+selector across runs.
+
 ### Validation oracle
 
 Performance evidence is not sufficient to establish semantic preservation.

--- a/docs/storage-and-evidence.md
+++ b/docs/storage-and-evidence.md
@@ -389,7 +389,11 @@ has a bounded `source` (`adapter`, `preflight`, `collector`, `artifact`,
 string field remains a deterministic, de-duplicated compatibility projection;
 older manifests containing only strings remain readable. Runtime resource
 summaries preserve sampling interval, minimum free bytes, staging growth, peak
-RSS, storage-policy termination, and explicitly unavailable metrics.
+RSS, its observation backend, storage-policy termination, and explicitly
+unavailable metrics. `peak_rss_backend = psutil_recursive_polling` means the
+reported value is the largest parent-plus-recursive-descendant RSS total seen
+by polling. It is an observed peak, not a guaranteed lifetime maximum: a
+short-lived descendant can exit between samples.
 
 Capture publication writes runtime-resource evidence into two dedicated tables:
 `runtime_resource_summaries` contains one bounded observation per terminal run,
@@ -400,6 +404,11 @@ short-lived process or a failed sampler publishes a nullable metric plus an
 explicit unavailable marker rather than silently substituting zero. Storage
 reserve termination is preserved in the summary and in the run's typed
 limitations.
+
+The evidence layer uses psutil for this bounded recursive collection and
+DuckDB/Parquet for schema-compatible reads. Added nullable summary fields are
+read as `NULL` from earlier Parquet evidence; prior generations are never
+rewritten merely to add a field.
 
 ### OTLP and process evidence
 

--- a/src/flameox/application/comparisons.py
+++ b/src/flameox/application/comparisons.py
@@ -40,6 +40,12 @@ from flameox.evidence import GenerationPublisher
 from flameox.models import ContractModel
 from flameox.storage import JsonRecordStore, RunStore, Workspace
 
+_RUNTIME_RESOURCE_COLUMNS = {
+    "runtime_resource.peak_rss_bytes": "peak_rss_bytes",
+    "runtime_resource.minimum_free_bytes": "minimum_free_bytes",
+    "runtime_resource.staging_growth_bytes": "staging_growth_bytes",
+}
+
 
 class FreezeRunSetMember(ContractModel):
     run_id: str
@@ -72,10 +78,20 @@ class CompareRunSetsRequest(ContractModel):
     experiment_id: str | None = None
     metric: str
     unit: str
+    metric_source: Literal["measurement", "runtime_resource"] = "measurement"
     polarity: Literal["lower_is_better", "higher_is_better", "neutral"]
     practical_threshold: float = Field(ge=0)
     confidence_level: float = Field(default=0.95, gt=0, lt=1)
     random_seed: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def validate_metric_source(self) -> CompareRunSetsRequest:
+        if self.metric_source == "runtime_resource":
+            if self.metric not in _RUNTIME_RESOURCE_COLUMNS:
+                raise ValueError("runtime-resource comparisons require a catalog metric")
+            if self.unit != "bytes":
+                raise ValueError("runtime-resource comparisons require unit='bytes'")
+        return self
 
 
 class ComparisonResult(ContractModel):
@@ -261,18 +277,22 @@ class ComparisonService:
             baseline_set,
             candidate_set,
         )
-        baseline = self._samples(
-            snapshot,
-            baseline_set,
-            request.metric,
-            request.unit,
-        )
-        candidate = self._samples(
-            snapshot,
-            candidate_set,
-            request.metric,
-            request.unit,
-        )
+        baseline = self._samples(snapshot, baseline_set, request)
+        candidate = self._samples(snapshot, candidate_set, request)
+        if request.metric_source == "runtime_resource":
+            invalidating.extend(
+                self._runtime_resource_compatibility_mismatches(
+                    snapshot, baseline_set, candidate_set, request.metric
+                )
+            )
+            if baseline.eligible != baseline.attempted - baseline.failed - baseline.excluded:
+                exploratory.append(
+                    "baseline runtime-resource evidence is unavailable or incomplete"
+                )
+            if candidate.eligible != candidate.attempted - candidate.failed - candidate.excluded:
+                exploratory.append(
+                    "candidate runtime-resource evidence is unavailable or incomplete"
+                )
         profile_changes = self._profile_changes(
             snapshot,
             baseline_set,
@@ -450,6 +470,16 @@ class ComparisonService:
         self,
         snapshot: Snapshot,
         run_set: RunSet,
+        request: CompareRunSetsRequest,
+    ) -> _SampleSet:
+        if request.metric_source == "runtime_resource":
+            return self._runtime_resource_samples(snapshot, run_set, request.metric)
+        return self._measurement_samples(snapshot, run_set, request.metric, request.unit)
+
+    def _measurement_samples(
+        self,
+        snapshot: Snapshot,
+        run_set: RunSet,
         metric: str,
         unit: str,
     ) -> _SampleSet:
@@ -537,6 +567,132 @@ class ComparisonService:
             failed=failed,
             excluded=excluded,
         )
+
+    def _runtime_resource_samples(
+        self,
+        snapshot: Snapshot,
+        run_set: RunSet,
+        metric: str,
+    ) -> _SampleSet:
+        column = _RUNTIME_RESOURCE_COLUMNS[metric]
+        values: dict[str, float] = {}
+        attempted = len(run_set.members)
+        failed = 0
+        excluded = 0
+        if len(run_set.members) > 1 and any(member.trial_id is None for member in run_set.members):
+            raise DomainError(
+                ErrorCode.COMPARISON_INVALID,
+                "Multi-run paired comparisons require explicit trial identities.",
+            )
+        for member in run_set.members:
+            if not member.included:
+                excluded += 1
+                continue
+            block_key = str(member.order)
+            if member.trial_id is not None:
+                trial_rows = snapshot.execute(
+                    "SELECT DISTINCT block_id, outcome FROM trials WHERE trial_id = ?",
+                    (member.trial_id,),
+                ).fetchall()
+                if len(trial_rows) != 1:
+                    raise DomainError(
+                        ErrorCode.COMPARISON_INVALID,
+                        "Run-set trial evidence is missing or ambiguous.",
+                        details={"trial_id": member.trial_id},
+                    )
+                block_id, outcome = trial_rows[0]
+                if str(outcome) != "succeeded":
+                    failed += 1
+                    continue
+                if block_id is None:
+                    raise DomainError(
+                        ErrorCode.COMPARISON_INVALID,
+                        "Paired experiment trials require block identities.",
+                        details={"trial_id": member.trial_id},
+                    )
+                block_key = str(block_id)
+            rows = snapshot.execute(
+                f"SELECT {column}, unavailable_metrics FROM runtime_resource_summaries "
+                "WHERE run_id = ?",
+                (member.run_id,),
+            ).fetchall()
+            if len(rows) > 1:
+                raise DomainError(
+                    ErrorCode.COMPARISON_INVALID,
+                    "Run has ambiguous runtime-resource summary evidence.",
+                    details={"run_id": member.run_id},
+                )
+            if not rows:
+                continue
+            value, unavailable_metrics = rows[0]
+            if value is None or metric.removeprefix("runtime_resource.") in set(
+                unavailable_metrics or []
+            ):
+                continue
+            if block_key in values:
+                raise DomainError(
+                    ErrorCode.COMPARISON_INVALID,
+                    "Run set contains more than one included trial for a block.",
+                    details={"block_id": block_key},
+                )
+            values[block_key] = float(value)
+        return _SampleSet(
+            values=values,
+            attempted=attempted,
+            eligible=len(values),
+            failed=failed,
+            excluded=excluded,
+        )
+
+    def _runtime_resource_compatibility_mismatches(
+        self,
+        snapshot: Snapshot,
+        baseline: RunSet,
+        candidate: RunSet,
+        metric: str,
+    ) -> list[str]:
+        reasons: list[str] = []
+        configurations: dict[str, set[tuple[object, ...]]] = {"baseline": set(), "candidate": set()}
+        for treatment, run_set in (("baseline", baseline), ("candidate", candidate)):
+            for member in run_set.members:
+                if not member.included:
+                    continue
+                if member.trial_id is not None:
+                    trial_rows = snapshot.execute(
+                        "SELECT DISTINCT outcome FROM trials WHERE trial_id = ?",
+                        (member.trial_id,),
+                    ).fetchall()
+                    if len(trial_rows) != 1 or str(trial_rows[0][0]) != "succeeded":
+                        continue
+                rows = snapshot.execute(
+                    "SELECT sampling_interval_ms, peak_rss_backend "
+                    "FROM runtime_resource_summaries WHERE run_id = ?",
+                    (member.run_id,),
+                ).fetchall()
+                if len(rows) != 1:
+                    continue
+                interval, backend = rows[0]
+                configuration = (
+                    (interval, backend) if metric.endswith("peak_rss_bytes") else (interval,)
+                )
+                configurations[treatment].add(configuration)
+        baseline_configs = configurations["baseline"]
+        candidate_configs = configurations["candidate"]
+        if (
+            len(baseline_configs) > 1
+            or len(candidate_configs) > 1
+            or baseline_configs != candidate_configs
+        ):
+            reasons.append(
+                "runtime-resource sampling interval or backend differs across treatments"
+            )
+        if metric.endswith("peak_rss_bytes") and (
+            not baseline_configs
+            or not candidate_configs
+            or any(config[1] is None for config in (*baseline_configs, *candidate_configs))
+        ):
+            reasons.append("peak RSS backend identity is unavailable")
+        return reasons
 
     def _compatibility_mismatches(
         self,

--- a/src/flameox/application/comparisons.py
+++ b/src/flameox/application/comparisons.py
@@ -127,6 +127,7 @@ class _SampleSet:
     eligible: int
     failed: int
     excluded: int
+    nonpositive: int = 0
 
 
 class RunSetService:
@@ -292,6 +293,11 @@ class ComparisonService:
             if candidate.eligible != candidate.attempted - candidate.failed - candidate.excluded:
                 exploratory.append(
                     "candidate runtime-resource evidence is unavailable or incomplete"
+                )
+            if baseline.nonpositive or candidate.nonpositive:
+                invalidating.append(
+                    "zero-valued runtime-resource evidence is incompatible with the "
+                    "median paired log-ratio estimand"
                 )
         profile_changes = self._profile_changes(
             snapshot,
@@ -579,6 +585,7 @@ class ComparisonService:
         attempted = len(run_set.members)
         failed = 0
         excluded = 0
+        nonpositive = 0
         if len(run_set.members) > 1 and any(member.trial_id is None for member in run_set.members):
             raise DomainError(
                 ErrorCode.COMPARISON_INVALID,
@@ -629,6 +636,9 @@ class ComparisonService:
                 unavailable_metrics or []
             ):
                 continue
+            if value <= 0:
+                nonpositive += 1
+                continue
             if block_key in values:
                 raise DomainError(
                     ErrorCode.COMPARISON_INVALID,
@@ -642,6 +652,7 @@ class ComparisonService:
             eligible=len(values),
             failed=failed,
             excluded=excluded,
+            nonpositive=nonpositive,
         )
 
     def _runtime_resource_compatibility_mismatches(
@@ -664,14 +675,22 @@ class ComparisonService:
                     ).fetchall()
                     if len(trial_rows) != 1 or str(trial_rows[0][0]) != "succeeded":
                         continue
+                column = _RUNTIME_RESOURCE_COLUMNS[metric]
                 rows = snapshot.execute(
-                    "SELECT sampling_interval_ms, peak_rss_backend "
+                    f"SELECT {column}, unavailable_metrics, sampling_interval_ms, "
+                    "peak_rss_backend "
                     "FROM runtime_resource_summaries WHERE run_id = ?",
                     (member.run_id,),
                 ).fetchall()
                 if len(rows) != 1:
                     continue
-                interval, backend = rows[0]
+                value, unavailable_metrics, interval, backend = rows[0]
+                if (
+                    value is None
+                    or value <= 0
+                    or metric.removeprefix("runtime_resource.") in set(unavailable_metrics or [])
+                ):
+                    continue
                 configuration = (
                     (interval, backend) if metric.endswith("peak_rss_bytes") else (interval,)
                 )

--- a/src/flameox/application/evidence_rows.py
+++ b/src/flameox/application/evidence_rows.py
@@ -128,6 +128,7 @@ def runtime_resource_summary_row(
         "minimum_free_bytes": resources.minimum_free_bytes if resources is not None else None,
         "staging_growth_bytes": resources.staging_growth_bytes if resources is not None else None,
         "peak_rss_bytes": resources.peak_rss_bytes if resources is not None else None,
+        "peak_rss_backend": resources.peak_rss_backend if resources is not None else None,
         "policy_termination": (resources.policy_termination if resources is not None else None),
         "unavailable_metrics": _normalized_unavailable_metrics(unavailable),
     }

--- a/src/flameox/application/experiments.py
+++ b/src/flameox/application/experiments.py
@@ -95,7 +95,7 @@ class ExperimentPlan(ContractModel):
     experiment_name: str
     experiment: Experiment
     adapter: str
-    metric_source: Literal["measurement", "runtime_resource"]
+    metric_source: Literal["measurement", "runtime_resource"] = "measurement"
     execution_policy: ExecutionPolicy
     variant_parameter: str
     variants: tuple[str, ...]

--- a/src/flameox/application/experiments.py
+++ b/src/flameox/application/experiments.py
@@ -95,6 +95,7 @@ class ExperimentPlan(ContractModel):
     experiment_name: str
     experiment: Experiment
     adapter: str
+    metric_source: Literal["measurement", "runtime_resource"]
     execution_policy: ExecutionPolicy
     variant_parameter: str
     variants: tuple[str, ...]
@@ -435,6 +436,11 @@ class ExperimentService:
             "name": experiment_name,
             "config": config.model_dump(mode="json"),
             "parameters": supplied_overrides,
+            "metric_source": (
+                "runtime_resource"
+                if config.primary_metric.startswith("runtime_resource.")
+                else "measurement"
+            ),
         }
         experiment = Experiment(
             experiment_id=new_id(),
@@ -537,6 +543,11 @@ class ExperimentService:
             experiment_name=experiment_name,
             experiment=experiment,
             adapter=adapter,
+            metric_source=(
+                "runtime_resource"
+                if config.primary_metric.startswith("runtime_resource.")
+                else "measurement"
+            ),
             execution_policy=execution_policy,
             variant_parameter=variant_parameter,
             variants=variants,
@@ -796,7 +807,7 @@ class ExperimentService:
             limitations.append(
                 "Automatic paired comparison currently requires exactly two variants."
             )
-        elif plan.adapter != "pyperf":
+        elif plan.metric_source == "measurement" and plan.adapter != "pyperf":
             limitations.append(
                 "Automatic experiment comparison currently requires pyperf measurements."
             )
@@ -808,7 +819,8 @@ class ExperimentService:
                         candidate_run_set_id=run_sets[1].run_set_id,
                         experiment_id=plan.experiment.experiment_id,
                         metric=plan.experiment.primary_metric,
-                        unit="ns",
+                        unit=("bytes" if plan.metric_source == "runtime_resource" else "ns"),
+                        metric_source=plan.metric_source,
                         polarity=plan.experiment.polarity,
                         practical_threshold=plan.experiment.practical_threshold,
                         confidence_level=plan.experiment.confidence_level,

--- a/src/flameox/application/faults.py
+++ b/src/flameox/application/faults.py
@@ -260,6 +260,11 @@ class FaultExperimentService:
             experiment_name=experiment_name,
             experiment=experiment,
             adapter="command",
+            metric_source=(
+                "runtime_resource"
+                if config.primary_metric.startswith("runtime_resource.")
+                else "measurement"
+            ),
             execution_policy=execution_policy,
             variant_parameter="scenario",
             variants=treatments,

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -38,6 +38,14 @@ from flameox.storage import Workspace
 
 Scalar = str | int | float | bool
 
+RUNTIME_RESOURCE_METRICS = frozenset(
+    {
+        "runtime_resource.peak_rss_bytes",
+        "runtime_resource.minimum_free_bytes",
+        "runtime_resource.staging_growth_bytes",
+    }
+)
+
 
 class WorkloadOracleConfig(ContractModel):
     strength: OracleStrength = OracleStrength.EXECUTION_CHECK
@@ -156,6 +164,14 @@ class ExperimentConfig(ContractModel):
 
     @model_validator(mode="after")
     def valid_design(self) -> ExperimentConfig:
+        if self.primary_metric.startswith("runtime_resource.") and (
+            self.primary_metric not in RUNTIME_RESOURCE_METRICS
+        ):
+            raise ValueError(
+                "runtime-resource primary_metric must be one of "
+                "runtime_resource.peak_rss_bytes, runtime_resource.minimum_free_bytes, "
+                "or runtime_resource.staging_growth_bytes"
+            )
         if self.factors:
             if self.variants or self.scaling_parameter is not None or self.scaling_values:
                 raise ValueError("factor experiments cannot use legacy variant or scaling fields")

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -639,6 +639,9 @@ class RuntimeResourceSummary(ContractModel):
     staging_growth_bytes: Annotated[int, Field(ge=0)] | None = None
     writable_root_growth_bytes: dict[str, Annotated[int, Field(ge=0)]] = Field(default_factory=dict)
     peak_rss_bytes: Annotated[int, Field(ge=0)] | None = None
+    # This identifies the observation method, not a guarantee of the process
+    # tree's lifetime maximum.
+    peak_rss_backend: str | None = None
     unavailable_metrics: tuple[str, ...] = ()
     policy_termination: Literal["storage_reserve_exceeded", "memory_limit_exceeded"] | None = None
 

--- a/src/flameox/evidence/schemas.py
+++ b/src/flameox/evidence/schemas.py
@@ -5,7 +5,7 @@ from typing import Any
 import pyarrow as pa
 
 SCHEMA_MAJOR = 1
-SCHEMA_MINOR = 7
+SCHEMA_MINOR = 8
 UTC_TIMESTAMP = pa.timestamp("us", tz="UTC")
 
 COMMON_FIELDS: tuple[Any, ...] = (
@@ -72,6 +72,7 @@ SCHEMAS: dict[str, pa.Schema] = {
             pa.field("minimum_free_bytes", pa.uint64()),
             pa.field("staging_growth_bytes", pa.uint64()),
             pa.field("peak_rss_bytes", pa.uint64()),
+            pa.field("peak_rss_backend", pa.string()),
             pa.field("policy_termination", pa.string()),
             pa.field("unavailable_metrics", pa.list_(pa.string()), nullable=False),
         ),

--- a/src/flameox/execution.py
+++ b/src/flameox/execution.py
@@ -1456,6 +1456,7 @@ class SubprocessBroker:
             staging_growth_bytes=staging_growth,
             writable_root_growth_bytes=growth,
             peak_rss_bytes=peak_rss or None,
+            peak_rss_backend=("psutil_recursive_polling" if peak_rss else None),
             unavailable_metrics=tuple(sorted(unavailable)),
             policy_termination=termination,
         )

--- a/tests/application/test_capture_lifecycle.py
+++ b/tests/application/test_capture_lifecycle.py
@@ -56,14 +56,15 @@ async def test_capture_plan_is_single_use_and_publishes_process_evidence(
     with Catalog(workspace).open_snapshot() as snapshot:
         resource_row = snapshot.execute(
             "SELECT run_id, sampling_interval_ms, minimum_free_bytes, "
-            "staging_growth_bytes, peak_rss_bytes, unavailable_metrics "
+            "staging_growth_bytes, peak_rss_bytes, peak_rss_backend, unavailable_metrics "
             "FROM runtime_resource_summaries WHERE run_id = ?",
             (result.run.run_id,),
         ).fetchone()
     assert resource_row is not None
     assert resource_row[0] == result.run.run_id
     assert resource_row[1] > 0
-    assert isinstance(resource_row[5], list)
+    assert resource_row[5] in {None, "psutil_recursive_polling"}
+    assert isinstance(resource_row[6], list)
     memory = RecipeService(workspace).memory(result.run.run_id)
     assert memory.runtime_resource_totals is not None
     assert memory.runtime_resource_totals.run_count == 1

--- a/tests/application/test_comparison_samples.py
+++ b/tests/application/test_comparison_samples.py
@@ -103,3 +103,71 @@ def test_comparison_pairs_distinct_measurement_keys_from_published_evidence(
     assert result.comparison.complete_pair_n == 4
     assert result.comparison.relative_change is not None
     assert result.comparison.relative_change < 0
+
+
+def test_comparison_pairs_runtime_resource_catalog_metric(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    baseline_id, candidate_id = _benchmark_pair(workspace, tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runtime_resource_summaries": [
+                {
+                    "run_id": baseline_id,
+                    "sampling_interval_ms": 100,
+                    "minimum_free_bytes": 1000,
+                    "staging_growth_bytes": 20,
+                    "peak_rss_bytes": 200,
+                    "peak_rss_backend": "psutil_recursive_polling",
+                    "policy_termination": None,
+                    "unavailable_metrics": [],
+                },
+                {
+                    "run_id": candidate_id,
+                    "sampling_interval_ms": 100,
+                    "minimum_free_bytes": 900,
+                    "staging_growth_bytes": 10,
+                    "peak_rss_bytes": 100,
+                    "peak_rss_backend": "psutil_recursive_polling",
+                    "policy_termination": None,
+                    "unavailable_metrics": [],
+                },
+            ]
+        },
+        publisher="comparison-resource-fixture",
+        publisher_version="1",
+        input_run_ids=(baseline_id, candidate_id),
+    )
+    run_sets = RunSetService(workspace)
+    baseline = run_sets.freeze(FreezeRunSetRequest(run_ids=(baseline_id,)))
+    candidate = run_sets.freeze(FreezeRunSetRequest(run_ids=(candidate_id,)))
+
+    result = ComparisonService(workspace).compare(
+        CompareRunSetsRequest(
+            baseline_run_set_id=baseline.run_set_id,
+            candidate_run_set_id=candidate.run_set_id,
+            metric="runtime_resource.peak_rss_bytes",
+            metric_source="runtime_resource",
+            unit="bytes",
+            polarity="lower_is_better",
+            practical_threshold=0.05,
+        )
+    )
+
+    assert result.comparison.baseline_value_float == 200
+    assert result.comparison.candidate_value_float == 100
+    assert result.comparison.complete_pair_n == 1
+
+
+def test_runtime_resource_comparison_rejects_wrong_unit() -> None:
+    with pytest.raises(ValueError, match="unit='bytes'"):
+        CompareRunSetsRequest(
+            baseline_run_set_id="baseline",
+            candidate_run_set_id="candidate",
+            metric="runtime_resource.peak_rss_bytes",
+            metric_source="runtime_resource",
+            unit="ns",
+            polarity="lower_is_better",
+            practical_threshold=0,
+        )

--- a/tests/application/test_comparison_samples.py
+++ b/tests/application/test_comparison_samples.py
@@ -11,7 +11,7 @@ from flameox.application import (
     RunSetService,
 )
 from flameox.catalog import Catalog
-from flameox.domain import DomainError, ErrorCode
+from flameox.domain import ComparisonValidity, DomainError, ErrorCode
 from flameox.evidence import GenerationPublisher
 from flameox.storage import Workspace
 from tests.support.comparisons import imported_benchmark, measurement_row
@@ -171,3 +171,56 @@ def test_runtime_resource_comparison_rejects_wrong_unit() -> None:
             polarity="lower_is_better",
             practical_threshold=0,
         )
+
+
+def test_runtime_resource_zero_is_invalid_for_log_ratio_estimation(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    baseline_id, candidate_id = _benchmark_pair(workspace, tmp_path)
+    GenerationPublisher(workspace).publish_rows(
+        {
+            "runtime_resource_summaries": [
+                {
+                    "run_id": baseline_id,
+                    "sampling_interval_ms": 100,
+                    "minimum_free_bytes": 1,
+                    "staging_growth_bytes": 10,
+                    "peak_rss_bytes": 100,
+                    "peak_rss_backend": "psutil_recursive_polling",
+                    "policy_termination": None,
+                    "unavailable_metrics": [],
+                },
+                {
+                    "run_id": candidate_id,
+                    "sampling_interval_ms": 100,
+                    "minimum_free_bytes": 1,
+                    "staging_growth_bytes": 0,
+                    "peak_rss_bytes": 100,
+                    "peak_rss_backend": "psutil_recursive_polling",
+                    "policy_termination": None,
+                    "unavailable_metrics": [],
+                },
+            ]
+        },
+        publisher="comparison-resource-fixture",
+        publisher_version="1",
+        input_run_ids=(baseline_id, candidate_id),
+    )
+    run_sets = RunSetService(workspace)
+    baseline = run_sets.freeze(FreezeRunSetRequest(run_ids=(baseline_id,)))
+    candidate = run_sets.freeze(FreezeRunSetRequest(run_ids=(candidate_id,)))
+
+    result = ComparisonService(workspace).compare(
+        CompareRunSetsRequest(
+            baseline_run_set_id=baseline.run_set_id,
+            candidate_run_set_id=candidate.run_set_id,
+            metric="runtime_resource.staging_growth_bytes",
+            metric_source="runtime_resource",
+            unit="bytes",
+            polarity="lower_is_better",
+            practical_threshold=0,
+        )
+    )
+
+    assert result.comparison.validity is ComparisonValidity.INVALID
+    assert result.comparison.candidate_eligible_n == 0
+    assert any("zero-valued" in reason for reason in result.comparison.mismatches)

--- a/tests/application/test_experiments.py
+++ b/tests/application/test_experiments.py
@@ -10,6 +10,7 @@ from flameox.analysis import RecipeService
 from flameox.application import (
     CreateInvestigationRequest,
     ExecutionPolicy,
+    ExperimentConfig,
     ExperimentService,
     InvestigationService,
 )
@@ -33,6 +34,33 @@ def _git(project: Path, *args: str) -> None:
         capture_output=True,
         text=True,
     )
+
+
+@pytest.mark.parametrize(
+    "metric",
+    (
+        "runtime_resource.peak_rss_bytes",
+        "runtime_resource.minimum_free_bytes",
+        "runtime_resource.staging_growth_bytes",
+    ),
+)
+def test_experiment_config_accepts_closed_runtime_resource_catalog(metric: str) -> None:
+    config = ExperimentConfig(
+        workload="scan",
+        variants=("baseline", "candidate"),
+        primary_metric=metric,
+    )
+
+    assert config.primary_metric == metric
+
+
+def test_experiment_config_rejects_writable_root_growth_metric() -> None:
+    with pytest.raises(ValueError, match="runtime-resource primary_metric"):
+        ExperimentConfig(
+            workload="scan",
+            variants=("baseline", "candidate"),
+            primary_metric="runtime_resource.writable_root_growth_bytes",
+        )
 
 
 @pytest.mark.anyio
@@ -138,6 +166,60 @@ implementation = ["baseline", "candidate"]
     assert [item[0] for item in progress] == list(range(7))
     assert {item[1] for item in progress} == {6}
     assert all(item[2] for item in progress)
+
+
+@pytest.mark.anyio
+async def test_runtime_resource_primary_metric_runs_paired_comparison(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    (tmp_path / "bench.py").write_text("assert sum(range(1000)) >= 0\n")
+    (tmp_path / "flameox.toml").write_text(
+        """
+schema_version = 1
+[workloads.scan]
+argv = ["python", "bench.py"]
+cwd = "."
+[workloads.scan.parameters]
+implementation = ["baseline", "candidate"]
+[workloads.scan.oracle]
+strength = "cross_treatment_equivalence"
+argv = ["python", "-c", "print('same-output')"]
+[experiments.resources]
+workload = "scan"
+treatment_factor = "implementation"
+blocks = 1
+primary_metric = "runtime_resource.peak_rss_bytes"
+polarity = "lower_is_better"
+[experiments.resources.factors]
+implementation = ["baseline", "candidate"]
+"""
+    )
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "bench.py", "flameox.toml")
+    _git(
+        tmp_path,
+        "-c",
+        "user.name=flameox Test",
+        "-c",
+        "user.email=flameox@example.invalid",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+    investigation = InvestigationService(workspace).create(
+        CreateInvestigationRequest(question="Does resource use differ?")
+    )
+    service = ExperimentService(workspace)
+    plan = await service.plan(
+        experiment_name="resources",
+        investigation_id=investigation.investigation_id,
+        adapter="command",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    result = await service.run(plan.plan_id)
+
+    assert result.comparison is not None
+    assert result.comparison.comparison.metric == "runtime_resource.peak_rss_bytes"
 
 
 @pytest.mark.anyio

--- a/tests/application/test_experiments.py
+++ b/tests/application/test_experiments.py
@@ -11,6 +11,7 @@ from flameox.application import (
     CreateInvestigationRequest,
     ExecutionPolicy,
     ExperimentConfig,
+    ExperimentPlan,
     ExperimentService,
     InvestigationService,
 )
@@ -61,6 +62,10 @@ def test_experiment_config_rejects_writable_root_growth_metric() -> None:
             variants=("baseline", "candidate"),
             primary_metric="runtime_resource.writable_root_growth_bytes",
         )
+
+
+def test_experiment_plan_defaults_metric_source_for_persisted_plans() -> None:
+    assert ExperimentPlan.model_fields["metric_source"].default == "measurement"
 
 
 @pytest.mark.anyio

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 782
+expected_test_count = 789
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -59,13 +59,13 @@ expected_test_count = 782
 'tests/application/test_async_work.py' = { count = 1, digest = '5c21ab9d048e8676c0b086ff6859e87b28da82ab793c2b70de975f592355067e' }
 'tests/application/test_capabilities.py' = { count = 20, digest = '15279d4414beca5438e376ff2f787b3e9fe916d8242de0b35d3580de4cc24069' }
 'tests/application/test_capture_native_outputs.py' = { count = 5, digest = '73ffb01416e94a3044feeecb6f11f1fb452f0b1595ecc8b3ac3ef4f749918f77' }
-'tests/application/test_comparison_samples.py' = { count = 2, digest = 'a65cec9530be08e51029fe8f5d283b6ef5f2fc2c7285f82eb224ee6be93fc914' }
+'tests/application/test_comparison_samples.py' = { count = 4, digest = 'b8991dad3746e42fe7373453660787de0302aa144b4f3184a97966cf1c026f4f' }
 'tests/application/test_detached.py' = { count = 9, digest = '4e14dd7f799b1dcbc3eddf8d6ab45af470f9287e769ee03346698aeb78477365' }
 'tests/application/test_discovery.py' = { count = 2, digest = '154e2545ae8110e6e72d19cd62a1734779f7bf2f6b14180f57ea2852365e8fd2' }
 'tests/application/test_environment_identity.py' = { count = 10, digest = '22a3e3a5af0f747fcf9a680ba01e2d05dab7362ed5ac558d774e788826fb62c6' }
 'tests/application/test_evidence_query.py' = { count = 2, digest = '9773c3030eed6d98646628197d0aa81bb7fcfefe6bc75c72a294cf1dac0a77dd' }
 'tests/application/test_evidence_scope.py' = { count = 2, digest = 'e3e51e28f67c6512e3943f88f469d937f88d5f7f88317a34868640e55b9f590b' }
-'tests/application/test_experiments.py' = { count = 11, digest = 'ef1d24a47a9ed83b4e069315bdf7057f7e2028ef840bcbd22b662d1442dae3ad' }
+'tests/application/test_experiments.py' = { count = 16, digest = 'ebaf81b100f66145dc9870b7b387f2d2b637c4c7a6e67f0fb62c4a26b815b462' }
 'tests/application/test_faults.py' = { count = 5, digest = '9330626143cdfb60660c3466aea29491ddce50d1cecd1e04fe4b4b7b11d2fe8a' }
 'tests/application/test_inference.py' = { count = 22, digest = '696d8052fed45f7eef19344604fd58aa7a7deb5c2d819038c5800fbebb111f88' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }

--- a/tests/execution/test_broker.py
+++ b/tests/execution/test_broker.py
@@ -778,6 +778,7 @@ async def test_resource_policy_records_descendant_rss_disk_floor_and_root_growth
     assert resources.minimum_free_bytes is not None
     assert resources.peak_rss_bytes is not None
     assert resources.peak_rss_bytes > 0
+    assert resources.peak_rss_backend == "psutil_recursive_polling"
     assert resources.writable_root_growth_bytes[str(output)] == 4096
     assert resources.policy_termination is None
     assert outcome.process.peak_rss_bytes == resources.peak_rss_bytes
@@ -840,6 +841,7 @@ async def test_resource_policy_marks_short_process_samples_unavailable(
     assert resources is not None
     assert resources.minimum_free_bytes is None
     assert resources.peak_rss_bytes is None
+    assert resources.peak_rss_backend is None
     assert set(resources.unavailable_metrics) >= {
         "minimum_free_bytes",
         "peak_rss_bytes",


### PR DESCRIPTION
## Summary

Adds a closed runtime-resource metric catalog for paired performance experiments. Runtime resource metrics now reuse the existing run-set pairing and NumPy/SciPy comparison path instead of requiring pyperf measurements.

The change also persists the RSS sampling backend, treats unavailable resource evidence as incomplete pairs, and invalidates comparisons with incompatible sampling intervals or RSS backends.

Closes #116.

## Scope

- Supports `runtime_resource.peak_rss_bytes`, `runtime_resource.minimum_free_bytes`, and `runtime_resource.staging_growth_bytes` with fixed `bytes` units.
- Keeps the existing psutil recursive polling collection contract and records `psutil_recursive_polling` provenance when RSS is observed.
- Leaves writable-root growth outside the scalar catalog because it needs cross-run root-identity selection. The broader admission contract for future resource metrics/backends is tracked in #124.

## Validation

- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest tests/execution/test_broker.py tests/application/test_capture_lifecycle.py tests/application/test_comparison_samples.py tests/application/test_experiments.py tests/evidence/test_publication_and_catalog.py -q`
- Structured autoreview of the complete local diff (no actionable findings)

## Compatibility

Existing measurement comparisons retain `metric_source = "measurement"` by default. The evidence schema minor version advances with a nullable backend field, so historical Parquet resource-summary rows remain readable as `NULL`.

## Suggested review order

1. `src/flameox/application/comparisons.py`
2. Evidence model/schema/publication changes
3. Experiment planning and automatic comparison changes
4. Tests and documentation