### PR TITLE
Harden runtime lifecycle recovery and extract MCP resources

### DIFF
--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import mimetypes
 import os
 import secrets
@@ -237,8 +238,6 @@ class _CaptureExecution:
             try:
                 self.run = await asyncio.shield(lease_write)
             except Exception as lease_error:
-                import logging
-
                 logging.getLogger("flameox.capture").warning(
                     "Lease write after cancellation raised: %s",
                     lease_error,
@@ -247,6 +246,31 @@ class _CaptureExecution:
 
     async def record_cleanup(self, complete: bool) -> None:
         self.cleanup_complete = complete
+
+    async def terminate_cancelled(
+        self,
+        *,
+        message: str,
+        phase: str,
+        cleanup_complete: bool | None = None,
+    ) -> None:
+        """Persist cancellation without allowing finalization failures to mask it."""
+
+        try:
+            await asyncio.shield(
+                self.terminate(
+                    execution=ExecutionStatus.CANCELLED,
+                    message=message,
+                    phase=phase,
+                    error_code="cancelled",
+                    cleanup_complete=cleanup_complete,
+                )
+            )
+        except Exception as terminate_error:
+            logging.getLogger("flameox.capture").warning(
+                "Cleanup after cancellation raised: %s",
+                terminate_error,
+            )
 
     async def terminate(
         self,
@@ -374,8 +398,6 @@ class _CaptureExecution:
                 error_code=error_code,
             )
         except Exception as terminate_error:
-            import logging
-
             self.cleanup_staging()
             logging.getLogger("flameox.capture").warning(
                 "Finalizing a startup identity failure raised: %s",
@@ -833,24 +855,12 @@ class CaptureService:
                 dynamic_parameters=plan.dynamic_parameters,
             )
             await capture.report(3, "Source and environment identity collected")
-        except asyncio.CancelledError as cancellation:
-            try:
-                await asyncio.shield(
-                    capture.terminate(
-                        execution=ExecutionStatus.CANCELLED,
-                        message="Capture cancelled while collecting source identity.",
-                        phase="capture cancelled during source identity",
-                        error_code="cancelled",
-                    )
-                )
-            except Exception as terminate_error:
-                import logging
-
-                logging.getLogger("flameox.capture").warning(
-                    "Cleanup after cancellation raised: %s",
-                    terminate_error,
-                )
-            raise cancellation
+        except asyncio.CancelledError:
+            await capture.terminate_cancelled(
+                message="Capture cancelled while collecting source identity.",
+                phase="capture cancelled during source identity",
+            )
+            raise
         except DomainError as error:
             terminal = await capture.terminate_startup_failure(
                 message=error.message,
@@ -936,24 +946,12 @@ class CaptureService:
             )
             StorageQuota(self.workspace).require_capacity(staging=True)
             await capture.report(5, "Collector execution complete")
-        except asyncio.CancelledError as cancellation:
-            try:
-                await asyncio.shield(
-                    capture.terminate(
-                        execution=ExecutionStatus.CANCELLED,
-                        message="Capture cancelled by caller after bounded cleanup.",
-                        phase="capture cancelled during collector execution",
-                        error_code="cancelled",
-                    )
-                )
-            except Exception as terminate_error:
-                import logging
-
-                logging.getLogger("flameox.capture").warning(
-                    "Cleanup after cancellation raised: %s",
-                    terminate_error,
-                )
-            raise cancellation
+        except asyncio.CancelledError:
+            await capture.terminate_cancelled(
+                message="Capture cancelled by caller after bounded cleanup.",
+                phase="capture cancelled during collector execution",
+            )
+            raise
         except DomainError as error:
             status = (
                 ExecutionStatus.TIMED_OUT
@@ -1572,24 +1570,12 @@ class CaptureService:
                     }
                 )
             await capture.report(7, "Artifacts registered")
-        except asyncio.CancelledError as cancellation:
-            try:
-                await asyncio.shield(
-                    capture.terminate(
-                        execution=ExecutionStatus.CANCELLED,
-                        message=("Capture cancelled during validation or artifact registration."),
-                        phase="capture cancelled during validation or registration",
-                        error_code="cancelled",
-                    )
-                )
-            except Exception as terminate_error:
-                import logging
-
-                logging.getLogger("flameox.capture").warning(
-                    "Cleanup after cancellation raised: %s",
-                    terminate_error,
-                )
-            raise cancellation
+        except asyncio.CancelledError:
+            await capture.terminate_cancelled(
+                message="Capture cancelled during validation or artifact registration.",
+                phase="capture cancelled during validation or registration",
+            )
+            raise
         except DomainError as error:
             quarantined = await run_atomic_thread(
                 lambda: self._quarantine_native_output(
@@ -1766,25 +1752,13 @@ class CaptureService:
                     ),
                 )
             )
-        except asyncio.CancelledError as cancellation:
-            try:
-                await asyncio.shield(
-                    capture.terminate(
-                        execution=ExecutionStatus.CANCELLED,
-                        message="Capture cancelled during atomic evidence publication.",
-                        phase="capture cancelled during evidence publication",
-                        error_code="cancelled",
-                        cleanup_complete=True,
-                    )
-                )
-            except Exception as terminate_error:
-                import logging
-
-                logging.getLogger("flameox.capture").warning(
-                    "Cleanup after cancellation raised: %s",
-                    terminate_error,
-                )
-            raise cancellation
+        except asyncio.CancelledError:
+            await capture.terminate_cancelled(
+                message="Capture cancelled during atomic evidence publication.",
+                phase="capture cancelled during evidence publication",
+                cleanup_complete=True,
+            )
+            raise
         except Exception as error:
             message = (
                 error.message

--- a/src/flameox/application/recovery.py
+++ b/src/flameox/application/recovery.py
@@ -9,6 +9,7 @@ from flameox.application.run_rows import run_row
 from flameox.domain import (
     CaptureStatus,
     DomainError,
+    ErrorCode,
     ExecutionStatus,
     ProcessResult,
     RunManifest,
@@ -107,7 +108,11 @@ class RecoveryService:
                     ),
                 }
             )
-            recovered.append(self.runs.append(terminal, expected_revision=current.revision))
+            try:
+                recovered.append(self.runs.append(terminal, expected_revision=current.revision))
+            except DomainError as error:
+                if error.code is not ErrorCode.REVISION_CONFLICT:
+                    raise
         if recovered:
             self.publisher.publish_rows(
                 {"runs": [run_row(run) for run in recovered]},

--- a/src/flameox/execution.py
+++ b/src/flameox/execution.py
@@ -1769,6 +1769,8 @@ class ManagedSidecarLease:
         output_budget: _OutputBudget,
         observations: list[ProcessObservation],
         started_at: datetime,
+        *,
+        supports_toxiproxy_control: bool = False,
     ) -> None:
         self._broker = broker
         self._process = process
@@ -1780,6 +1782,7 @@ class ManagedSidecarLease:
         self._output_budget = output_budget
         self._observations = observations
         self._started_at = started_at
+        self._supports_toxiproxy_control = supports_toxiproxy_control
         self._tracked_proxies: set[str] = set()
         self._closed = False
         self._outcome: ManagedSidecarOutcome | None = None
@@ -1867,6 +1870,7 @@ class ManagedSidecarLease:
             output_budget,
             observations,
             datetime.now(UTC),
+            supports_toxiproxy_control=True,
         )
         deadline = time.monotonic() + readiness_timeout_seconds
         try:
@@ -2044,6 +2048,7 @@ class ManagedSidecarLease:
     def create_proxy(
         self, *, name: str, listen: str, upstream: str, enabled: bool = True
     ) -> dict[str, Any]:
+        self._require_toxiproxy_control()
         self._ensure_open()
         from flameox.adapters.toxiproxy import ToxiproxyClient
 
@@ -2054,6 +2059,7 @@ class ManagedSidecarLease:
         return result
 
     def update_proxy(self, name: str, *, enabled: bool) -> dict[str, Any]:
+        self._require_toxiproxy_control()
         self._ensure_open()
         from flameox.adapters.toxiproxy import ToxiproxyClient
 
@@ -2061,6 +2067,7 @@ class ManagedSidecarLease:
         return ToxiproxyClient(self.base_url).update_proxy(name, enabled=enabled)
 
     def add_toxic(self, **kwargs: Any) -> dict[str, Any]:
+        self._require_toxiproxy_control()
         self._ensure_open()
         from flameox.adapters.toxiproxy import ToxiproxyClient
 
@@ -2082,19 +2089,20 @@ class ManagedSidecarLease:
         if self._outcome is not None:
             return self._outcome
         self._closed = True
-        from flameox.adapters.toxiproxy import ToxiproxyApiError, ToxiproxyClient
-
         cleanup_failures: list[str] = []
         if self._output_budget.exceeded:
             cleanup_failures.append(
                 "sidecar output exceeded the bounded capture budget; excess bytes were discarded"
             )
-        client = ToxiproxyClient(self.base_url, timeout_seconds=1.0)
-        for name in tuple(sorted(self._tracked_proxies)):
-            try:
-                await asyncio.to_thread(client.delete_proxy, name)
-            except (ToxiproxyApiError, OSError) as error:
-                cleanup_failures.append(f"proxy {name}: {error}")
+        if self._supports_toxiproxy_control:
+            from flameox.adapters.toxiproxy import ToxiproxyApiError, ToxiproxyClient
+
+            client = ToxiproxyClient(self.base_url, timeout_seconds=1.0)
+            for name in tuple(sorted(self._tracked_proxies)):
+                try:
+                    await asyncio.to_thread(client.delete_proxy, name)
+                except (ToxiproxyApiError, OSError) as error:
+                    cleanup_failures.append(f"proxy {name}: {error}")
         request = ExecutionRequest(
             argv=(str(self._executable),),
             cwd=self._executable.parent,
@@ -2148,6 +2156,13 @@ class ManagedSidecarLease:
     def _ensure_open(self) -> None:
         if self._closed:
             raise DomainError(ErrorCode.EXECUTION_REFUSED, "The Toxiproxy sidecar lease is closed.")
+
+    def _require_toxiproxy_control(self) -> None:
+        if not self._supports_toxiproxy_control:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "This managed sidecar does not expose Toxiproxy controls.",
+            )
 
     def _require_tracked(self, name: str) -> None:
         if name not in self._tracked_proxies:

--- a/src/flameox/mcp/resources.py
+++ b/src/flameox/mcp/resources.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, Literal, cast
+
+from mcp.server import MCPServer
+
+from flameox.application import (
+    ArtifactService,
+    EvidenceLookupService,
+    ExperimentService,
+    FindingService,
+    InvestigationService,
+    RunSetService,
+)
+from flameox.domain import DomainError, ErrorCode
+from flameox.storage import RunStore, Workspace
+
+
+def register_resources(  # noqa: C901
+    server: MCPServer[Any],
+    workspace: Callable[[], Workspace],
+) -> None:
+    """Register resource projections independently from the MCP tool transport."""
+
+    def error_payload(error: DomainError) -> str:
+        return json.dumps({"ok": False, "error": error.to_detail()})
+
+    @server.resource(
+        "flameox://runs/{run_id}",
+        mime_type="application/json",
+        description="Bounded run manifest projection.",
+    )
+    async def run_resource(run_id: str) -> str:
+        try:
+            return RunStore(workspace()).read(run_id).model_dump_json(indent=2)
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://artifacts/{artifact_id}",
+        mime_type="application/json",
+        description="Artifact metadata without binary content.",
+    )
+    async def artifact_resource(artifact_id: str) -> str:
+        try:
+            return ArtifactService(workspace()).get(artifact_id).model_dump_json(indent=2)
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://investigations/{investigation_id}",
+        mime_type="application/json",
+        description="Current investigation projection.",
+    )
+    async def investigation_resource(investigation_id: str) -> str:
+        try:
+            return (
+                InvestigationService(workspace())
+                .investigations.read(investigation_id)
+                .model_dump_json(indent=2)
+            )
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://hypotheses/{hypothesis_id}",
+        mime_type="application/json",
+        description="Current hypothesis revision.",
+    )
+    async def hypothesis_resource(hypothesis_id: str) -> str:
+        try:
+            return (
+                InvestigationService(workspace())
+                .hypotheses.read(hypothesis_id)
+                .model_dump_json(indent=2)
+            )
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://findings/{finding_id}",
+        mime_type="application/json",
+        description="Current finding revision.",
+    )
+    async def finding_resource(finding_id: str) -> str:
+        try:
+            return FindingService(workspace()).findings.read(finding_id).model_dump_json(indent=2)
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://experiments/{experiment_id}",
+        mime_type="application/json",
+        description="Immutable experiment protocol.",
+    )
+    async def experiment_resource(experiment_id: str) -> str:
+        try:
+            return (
+                ExperimentService(workspace())
+                .experiments.read(experiment_id)
+                .model_dump_json(indent=2)
+            )
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://experiments/{experiment_id}/trials",
+        mime_type="application/json",
+        description="Bounded immutable trial collection for an experiment.",
+    )
+    async def experiment_trials_resource(experiment_id: str) -> str:
+        try:
+            return (
+                ExperimentService(workspace()).list_trials(experiment_id).model_dump_json(indent=2)
+            )
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://experiments/{experiment_id}/trials/{trial_id}",
+        mime_type="application/json",
+        description="One immutable trial and its structured oracle receipt.",
+    )
+    async def experiment_trial_resource(experiment_id: str, trial_id: str) -> str:
+        try:
+            return (
+                ExperimentService(workspace())
+                .get_trial(trial_id, experiment_id=experiment_id)
+                .model_dump_json(indent=2)
+            )
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://run-sets/{run_set_id}",
+        mime_type="application/json",
+        description="Immutable frozen run cohort.",
+    )
+    async def run_set_resource(run_set_id: str) -> str:
+        try:
+            return RunSetService(workspace()).store.read(run_set_id).model_dump_json(indent=2)
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://evidence/{ref_type}/{ref_id}",
+        mime_type="application/json",
+        description="Authoritative persisted analysis or comparison evidence.",
+    )
+    async def evidence_resource(ref_type: str, ref_id: str) -> str:
+        try:
+            if ref_type not in {"analysis", "comparison"}:
+                raise DomainError(
+                    ErrorCode.WORKSPACE_INVALID,
+                    f"Unsupported evidence resource type {ref_type!r}.",
+                )
+            return (
+                EvidenceLookupService(workspace())
+                .get(cast(Literal["analysis", "comparison"], ref_type), ref_id)
+                .model_dump_json(indent=2)
+            )
+        except DomainError as error:
+            return error_payload(error)

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import json
 import tempfile
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal
 
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
@@ -170,6 +169,7 @@ from flameox.domain import (
     Sensitivity,
     TrialOutcome,
 )
+from flameox.mcp.resources import register_resources
 from flameox.models import ContractModel
 from flameox.storage import RunStore, Workspace
 
@@ -3258,152 +3258,10 @@ def create_server(
         except DomainError as error:
             return _failure(error)
 
-    @server.resource(
-        "flameox://runs/{run_id}",
-        mime_type="application/json",
-        description="Bounded run manifest projection.",
+    register_resources(
+        server,
+        lambda: _active_state(lifespan_state).require_workspace(),
     )
-    async def run_resource(run_id: str) -> str:
-        try:
-            if not lifespan_state:
-                raise DomainError(
-                    ErrorCode.WORKSPACE_NOT_FOUND,
-                    "The MCP server lifespan is not active.",
-                )
-            run = RunStore(lifespan_state[0].require_workspace()).read(run_id)
-            return run.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://artifacts/{artifact_id}",
-        mime_type="application/json",
-        description="Artifact metadata without binary content.",
-    )
-    async def artifact_resource(artifact_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = ArtifactService(state.require_workspace()).get(artifact_id)
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://investigations/{investigation_id}",
-        mime_type="application/json",
-        description="Current investigation projection.",
-    )
-    async def investigation_resource(investigation_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = InvestigationService(state.require_workspace()).investigations.read(
-                investigation_id
-            )
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://hypotheses/{hypothesis_id}",
-        mime_type="application/json",
-        description="Current hypothesis revision.",
-    )
-    async def hypothesis_resource(hypothesis_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = InvestigationService(state.require_workspace()).hypotheses.read(hypothesis_id)
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://findings/{finding_id}",
-        mime_type="application/json",
-        description="Current finding revision.",
-    )
-    async def finding_resource(finding_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = FindingService(state.require_workspace()).findings.read(finding_id)
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://experiments/{experiment_id}",
-        mime_type="application/json",
-        description="Immutable experiment protocol.",
-    )
-    async def experiment_resource(experiment_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = ExperimentService(state.require_workspace()).experiments.read(experiment_id)
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://experiments/{experiment_id}/trials",
-        mime_type="application/json",
-        description="Bounded immutable trial collection for an experiment.",
-    )
-    async def experiment_trials_resource(experiment_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = ExperimentService(state.require_workspace()).list_trials(experiment_id)
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://experiments/{experiment_id}/trials/{trial_id}",
-        mime_type="application/json",
-        description="One immutable trial and its structured oracle receipt.",
-    )
-    async def experiment_trial_resource(experiment_id: str, trial_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = ExperimentService(state.require_workspace()).get_trial(
-                trial_id,
-                experiment_id=experiment_id,
-            )
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://run-sets/{run_set_id}",
-        mime_type="application/json",
-        description="Immutable frozen run cohort.",
-    )
-    async def run_set_resource(run_set_id: str) -> str:
-        try:
-            state = _active_state(lifespan_state)
-            value = RunSetService(state.require_workspace()).store.read(run_set_id)
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
-
-    @server.resource(
-        "flameox://evidence/{ref_type}/{ref_id}",
-        mime_type="application/json",
-        description="Authoritative persisted analysis or comparison evidence.",
-    )
-    async def evidence_resource(ref_type: str, ref_id: str) -> str:
-        try:
-            if ref_type not in {"analysis", "comparison"}:
-                raise DomainError(
-                    ErrorCode.WORKSPACE_INVALID,
-                    f"Unsupported evidence resource type {ref_type!r}.",
-                )
-            state = _active_state(lifespan_state)
-            value = EvidenceLookupService(state.require_workspace()).get(
-                cast(Literal["analysis", "comparison"], ref_type),
-                ref_id,
-            )
-            return value.model_dump_json(indent=2)
-        except DomainError as error:
-            return json.dumps({"ok": False, "error": error.to_detail()})
 
     return server
 

--- a/tests/application/test_recovery.py
+++ b/tests/application/test_recovery.py
@@ -111,6 +111,45 @@ def test_recovery_closes_only_disappeared_exact_process_lease(tmp_path: Path) ->
     assert excluded.total_clusters == 0
 
 
+def test_recovery_skips_a_run_that_changes_after_inspection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    run = _running_run(
+        run_id="raced-run",
+        boot_id="wrong-boot",
+        start_identity="never-existed",
+    )
+    RunStore(workspace).create(run)
+    service = RecoveryService(workspace)
+    append = service.runs.append
+    raced = False
+
+    def append_after_concurrent_update(
+        manifest: RunManifest,
+        *,
+        expected_revision: int,
+    ) -> RunManifest:
+        nonlocal raced
+        if not raced:
+            raced = True
+            current = service.runs.read(manifest.run_id)
+            append(
+                current.model_copy(update={"revision": current.revision + 1}),
+                expected_revision=current.revision,
+            )
+        return append(manifest, expected_revision=expected_revision)
+
+    monkeypatch.setattr(service.runs, "append", append_after_concurrent_update)
+
+    result = service.recover()
+
+    assert result.recovered_runs == ()
+    assert result.inspection.recoverable_run_ids == ("raced-run",)
+    assert service.runs.read("raced-run").revision == 1
+
+
 def test_recovery_keeps_live_lease_when_process_name_contains_spaces(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 791
+expected_test_count = 792
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -80,7 +80,7 @@ expected_test_count = 791
 'tests/application/test_proc_stat_parsing.py' = { count = 8, digest = '304f574ce49f342fccbecae8ef16ea8aa0e55003d4a9b654c875a381d9092183' }
 'tests/application/test_python_evidence_capture.py' = { count = 4, digest = 'a74791e80211abb9630845a3fd76a324c20124278f4df80140158f8c1495d03d' }
 'tests/application/test_records_and_comparisons.py' = { count = 8, digest = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759' }
-'tests/application/test_recovery.py' = { count = 5, digest = 'd14450b75df01af16d43f3fc9142017ef24a064e2bcc6df60de74398c9289d63' }
+'tests/application/test_recovery.py' = { count = 6, digest = 'e211760dfee242452e83a04084a6f127eac1da1da29cfadc878c66e714e37e2b' }
 'tests/application/test_reductions.py' = { count = 6, digest = 'c67f91c01c948556e2b38604b4c4bd633618807a8aa38df357699dc1633c119c' }
 'tests/application/test_repair.py' = { count = 11, digest = '9a54b35c41c9d52684439f454a14d15bfd56a31dba7c06f07df0e67b01b433dc' }
 'tests/application/test_setup.py' = { count = 19, digest = '4ca5627f631a69bde5ecca086bc2ce4daa71fd2d90f5e2723d9ec40fa1b2201a' }

--- a/tests/execution/test_broker.py
+++ b/tests/execution/test_broker.py
@@ -80,6 +80,13 @@ async def test_managed_inference_lease_uses_absolute_readiness_deadline(
         readiness=readiness,
         absolute_deadline=time.monotonic() + 2,
     )
+    with pytest.raises(DomainError) as error:
+        lease.create_proxy(
+            name="wrong-sidecar",
+            listen="127.0.0.1:8124",
+            upstream="127.0.0.1:8125",
+        )
+    assert error.value.code is ErrorCode.EXECUTION_REFUSED
     outcome = await lease.close()
 
     assert ready_calls == 2


### PR DESCRIPTION
This tightens two high-churn boundaries without changing the public MCP resource contract.

The runtime changes consolidate cancellation finalization, let recovery skip stale optimistic revisions instead of aborting the batch, and refuse Toxiproxy controls on inference sidecar leases. The MCP refactor moves resource registration out of the server factory while the factory continues to own lifespan and workspace activation.

Validation:
- `uv run pytest -q` — 635 passed, 157 deselected
- `FLAMEOX_RUN_PERFORMANCE=1 uv run pytest -q -m performance` — 4 passed
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src tests`
- MCP contract/workflow/agent tests — 27 passed

Suggested review order:
1. `fix(runtime): harden cancellation and recovery`
2. `refactor(mcp): extract resource registrations`

No compatibility changes are intended.