### PR TITLE
docs: require changelog-ready pull request titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,10 @@
+<!--
+PR title: type(optional-scope): imperative outcome
+Example: fix(storage): preserve comparison evidence
+
+The squash-merge commit and generated changelog use the PR title.
+-->
+
 ## Description
 
 <!-- What problem does this PR solve? Link related issues. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,10 @@ feat(adapters): add bounded provider readiness probe
 docs: explain comparison compatibility
 ```
 
+Pull request titles follow the same `type(optional-scope): imperative outcome`
+format. GitHub uses the title as the squash-merge commit subject, and `git-cliff`
+uses that subject to place and describe the change in the generated changelog.
+
 Open the pull request against `main` and complete the pull request template.
 Explain the concrete problem, the chosen approach, and why it fits flameox's
 architecture. Link related issues and list only commands that actually ran.


### PR DESCRIPTION
## Description

Flameox squash-merges pull requests, so the pull request title becomes the commit subject consumed by `git-cliff`. The contribution guide previously required Conventional Commit subjects without stating that pull request titles carry the same changelog contract.

## Approach

Document the `type(optional-scope): imperative outcome` format in `CONTRIBUTING.md`, including why it matters. Add the same guidance as an HTML comment at the top of the pull request template so authors see it while creating a pull request.

This intentionally adds no Git hook or title-validation workflow. The convention is discoverable before submission without adding another required check.

## Commands run

```console
git diff --check origin/main...HEAD
```

## Compatibility

Documentation and contribution workflow only. No runtime, protocol, storage, or platform behavior changes.