### PR TITLE
docs: align public descriptions and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,15 +217,19 @@ argv = ["python", "validate.py", "--implementation", "{implementation}"]
 
 [experiments.scan_comparison]
 workload = "scan"
-variants = ["baseline", "candidate"]
 design = "randomized_complete_blocks"
 blocks = 10
+treatment_factor = "implementation"
+combination_policy = "cartesian"
 primary_metric = "pyperf.workload"
 polarity = "lower_is_better"
 estimand = "median_paired_log_ratio"
 practical_threshold = 0.05
 confidence_level = 0.95
 random_seed = 1984
+
+[experiments.scan_comparison.factors]
+implementation = ["baseline", "candidate"]
 ```
 
 An agent can create this declaration directly through MCP with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "flameox"
 version = "0.1.12"
-description = "Local runtime evidence CLI and MCP server for coding agents"
+description = "Runtime evidence that helps agents trace, profile, and burn down hotspots in application and native code, GPU kernels, and inference stacks."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.morluto/flameox",
   "title": "Flameox",
-  "description": "Local runtime evidence for coding-agent performance and reliability investigations",
+  "description": "Runtime evidence that helps agents trace, profile, and burn down hotspots in application and native code, GPU kernels, and inference stacks.",
   "websiteUrl": "https://github.com/morluto/flameox",
   "repository": {
     "url": "https://github.com/morluto/flameox",


### PR DESCRIPTION
## Description

The README hero and GitHub repository description already use an outcome-focused explanation of Flameox, while the PyPI and MCP Registry metadata used separate, less concrete summaries. The README's primary experiment example also presented the legacy `variants` shape even though current configurations should use an explicit treatment factor and factor map.

## Approach

Use the existing repository description verbatim for the PyPI and MCP Registry summaries:

> Runtime evidence that helps agents trace, profile, and burn down hotspots in application and native code, GPU kernels, and inference stacks.

Update the named-workload example to declare `treatment_factor = "implementation"`, Cartesian combination policy, and an `experiments.scan_comparison.factors` table. Legacy variant configurations remain readable; the README now teaches the preferred shape.

## Commands run

```console
uv run pytest -q tests/application/test_workloads.py
# 23 passed

uv lock --check
jq empty server.json
git diff --check
```

The complete README TOML example was also parsed through `ProjectConfig` and resolved to the current factor experiment variant.

## Compatibility

Documentation and package/registry metadata only. No runtime, protocol, storage, or platform behavior changes. Legacy experiment variants remain supported for existing schema-v1 configuration.