### PR TITLE
feat(adapters): add GPU correctness evidence

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -375,6 +375,58 @@ the graph-trace table as the graph-launch source. The fixture is hardware- and
 timestamp-specific, so the test asserts event classes and identity coverage,
 not exact timestamps.
 
+#### `flameox.kernel-validation.v1`
+
+Producer-neutral kernel-correctness evidence is imported as strict JSON conforming to the
+`flameox.kernel-validation.v1` schema. The published JSON Schema lives at
+`src/flameox/schemas/kernel-validation-v1.schema.json` and is generated from the same Pydantic
+model used for validation. The artifact kind is `validation_output`; import does not require a
+GPU, CUDA, or a kernel runner.
+
+The contract binds producer and reference identity, bounded case inputs, seed and device,
+declared metrics and tolerances, output and case outcomes, up to eight representative failures,
+and coverage limitations. Supported metrics are `max_abs_error`, `max_rel_error`, `mse`, `rmse`,
+`psnr`, and `cosine_similarity`. Lower-is-better metrics require `<=`; higher-is-better metrics
+require `>=`. Metric, output, case, and aggregate statuses are checked for consistency. Passing
+the document requires complete coverage; non-finite values and incomplete coverage without a
+limitation are rejected.
+
+Extraction publishes additive schema-minor-9 tables `kernel_validation_cases` and
+`kernel_validation_metrics`. Native JSON remains authoritative, extracted tables are rebuildable,
+and repeated extraction reuses the existing generation. Fixtures are project-owned synthetic JSON
+documents generated in `tests/adapters/test_kernel_validation.py` under the project MIT license.
+
+Observed claims are the declared case outcomes, metric values and thresholds, coverage flag, and
+representative failure coordinates. Aggregate statuses are derived. The extractor makes no inferred
+correctness claim beyond the declared metrics, tolerances, and coverage.
+
+#### `compute-sanitizer`
+
+The maintained adapter runs NVIDIA Compute Sanitizer around a declared workload and preserves its
+XML report as `sanitizer_report`. It supports the official `memcheck`, `racecheck`, `initcheck`, and
+`synccheck` tools and fixes output to `--xml --save <path>`. Strict options cover launch skip/count,
+target-process scope and bounded filter, kernel name, demangling, a distinct finding exit code, and
+an optional project-relative suppression file whose SHA-256 digest enters capture-plan identity.
+Suppression files must be regular, non-linked, project-contained files; arbitrary flags are refused.
+
+Compatibility family `compute-sanitizer.xml.2026.v1` was observed with Compute Sanitizer 2026.2.1.
+NVIDIA does not publish a stable XML XSD, so extraction is version-bounded and unknown record shapes
+or tags become limitations. XML parsing runs in an isolated bounded worker using `defusedxml`, caps
+host stacks at 64 frames, and normalizes source paths. A configured finding exit plus parsed records
+is a completed failed validation, while other nonzero exits, missing or malformed reports, and
+timeouts remain failed attempts with preserved partial evidence.
+
+Linux and Windows are supported; GPU access and a CUDA toolkit installation are required and are
+not provisioned by Flameox. Overhead depends on the selected sanitizer tool and input. A clean report
+covers only the selected tool, launches, processes, and filters and does not prove numerical
+correctness.
+
+The live fixture `tests/fixtures/compute_sanitizer/kernel_probe.cu` is project-owned MIT-licensed
+CUDA C++. The optional live test compiles it with `nvcc -lineinfo` and checks both in-bounds and
+out-of-bounds captures. Deterministic tests use synthetic XML and cover clean, memory, API,
+sanitizer, malformed, truncated, unknown, and oversized reports. Observed claims come from XML;
+classification and path normalization are deterministic derivations; no root cause is inferred.
+
 ### Candidate adapters
 
 - GDB/LLDB and elfutils for core metadata, with user init files, autoload, and

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -404,7 +404,7 @@ The supported tools are grouped as follows:
 | Family | Tools |
 | --- | --- |
 | Workspace | `initialize_workspace`, `workspace_status`, `workload_configuration_status`, `configure_workload`, `list_capabilities`, `start_capability_setup`, `get_capability_setup`, `cancel_capability_setup`, `prepare_adapter`, `prepare_workload_dependencies`, `validate_workspace` |
-| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_benchmark_samples`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_nsight_systems`, `extract_observations` |
+| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_benchmark_samples`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_nsight_systems`, `extract_kernel_validation`, `extract_compute_sanitizer`, `extract_observations` |
 | Detached capture | `start_detached_capture`, `get_detached_capture`, `cancel_detached_capture` |
 | Discovery | `list_declared_workflows`, `get_declared_workflow`, `list_runs`, `list_findings` |
 | Investigations | `create_investigation`, `list_investigations`, `get_investigation`, `record_hypothesis`, `get_hypothesis` |
@@ -821,6 +821,7 @@ flameox://experiments/{experiment_id}
 flameox://experiments/{experiment_id}/trials
 flameox://experiments/{experiment_id}/trials/{trial_id}
 flameox://run-sets/{run_set_id}
+flameox://schemas/kernel-validation/v1
 ```
 
 Resources return JSON or text summaries. Large native artifacts are represented

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
+    "defusedxml>=0.7.1,<0.8",
     "anyio>=4.9,<5",
     "duckdb>=1.5.4,<1.6",
     "ijson>=3.4,<4",
@@ -86,6 +87,7 @@ packages = ["src/flameox"]
 addopts = "-ra --strict-config --strict-markers --durations=10 -p no:randomly -m 'not performance and not optional and not process'"
 testpaths = ["tests"]
 markers = [
+    "requires_compute_sanitizer: requires NVIDIA Compute Sanitizer and a compatible GPU",
     "unit: deterministic tests for one semantic owner",
     "integration: tests crossing two or more Flameox services",
     "process: tests that spawn, transport to, or cancel another process",

--- a/src/flameox/adapters/__init__.py
+++ b/src/flameox/adapters/__init__.py
@@ -8,11 +8,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from flameox.adapters.benchmark_samples import *  # noqa: F403
     from flameox.adapters.client_setup import *  # noqa: F403
+    from flameox.adapters.compute_sanitizer import *  # noqa: F403
     from flameox.adapters.coverage import *  # noqa: F403
     from flameox.adapters.inference import *  # noqa: F403
+    from flameox.adapters.kernel_validation import *  # noqa: F403
     from flameox.adapters.memray import *  # noqa: F403
     from flameox.adapters.nsight_systems import *  # noqa: F403
     from flameox.adapters.observations import *  # noqa: F403
+    from flameox.adapters.options import *  # noqa: F403
     from flameox.adapters.perfetto import *  # noqa: F403
     from flameox.adapters.pyperf import *  # noqa: F403
     from flameox.adapters.pytest import *  # noqa: F403
@@ -26,11 +29,14 @@ if TYPE_CHECKING:
 _MODULES = (
     "benchmark_samples",
     "client_setup",
+    "compute_sanitizer",
     "coverage",
     "inference",
+    "kernel_validation",
     "memray",
     "nsight_systems",
     "observations",
+    "options",
     "perfetto",
     "pyperf",
     "pytest",
@@ -56,10 +62,16 @@ __all__ = [
     "ClientConfigEdit",
     "ClientConfigRegistry",
     "ClientPlanAction",
+    "ComputeSanitizerExtractionResult",
+    "ComputeSanitizerExtractor",
+    "ComputeSanitizerOptions",
     "CoverageExtractionResult",
     "CoverageExtractor",
     "InferenceArtifactExtractor",
     "InferenceExtractionResult",
+    "KernelValidationExtractionResult",
+    "KernelValidationExtractor",
+    "KernelValidationV1",
     "Launcher",
     "ManagedRuntime",
     "MemrayExtractionResult",
@@ -98,6 +110,7 @@ __all__ = [
     "VllmResultDocument",
     "VllmResultParser",
     "WholeEntrypointTorchProfilerOptions",
+    "bind_adapter_options",
     "install_trace_processor",
 ]
 

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from flameox.adapters.options import (
+    adapter_accepts_options,
+    compute_sanitizer_options,
+    compute_sanitizer_suppression_path,
+)
 from flameox.adapters.torch_profiler import SdkTorchProfilerOptions, torch_profiler_options
 from flameox.domain import ArtifactKind, DomainError, ErrorCode
 
@@ -225,6 +230,27 @@ BUILTIN_ADAPTERS = {
             ),
         ),
         BuiltinAdapter(
+            name="compute-sanitizer",
+            dependency_kind="executable",
+            dependency="compute-sanitizer",
+            supported_modes=("memcheck", "racecheck", "initcheck", "synccheck"),
+            supported_formats=("compute-sanitizer-xml",),
+            features=("memory_safety", "race_detection", "initialization", "synchronization"),
+            remediation=(
+                "Install NVIDIA Compute Sanitizer from the CUDA toolkit and verify GPU access.",
+            ),
+            version_args=("--version",),
+            supported_platforms=("linux", "windows"),
+            output_filename="compute-sanitizer.xml",
+            artifact_kinds=(ArtifactKind.SANITIZER_REPORT,),
+            expected_overhead="GPU instrumentation overhead; exact cost depends on sanitizer tool.",
+            capture_limitations=(
+                "A clean report covers only the selected tool, launches, processes, and filters.",
+                "Compute Sanitizer XML has no published stable XSD; extraction is version-bounded.",
+            ),
+            preserve_artifact_on_nonzero=True,
+        ),
+        BuiltinAdapter(
             name="coverage",
             dependency_kind="package",
             dependency="coverage",
@@ -254,6 +280,7 @@ def build_capture_invocation(
     executable: str | None,
     timeout_seconds: float = 300,
     options: dict[str, object] | None = None,
+    project_root: Path | None = None,
 ) -> CaptureInvocation:
     adapter = BUILTIN_ADAPTERS.get(adapter_name)
     if (
@@ -266,7 +293,7 @@ def build_capture_invocation(
             ErrorCode.CAPABILITY_UNAVAILABLE,
             f"Adapter {adapter_name!r} does not support capture planning.",
         )
-    if options and adapter_name != "torch.profiler":
+    if options and not adapter_accepts_options(adapter_name):
         raise DomainError(
             ErrorCode.INVALID_CAPTURE_PLAN,
             f"Adapter {adapter_name!r} does not accept capture options.",
@@ -326,6 +353,15 @@ def build_capture_invocation(
             output,
             options=options,
         )
+    elif adapter_name == "compute-sanitizer":
+        return _compute_sanitizer_capture_invocation(
+            adapter,
+            workload_argv,
+            output,
+            executable=executable,
+            options=options,
+            project_root=project_root,
+        )
     elif adapter_name == "pyperf":
         python, _ = _python_target(workload_argv)
         argv = (
@@ -383,6 +419,68 @@ def build_capture_invocation(
         limitations=limitations,
         environment=environment,
     )
+
+
+def _compute_sanitizer_capture_invocation(
+    adapter: BuiltinAdapter,
+    workload_argv: tuple[str, ...],
+    output: str,
+    *,
+    executable: str | None,
+    options: dict[str, object] | None,
+    project_root: Path | None,
+) -> CaptureInvocation:
+    selected = compute_sanitizer_options(options)
+    argv_parts: list[str] = [
+        _require_executable(adapter.name, executable),
+        "--tool",
+        selected.tool,
+        "--xml",
+        "--save",
+        output,
+        "--error-exitcode",
+        str(selected.finding_exit_code),
+        "--launch-skip",
+        str(selected.launch_skip),
+        "--launch-count",
+        str(selected.launch_count),
+        "--target-processes",
+        selected.target_processes,
+        "--demangle",
+        selected.demangle,
+    ]
+    if selected.target_processes_filter is not None:
+        argv_parts.extend(("--target-processes-filter", selected.target_processes_filter))
+    if selected.kernel_name is not None:
+        argv_parts.extend(("--kernel-name", selected.kernel_name))
+    suppression = compute_sanitizer_suppression_path(
+        selected,
+        project_root=project_root or Path.cwd(),
+    )
+    if suppression is not None:
+        argv_parts.extend(("--suppressions", str(suppression)))
+    return CaptureInvocation(
+        argv=(*argv_parts, *workload_argv),
+        artifact_kinds=adapter.artifact_kinds,
+        expected_overhead=adapter.expected_overhead or "",
+        limitations=adapter.capture_limitations,
+        environment={},
+    )
+
+
+def replace_compute_sanitizer_suppression(
+    argv: tuple[str, ...],
+    staged_path: Path,
+) -> tuple[str, ...]:
+    """Point a planned Compute Sanitizer invocation at its verified staged input."""
+    indexes = [index for index, value in enumerate(argv[:-1]) if value == "--suppressions"]
+    if len(indexes) != 1:
+        raise DomainError(
+            ErrorCode.INTERNAL_ERROR,
+            "Planned Compute Sanitizer suppression argument is missing or ambiguous.",
+        )
+    index = indexes[0] + 1
+    return (*argv[:index], str(staged_path), *argv[index + 1 :])
 
 
 def _torch_capture_invocation(

--- a/src/flameox/adapters/compute_sanitizer.py
+++ b/src/flameox/adapters/compute_sanitizer.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from flameox.application.artifact_workers import ArtifactWorker
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, digest_model
+from flameox.evidence import GenerationPublisher
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+
+class ComputeSanitizerExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    producer_version: str | None
+    status: Literal["clean", "findings", "inconclusive"]
+    finding_count: int
+    classifications: dict[str, int]
+    schema_fingerprint: str
+    corpus_commit_id: str
+    limitations: tuple[str, ...]
+
+
+class ComputeSanitizerInspection(ContractModel):
+    records: tuple[dict[str, Any], ...]
+    classifications: dict[str, int]
+    limitations: tuple[str, ...]
+
+
+def inspect_compute_sanitizer_report(
+    workspace: Workspace,
+    artifact_path: str,
+    *,
+    max_records: int,
+    max_frames: int = 64,
+) -> ComputeSanitizerInspection:
+    response = ArtifactWorker(workspace).run_sync(
+        "flameox.workers.compute_sanitizer",
+        {
+            "artifact_path": artifact_path,
+            "project_root": str(workspace.project_root),
+            "max_records": max_records,
+            "max_frames": max_frames,
+        },
+        name="Compute Sanitizer",
+        timeout_seconds=120,
+    )
+    records = response.get("records")
+    classifications = response.get("classifications")
+    raw_limitations = response.get("limitations")
+    if (
+        not isinstance(records, list)
+        or any(not isinstance(item, dict) for item in records)
+        or not isinstance(classifications, dict)
+        or any(
+            not isinstance(key, str) or isinstance(value, bool) or not isinstance(value, int)
+            for key, value in classifications.items()
+        )
+        or not isinstance(raw_limitations, list)
+        or any(not isinstance(item, str) for item in raw_limitations)
+    ):
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            "Compute Sanitizer worker returned an invalid normalized result.",
+        )
+    limitations = list(raw_limitations)
+    if any(record.get("classification") == "unknown" for record in records):
+        limitations.append("One or more Compute Sanitizer record shapes were not classified.")
+    return ComputeSanitizerInspection(
+        records=tuple(records),
+        classifications={str(key): int(value) for key, value in classifications.items()},
+        limitations=tuple(dict.fromkeys(limitations)),
+    )
+
+
+class ComputeSanitizerExtractor:
+    name = "compute-sanitizer.xml"
+    version = "1"
+    compatibility_family = "compute-sanitizer.xml.2026.v1"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.publisher = GenerationPublisher(workspace)
+
+    def extract(self, run_id: str) -> ComputeSanitizerExtractionResult:
+        run = RunStore(self.workspace).read(run_id)
+        registrations = tuple(
+            item for item in run.artifacts if item.kind is ArtifactKind.SANITIZER_REPORT
+        )
+        if len(registrations) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one Compute Sanitizer XML report.",
+                run_id=run_id,
+            )
+        registration = registrations[0]
+        if registration.producer not in {"compute-sanitizer", "flameox.import"}:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The sanitizer report is not registered as Compute Sanitizer output.",
+                run_id=run_id,
+            )
+        artifact = ArtifactStore(self.workspace).get(registration.artifact_id)
+        maximum = self.workspace.config.storage.max_rows_per_generation
+        if maximum < 2:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "Compute Sanitizer extraction requires room for provenance and findings.",
+            )
+        inspection = inspect_compute_sanitizer_report(
+            self.workspace,
+            str(artifact.payload_path),
+            max_records=maximum - 1,
+        )
+        records = inspection.records
+        classifications = inspection.classifications
+        limitations = list(inspection.limitations)
+        schema_fingerprint = digest_model(
+            {
+                "compatibility_family": self.compatibility_family,
+                "producer_version": registration.producer_version,
+                "record_kinds": sorted(
+                    {str(item.get("kind")) for item in records if item.get("kind") is not None}
+                ),
+                "classifications": sorted(classifications),
+            }
+        )
+        rows = [
+            self._finding_row(
+                run_id,
+                registration.artifact_id,
+                index,
+                record,
+            )
+            for index, record in enumerate(records)
+        ]
+        rows.append(
+            {
+                "observation_id": digest_model(
+                    {
+                        "artifact_id": registration.artifact_id,
+                        "kind": "sanitizer.extraction",
+                        "schema_fingerprint": schema_fingerprint,
+                    }
+                ),
+                "run_id": run_id,
+                "artifact_id": registration.artifact_id,
+                "kind": "sanitizer.extraction",
+                "name": self.compatibility_family,
+                "value_json": _json(
+                    {
+                        "classifications": classifications,
+                        "finding_count": len(records),
+                        "producer_version": registration.producer_version,
+                        "schema_fingerprint": schema_fingerprint,
+                    }
+                ),
+                "file": None,
+                "line_from": None,
+                "line_to": None,
+                "context": "extractor_provenance",
+                "evidence_level": "observed",
+            }
+        )
+        published = self.publisher.publish_rows_idempotent(
+            {"observations": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=(registration.artifact_id,),
+            operation_identity={
+                "compatibility_family": self.compatibility_family,
+                "max_records": maximum - 1,
+                "max_frames": 64,
+                "producer_version": registration.producer_version,
+                "schema_fingerprint": schema_fingerprint,
+            },
+        )
+        inconclusive = bool(limitations) and not records
+        return ComputeSanitizerExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            producer_version=registration.producer_version,
+            status=("findings" if records else "inconclusive" if inconclusive else "clean"),
+            finding_count=len(records),
+            classifications={str(key): int(value) for key, value in classifications.items()},
+            schema_fingerprint=schema_fingerprint,
+            corpus_commit_id=published.commit.commit_id,
+            limitations=tuple(dict.fromkeys(limitations)),
+        )
+
+    @staticmethod
+    def _finding_row(
+        run_id: str,
+        artifact_id: str,
+        index: int,
+        record: dict[str, Any],
+    ) -> dict[str, object]:
+        path = record.get("path")
+        line = record.get("line")
+        return {
+            "observation_id": digest_model(
+                {
+                    "artifact_id": artifact_id,
+                    "record_index": index,
+                    "record": record,
+                }
+            ),
+            "run_id": run_id,
+            "artifact_id": artifact_id,
+            "kind": "sanitizer.finding",
+            "name": str(record.get("classification", "unknown")),
+            "value_json": _json(record),
+            "file": path if isinstance(path, str) else None,
+            "line_from": line if isinstance(line, int) else None,
+            "line_to": line if isinstance(line, int) else None,
+            "context": record.get("function") if isinstance(record.get("function"), str) else None,
+            "evidence_level": "observed",
+        }
+
+
+def _json(value: object) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )

--- a/src/flameox/adapters/kernel_validation.py
+++ b/src/flameox/adapters/kernel_validation.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import (
+    Field,
+    JsonValue,
+    StringConstraints,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, digest_model
+from flameox.evidence import GenerationPublisher
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+ValidationStatus = Literal["pass", "fail", "inconclusive", "unsupported"]
+MetricName = Literal[
+    "max_abs_error",
+    "max_rel_error",
+    "mse",
+    "rmse",
+    "psnr",
+    "cosine_similarity",
+]
+Comparator = Literal["<=", ">="]
+BoundedName = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=200, pattern=r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$"),
+]
+_DimensionValue = str | int | float | bool
+Int64 = Annotated[int, Field(ge=-(2**63), le=2**63 - 1)]
+
+_MAX_KERNEL_VALIDATION_BYTES = 64 * 1024 * 1024
+
+_LOWER_IS_BETTER = {"max_abs_error", "max_rel_error", "mse", "rmse"}
+_HIGHER_IS_BETTER = {"psnr", "cosine_similarity"}
+
+
+def _require_finite(value: float | None, field: str) -> None:
+    if value is not None and not math.isfinite(value):
+        raise ValueError(f"{field} must be finite")
+
+
+class KernelValidationReference(ContractModel):
+    name: BoundedName
+    version: Annotated[str, StringConstraints(max_length=200)] | None = None
+    identity: Annotated[str, StringConstraints(min_length=1, max_length=500)]
+
+
+class KernelValidationInput(ContractModel):
+    dtype: Annotated[str, StringConstraints(min_length=1, max_length=100)]
+    shape: Annotated[tuple[Int64, ...], Field(max_length=16)]
+    role: Annotated[str, StringConstraints(max_length=100)] | None = None
+
+    @field_validator("shape")
+    @classmethod
+    def nonnegative_shape(cls, value: tuple[int, ...]) -> tuple[int, ...]:
+        if any(item < 0 for item in value):
+            raise ValueError("input shape dimensions must be nonnegative")
+        return value
+
+
+class KernelValidationMetric(ContractModel):
+    name: MetricName
+    value: float | None
+    comparator: Comparator | None
+    threshold: float | None
+    unit: Annotated[str, StringConstraints(min_length=1, max_length=100)]
+    status: ValidationStatus
+    limitation: Annotated[str, StringConstraints(max_length=500)] | None = None
+
+    @model_validator(mode="after")
+    def coherent_result(self) -> KernelValidationMetric:
+        _require_finite(self.value, "metric value")
+        _require_finite(self.threshold, "metric threshold")
+        expected = "<=" if self.name in _LOWER_IS_BETTER else ">="
+        if self.status == "unsupported":
+            if self.limitation is None:
+                raise ValueError("unsupported metrics require a limitation")
+            return self
+        if self.value is None or self.threshold is None or self.comparator is None:
+            raise ValueError("supported metrics require value, comparator, and threshold")
+        if self.comparator != expected:
+            raise ValueError(f"{self.name} requires comparator {expected}")
+        passed = (
+            self.value <= self.threshold
+            if self.comparator == "<="
+            else self.value >= self.threshold
+        )
+        expected_status: ValidationStatus = "pass" if passed else "fail"
+        if self.status != expected_status:
+            raise ValueError("metric status contradicts its value and threshold")
+        return self
+
+
+class KernelValidationFailure(ContractModel):
+    coordinates: Annotated[tuple[int, ...], Field(max_length=16)] = ()
+    expected: float | None = None
+    actual: float | None = None
+    absolute_error: float | None = None
+    relative_error: float | None = None
+    detail: Annotated[str, StringConstraints(max_length=500)] | None = None
+
+    @model_validator(mode="after")
+    def finite_values(self) -> KernelValidationFailure:
+        for name in ("expected", "actual", "absolute_error", "relative_error"):
+            _require_finite(getattr(self, name), name)
+        return self
+
+
+class KernelValidationOutput(ContractModel):
+    name: BoundedName
+    dtype: Annotated[str, StringConstraints(min_length=1, max_length=100)]
+    shape: Annotated[tuple[Int64, ...], Field(max_length=16)]
+    status: ValidationStatus
+    metrics: Annotated[tuple[KernelValidationMetric, ...], Field(max_length=16)] = ()
+    representative_failures: Annotated[
+        tuple[KernelValidationFailure, ...], Field(max_length=8)
+    ] = ()
+    limitations: Annotated[tuple[str, ...], Field(max_length=20)] = ()
+
+    @field_validator("shape")
+    @classmethod
+    def nonnegative_shape(cls, value: tuple[int, ...]) -> tuple[int, ...]:
+        if any(item < 0 for item in value):
+            raise ValueError("output shape dimensions must be nonnegative")
+        return value
+
+    @model_validator(mode="after")
+    def aggregate_metrics(self) -> KernelValidationOutput:
+        names = [item.name for item in self.metrics]
+        if len(names) != len(set(names)):
+            raise ValueError("output metric names must be unique")
+        if not self.metrics:
+            if self.status not in {"inconclusive", "unsupported"} or not self.limitations:
+                raise ValueError(
+                    "outputs without metrics must be inconclusive or unsupported with a limitation"
+                )
+        else:
+            expected = _aggregate_status(tuple(item.status for item in self.metrics))
+            if self.status != expected:
+                raise ValueError("output status contradicts its metrics")
+        if self.status == "fail" and not self.representative_failures:
+            raise ValueError("failed outputs require at least one representative failure")
+        if self.status != "fail" and self.representative_failures:
+            raise ValueError("representative failures require failed output status")
+        return self
+
+
+class KernelValidationCase(ContractModel):
+    case_id: BoundedName
+    dimensions: Annotated[dict[BoundedName, _DimensionValue], Field(max_length=32)] = Field(
+        default_factory=dict
+    )
+    inputs: Annotated[dict[BoundedName, KernelValidationInput], Field(max_length=32)] = Field(
+        default_factory=dict
+    )
+    seed: Int64 | None = None
+    device: Annotated[str, StringConstraints(min_length=1, max_length=200)]
+    status: ValidationStatus
+    outputs: Annotated[tuple[KernelValidationOutput, ...], Field(min_length=1, max_length=32)]
+    limitations: Annotated[tuple[str, ...], Field(max_length=20)] = ()
+
+    @field_validator("dimensions")
+    @classmethod
+    def finite_dimensions(cls, value: dict[str, _DimensionValue]) -> dict[str, _DimensionValue]:
+        if any(isinstance(item, float) and not math.isfinite(item) for item in value.values()):
+            raise ValueError("case dimensions must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def aggregate_outputs(self) -> KernelValidationCase:
+        names = [item.name for item in self.outputs]
+        if len(names) != len(set(names)):
+            raise ValueError("case output names must be unique")
+        expected = _aggregate_status(tuple(item.status for item in self.outputs))
+        if self.status != expected:
+            raise ValueError("case status contradicts its outputs")
+        return self
+
+
+class KernelValidationV1(ContractModel):
+    schema_version: Literal["flameox.kernel-validation.v1"]
+    producer: BoundedName
+    producer_version: Annotated[str, StringConstraints(max_length=200)] | None = None
+    reference: KernelValidationReference
+    status: ValidationStatus
+    coverage_complete: bool
+    cases: Annotated[tuple[KernelValidationCase, ...], Field(min_length=1, max_length=1_000)]
+    limitations: Annotated[tuple[str, ...], Field(max_length=20)] = ()
+
+    @model_validator(mode="after")
+    def aggregate_cases(self) -> KernelValidationV1:
+        identifiers = [item.case_id for item in self.cases]
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError("case IDs must be unique")
+        child_status = _aggregate_status(tuple(item.status for item in self.cases))
+        expected: ValidationStatus
+        if child_status == "fail":
+            expected = "fail"
+        elif child_status == "pass" and self.coverage_complete:
+            expected = "pass"
+        elif child_status == "unsupported":
+            expected = "unsupported"
+        else:
+            expected = "inconclusive"
+        if self.status != expected:
+            raise ValueError("document status contradicts case outcomes or coverage")
+        if not self.coverage_complete and not self.limitations:
+            raise ValueError("incomplete coverage requires a limitation")
+        return self
+
+
+def _aggregate_status(statuses: tuple[ValidationStatus, ...]) -> ValidationStatus:
+    if "fail" in statuses:
+        return "fail"
+    if statuses and all(item == "pass" for item in statuses):
+        return "pass"
+    if statuses and all(item == "unsupported" for item in statuses):
+        return "unsupported"
+    return "inconclusive"
+
+
+class KernelValidationExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    producer: str
+    producer_version: str | None
+    status: ValidationStatus
+    coverage_complete: bool
+    case_count: int
+    output_count: int
+    metric_count: int
+    corpus_commit_id: str
+    limitations: tuple[str, ...]
+
+
+class KernelValidationExtractor:
+    name = "flameox.kernel-validation"
+    version = "1"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.runs = RunStore(workspace)
+        self.artifacts = ArtifactStore(workspace)
+        self.publisher = GenerationPublisher(workspace)
+
+    def extract(self, run_id: str) -> KernelValidationExtractionResult:
+        run = self.runs.read(run_id)
+        registrations = tuple(
+            item for item in run.artifacts if item.kind is ArtifactKind.VALIDATION_OUTPUT
+        )
+        if len(registrations) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one kernel-validation artifact.",
+                run_id=run_id,
+            )
+        registration = registrations[0]
+        artifact = self.artifacts.get(registration.artifact_id)
+        document = self._load(artifact.payload_path)
+        if registration.producer not in {None, "flameox.import", document.producer}:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Kernel-validation producer identity conflicts with the registration.",
+                run_id=run_id,
+            )
+        if (
+            registration.producer_version is not None
+            and document.producer_version is not None
+            and registration.producer_version != document.producer_version
+        ):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "Kernel-validation producer version conflicts with the registration.",
+                run_id=run_id,
+            )
+
+        case_rows: list[dict[str, object]] = []
+        metric_rows: list[dict[str, object]] = []
+        for case in document.cases:
+            for output in case.outputs:
+                output_id = digest_model(
+                    {
+                        "artifact_id": registration.artifact_id,
+                        "case_id": case.case_id,
+                        "output": output.name,
+                    }
+                )
+                case_rows.append(
+                    {
+                        "case_output_id": output_id,
+                        "run_id": run_id,
+                        "artifact_id": registration.artifact_id,
+                        "case_id": case.case_id,
+                        "output_name": output.name,
+                        "case_status": case.status,
+                        "output_status": output.status,
+                        "coverage_complete": document.coverage_complete,
+                        "producer": document.producer,
+                        "producer_version": document.producer_version,
+                        "reference_name": document.reference.name,
+                        "reference_version": document.reference.version,
+                        "reference_identity": document.reference.identity,
+                        "device": case.device,
+                        "seed": case.seed,
+                        "dimensions_json": _json(case.dimensions),
+                        "inputs_json": _json(
+                            {
+                                name: value.model_dump(mode="json")
+                                for name, value in case.inputs.items()
+                            }
+                        ),
+                        "dtype": output.dtype,
+                        "shape": list(output.shape),
+                        "representative_failures_json": _json(
+                            [
+                                item.model_dump(mode="json")
+                                for item in output.representative_failures
+                            ]
+                        ),
+                        "limitations": list(
+                            dict.fromkeys((*case.limitations, *output.limitations))
+                        ),
+                    }
+                )
+                for metric in output.metrics:
+                    metric_rows.append(
+                        {
+                            "metric_id": digest_model(
+                                {"case_output_id": output_id, "metric": metric.name}
+                            ),
+                            "case_output_id": output_id,
+                            "run_id": run_id,
+                            "artifact_id": registration.artifact_id,
+                            "case_id": case.case_id,
+                            "output_name": output.name,
+                            "metric_name": metric.name,
+                            "value": metric.value,
+                            "comparator": metric.comparator,
+                            "threshold": metric.threshold,
+                            "unit": metric.unit,
+                            "status": metric.status,
+                            "limitation": metric.limitation,
+                        }
+                    )
+        if (
+            len(case_rows) + len(metric_rows)
+            > self.workspace.config.storage.max_rows_per_generation
+        ):
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "Kernel-validation evidence exceeds the workspace generation row limit.",
+            )
+        published = self.publisher.publish_rows_idempotent(
+            {
+                "kernel_validation_cases": case_rows,
+                "kernel_validation_metrics": metric_rows,
+            },
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=(registration.artifact_id,),
+            operation_identity={
+                "schema_version": document.schema_version,
+                "document_digest": digest_model(document.model_dump(mode="json")),
+            },
+        )
+        return KernelValidationExtractionResult(
+            run_id=run_id,
+            artifact_id=registration.artifact_id,
+            producer=document.producer,
+            producer_version=document.producer_version,
+            status=document.status,
+            coverage_complete=document.coverage_complete,
+            case_count=len(document.cases),
+            output_count=len(case_rows),
+            metric_count=len(metric_rows),
+            corpus_commit_id=published.commit.commit_id,
+            limitations=document.limitations,
+        )
+
+    @staticmethod
+    def _load(path: Path) -> KernelValidationV1:
+        try:
+            if path.stat().st_size > _MAX_KERNEL_VALIDATION_BYTES:
+                raise DomainError(
+                    ErrorCode.ARTIFACT_TOO_LARGE,
+                    "Kernel-validation JSON exceeds the 64 MiB contract limit.",
+                )
+            with path.open(encoding="utf-8") as stream:
+                return KernelValidationV1.model_validate(json.load(stream))
+        except DomainError:
+            raise
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The artifact is not a valid flameox kernel-validation v1 document.",
+            ) from exc
+
+
+def kernel_validation_json_schema() -> dict[str, JsonValue]:
+    return KernelValidationV1.model_json_schema(mode="validation")
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, allow_nan=False, separators=(",", ":"), sort_keys=True)

--- a/src/flameox/adapters/options.py
+++ b/src/flameox/adapters/options.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from pathlib import Path
+from typing import Annotated, Literal, cast
+
+from pydantic import Field, JsonValue, StringConstraints, field_validator, model_validator
+
+from flameox.adapters.torch_profiler import torch_profiler_options
+from flameox.domain import DomainError, ErrorCode
+from flameox.models import ContractModel
+
+BoundedFilter = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=500, pattern=r"^[^\x00\r\n]+$"),
+]
+
+
+class ComputeSanitizerOptions(ContractModel):
+    tool: Literal["memcheck", "racecheck", "initcheck", "synccheck"] = "memcheck"
+    launch_skip: Annotated[int, Field(ge=0, le=1_000_000)] = 0
+    launch_count: Annotated[int, Field(ge=0, le=1_000_000)] = 0
+    target_processes: Literal["application-only", "all"] = "application-only"
+    target_processes_filter: BoundedFilter | None = None
+    kernel_name: BoundedFilter | None = None
+    demangle: Literal["full", "simple", "no"] = "full"
+    suppression_file: Annotated[str, StringConstraints(min_length=1, max_length=500)] | None = None
+    suppression_digest: (
+        Annotated[str, StringConstraints(pattern=r"^sha256:[0-9a-f]{64}$")] | None
+    ) = None
+    finding_exit_code: Annotated[int, Field(ge=1, le=255)] = 86
+
+    @field_validator("suppression_file")
+    @classmethod
+    def project_relative_suppression(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        path = Path(value)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("suppression_file must be project-relative and contained")
+        return path.as_posix()
+
+    @model_validator(mode="after")
+    def suppression_identity_is_complete(self) -> ComputeSanitizerOptions:
+        if (self.suppression_file is None) != (self.suppression_digest is None):
+            raise ValueError("suppression_file and suppression_digest must be bound together")
+        return self
+
+
+_ADAPTER_OPTION_MODELS: dict[str, type[ContractModel]] = {
+    "compute-sanitizer": ComputeSanitizerOptions,
+}
+
+
+def adapter_accepts_options(adapter: str) -> bool:
+    return adapter == "torch.profiler" or adapter in _ADAPTER_OPTION_MODELS
+
+
+def _validate_adapter_options(
+    adapter: str,
+    options: dict[str, object] | None,
+) -> ContractModel:
+    model = _ADAPTER_OPTION_MODELS[adapter]
+    try:
+        return model.model_validate(options or {})
+    except ValueError as exc:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            f"Invalid {adapter} capture options.",
+            details={"validation_error": str(exc)},
+        ) from exc
+
+
+def bind_adapter_options(
+    adapter: str,
+    options: dict[str, JsonValue] | None,
+    *,
+    project_root: Path,
+) -> dict[str, JsonValue]:
+    if adapter == "torch.profiler":
+        selected = torch_profiler_options(cast(dict[str, object] | None, options))
+        return cast(dict[str, JsonValue], selected.model_dump(mode="json"))
+    if adapter == "compute-sanitizer":
+        raw = dict(options or {})
+        suppression = raw.get("suppression_file")
+        if suppression is not None:
+            if not isinstance(suppression, str):
+                raise DomainError(
+                    ErrorCode.INVALID_CAPTURE_PLAN,
+                    "Compute Sanitizer suppression_file must be a project-relative string.",
+                )
+            path = _contained_project_file(project_root, suppression)
+            raw["suppression_file"] = path.relative_to(project_root.resolve()).as_posix()
+            raw["suppression_digest"] = _sha256(path)
+        bound = _validate_adapter_options(adapter, cast(dict[str, object], raw))
+        return cast(dict[str, JsonValue], bound.model_dump(mode="json"))
+    if adapter in _ADAPTER_OPTION_MODELS:
+        bound = _validate_adapter_options(adapter, cast(dict[str, object] | None, options))
+        return cast(dict[str, JsonValue], bound.model_dump(mode="json"))
+    if options:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            f"Adapter {adapter!r} does not accept capture options.",
+        )
+    return {}
+
+
+def compute_sanitizer_options(options: dict[str, object] | None) -> ComputeSanitizerOptions:
+    return cast(ComputeSanitizerOptions, _validate_adapter_options("compute-sanitizer", options))
+
+
+def compute_sanitizer_suppression_path(
+    options: ComputeSanitizerOptions,
+    *,
+    project_root: Path,
+) -> Path | None:
+    if options.suppression_file is None:
+        return None
+    path = _contained_project_file(project_root, options.suppression_file)
+    observed_digest = _sha256(path)
+    if observed_digest != options.suppression_digest:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "Compute Sanitizer suppression file changed after the capture plan was issued.",
+            details={
+                "expected_sha256": options.suppression_digest,
+                "observed_sha256": observed_digest,
+            },
+            remediation=("Create a new capture plan after updating the suppression file.",),
+        )
+    return path
+
+
+def read_compute_sanitizer_suppression(
+    options: ComputeSanitizerOptions,
+    *,
+    project_root: Path,
+) -> bytes | None:
+    """Read and verify the plan-bound suppression bytes from a no-follow descriptor."""
+    if options.suppression_file is None:
+        return None
+    path = _contained_project_file(project_root, options.suppression_file)
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "Compute Sanitizer suppression file must be a regular non-linked file.",
+            )
+        if metadata.st_size > 1024 * 1024:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "Compute Sanitizer suppression file exceeds the 1 MiB limit.",
+            )
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            payload = stream.read(1024 * 1024 + 1)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if len(payload) > 1024 * 1024:
+        raise DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            "Compute Sanitizer suppression file exceeds the 1 MiB limit.",
+        )
+    observed_digest = f"sha256:{hashlib.sha256(payload).hexdigest()}"
+    if observed_digest != options.suppression_digest:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "Compute Sanitizer suppression file changed after the capture plan was issued.",
+            details={
+                "expected_sha256": options.suppression_digest,
+                "observed_sha256": observed_digest,
+            },
+            remediation=("Create a new capture plan after updating the suppression file.",),
+        )
+    return payload
+
+
+def _contained_project_file(project_root: Path, relative: str) -> Path:
+    root = project_root.resolve()
+    lexical = Path(relative)
+    if lexical.is_absolute() or ".." in lexical.parts:
+        raise DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            "Compute Sanitizer suppression files must be project-relative.",
+        )
+    path = (root / lexical).resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            "Compute Sanitizer suppression file escapes the project root.",
+        ) from exc
+    try:
+        metadata = path.stat()
+    except OSError as exc:
+        raise DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            "Compute Sanitizer suppression file is missing.",
+        ) from exc
+    if path.is_symlink() or not path.is_file() or metadata.st_nlink != 1:
+        raise DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            "Compute Sanitizer suppression file must be a regular non-linked file.",
+        )
+    return path
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        stream = os.fdopen(descriptor, "rb")
+    except OSError:
+        os.close(descriptor)
+        raise
+    with stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -23,6 +23,13 @@ from flameox.adapters.builtins import (
     BUILTIN_ADAPTERS,
     build_capture_invocation,
     builtin_adapter,
+    replace_compute_sanitizer_suppression,
+)
+from flameox.adapters.compute_sanitizer import inspect_compute_sanitizer_report
+from flameox.adapters.options import (
+    bind_adapter_options,
+    compute_sanitizer_options,
+    read_compute_sanitizer_suppression,
 )
 from flameox.adapters.registry import AdapterRegistry
 from flameox.adapters.torch_profiler import SdkTorchProfilerOptions, torch_profiler_options
@@ -575,17 +582,11 @@ class CaptureService:
         collector_environment = {
             "FLAMEOX_OBSERVATIONS_PATH": str(output_root / "observations.jsonl")
         }
-        if adapter == "torch.profiler":
-            bound_adapter_options = torch_profiler_options(
-                cast(dict[str, object] | None, adapter_options)
-            ).model_dump(mode="json")
-        elif adapter_options:
-            raise DomainError(
-                ErrorCode.INVALID_CAPTURE_PLAN,
-                f"Adapter {adapter!r} does not accept capture options.",
-            )
-        else:
-            bound_adapter_options = {}
+        bound_adapter_options = bind_adapter_options(
+            adapter,
+            adapter_options,
+            project_root=self.workspace.project_root,
+        )
         adapter_binding = await self._adapter_command(
             adapter,
             instance.command,
@@ -902,9 +903,23 @@ class CaptureService:
             await self.plans.acquire_capture_slot()
             acquired_slot = True
             await capture.report(4, "Capture slot acquired")
+            collector_argv = plan.collector_argv
+            if plan.adapter == "compute-sanitizer":
+                selected = compute_sanitizer_options(cast(dict[str, object], plan.adapter_options))
+                suppression = read_compute_sanitizer_suppression(
+                    selected,
+                    project_root=self.workspace.project_root,
+                )
+                if suppression is not None:
+                    staged_suppression = output_root / "inputs" / "compute-sanitizer.supp"
+                    atomic_write_bytes(staged_suppression, suppression, mode=0o400)
+                    collector_argv = replace_compute_sanitizer_suppression(
+                        collector_argv,
+                        staged_suppression,
+                    )
             outcome = await self.broker.run(
                 ExecutionRequest(
-                    argv=plan.collector_argv,
+                    argv=collector_argv,
                     cwd=Path(plan.workload_instance.command.cwd),
                     environment_allowlist=(
                         self.workspace.config.execution.child_environment_allowlist
@@ -1091,7 +1106,12 @@ class CaptureService:
                 "capture run disappeared after collector execution",
             )
 
-        collector_succeeded = outcome.process.exit_code == 0
+        sanitizer_finding_exit = (
+            plan.adapter == "compute-sanitizer"
+            and outcome.process.exit_code == plan.adapter_options.get("finding_exit_code")
+        )
+        sanitizer_finding = False
+        collector_succeeded = outcome.process.exit_code == 0 or sanitizer_finding_exit
         native_paths = self._native_output_paths(plan, output_root)
         valid_native_paths = self._valid_native_output_paths(plan, output_root)
         unexpected_native_paths = self._unexpected_native_output_paths(plan, output_root)
@@ -1131,7 +1151,12 @@ class CaptureService:
                 collector_limitation_details.append(quarantined)
             valid_native_paths = ()
             native_complete = False
-        elif native_paths and not native_complete and not outcome.process.timed_out:
+        elif (
+            native_paths
+            and not native_complete
+            and not outcome.process.timed_out
+            and not preserve_nonzero_artifact
+        ):
             reason = (
                 "Collector completed without every expected native output."
                 if not any(path.exists() for path in native_paths)
@@ -1146,6 +1171,21 @@ class CaptureService:
                 _limitation("artifact", "expected_output_invalid", reason)
             )
             valid_native_paths = ()
+        elif (
+            native_paths
+            and not native_complete
+            and not outcome.process.timed_out
+            and preserve_nonzero_artifact
+        ):
+            reason = (
+                "Collector completed without every expected native output."
+                if not any(path.exists() for path in native_paths)
+                else "Collector emitted an incomplete, extra, empty, or non-regular output set."
+            )
+            collector_limitation_details.append(
+                _limitation("artifact", "expected_output_invalid", reason)
+            )
+            collector_succeeded = False
         if native_paths and outcome.process.timed_out and valid_native_paths:
             collector_limitation_details.append(
                 _limitation(
@@ -1498,19 +1538,62 @@ class CaptureService:
                         role = f"cycle_{cycle_index:04d}"
                     else:
                         role = "primary"
-                    registrations.append(
-                        await self._register_path_async(
-                            run_id,
-                            native,
-                            kind=plan.expected_artifact_kinds[0],
-                            role=role,
-                            media_type=(
-                                mimetypes.guess_type(native.name)[0] or "application/octet-stream"
-                            ),
-                            producer=plan.adapter,
-                            producer_version=plan.adapter_version,
-                        )
+                    registration = await self._register_path_async(
+                        run_id,
+                        native,
+                        kind=plan.expected_artifact_kinds[0],
+                        role=role,
+                        media_type=(
+                            mimetypes.guess_type(native.name)[0] or "application/octet-stream"
+                        ),
+                        producer=plan.adapter,
+                        producer_version=plan.adapter_version,
                     )
+                    registrations.append(registration)
+                    if plan.adapter == "compute-sanitizer":
+                        immutable = self.artifacts.get(registration[0].artifact_id)
+                        try:
+                            inspection = await run_atomic_thread(
+                                partial(
+                                    inspect_compute_sanitizer_report,
+                                    self.workspace,
+                                    str(immutable.payload_path),
+                                    max_records=max(
+                                        1,
+                                        min(
+                                            10_000,
+                                            self.workspace.config.storage.max_rows_per_generation
+                                            - 1,
+                                        ),
+                                    ),
+                                )
+                            )
+                        except DomainError as error:
+                            collector_succeeded = False
+                            validation_status = ValidationStatus.ERROR
+                            validation_limitations.append(
+                                f"Compute Sanitizer report validation failed: {error.message}"
+                            )
+                        else:
+                            has_findings = bool(inspection.records)
+                            supported_exit = outcome.process.exit_code in {
+                                0,
+                                plan.adapter_options.get("finding_exit_code"),
+                            }
+                            sanitizer_finding = has_findings and supported_exit
+                            if not supported_exit or (sanitizer_finding_exit and not has_findings):
+                                collector_succeeded = False
+                                validation_status = ValidationStatus.ERROR
+                                validation_limitations.append(
+                                    "Compute Sanitizer exit status contradicts the parsed report."
+                                )
+                            else:
+                                validation_status = (
+                                    ValidationStatus.FAILED
+                                    if has_findings
+                                    else ValidationStatus.PASSED
+                                )
+                            validation_limitations.extend(inspection.limitations)
                 manifest = output_root / "torch-profiler-cycles.json"
                 if (
                     plan.adapter == "torch.profiler"
@@ -1599,7 +1682,7 @@ class CaptureService:
             )
             error.run_id = terminal.run_id
             raise
-        succeeded = outcome.process.exit_code == 0
+        succeeded = collector_succeeded and (not sanitizer_finding or native_complete)
         timed_out = outcome.process.timed_out
         detail_groups = [
             tuple(collector_limitation_details),
@@ -2063,6 +2146,7 @@ class CaptureService:
                 executable=capability.executable,
                 timeout_seconds=workload.timeout_seconds,
                 options=cast(dict[str, object] | None, options),
+                project_root=self.workspace.project_root,
             )
             return _AdapterBinding(
                 argv=invocation.argv,

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -19,8 +19,10 @@ from flameox import __version__, setup_ui
 from flameox.adapters import (
     AdapterRegistry,
     BenchmarkSamplesExtractor,
+    ComputeSanitizerExtractor,
     CoverageExtractor,
     InferenceArtifactExtractor,
+    KernelValidationExtractor,
     MemrayExtractor,
     NsightSystemsExtractor,
     ObservationExtractor,
@@ -2237,6 +2239,40 @@ def extract_benchmark_samples(
     """Extract producer-neutral raw benchmark samples and timing semantics."""
     try:
         result = BenchmarkSamplesExtractor(_workspace(workspace)).extract(run_id)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@extract_app.command("kernel-validation")
+def extract_kernel_validation(
+    run_id: Annotated[
+        str,
+        typer.Argument(help="Import run containing flameox kernel-validation v1 JSON."),
+    ],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract bounded per-case numerical validation evidence."""
+    try:
+        result = KernelValidationExtractor(_workspace(workspace)).extract(run_id)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@extract_app.command("compute-sanitizer")
+def extract_compute_sanitizer(
+    run_id: Annotated[
+        str,
+        typer.Argument(help="Run containing an official Compute Sanitizer XML report."),
+    ],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract bounded sanitizer findings through the isolated XML worker."""
+    try:
+        result = ComputeSanitizerExtractor(_workspace(workspace)).extract(run_id)
     except DomainError as error:
         _fail(error)
     _emit(result, as_json=json_output)

--- a/src/flameox/evidence/schemas.py
+++ b/src/flameox/evidence/schemas.py
@@ -5,7 +5,7 @@ from typing import Any
 import pyarrow as pa
 
 SCHEMA_MAJOR = 1
-SCHEMA_MINOR = 8
+SCHEMA_MINOR = 9
 UTC_TIMESTAMP = pa.timestamp("us", tz="UTC")
 
 COMMON_FIELDS: tuple[Any, ...] = (
@@ -132,6 +132,50 @@ SCHEMAS: dict[str, pa.Schema] = {
             pa.field("stages_json", pa.string(), nullable=False),
             pa.field("limitations", pa.list_(pa.string()), nullable=False),
             pa.field("created_at", UTC_TIMESTAMP, nullable=False),
+        ),
+    ),
+    "kernel_validation_cases": _schema(
+        "kernel_validation_cases",
+        (
+            pa.field("case_output_id", pa.string(), nullable=False),
+            pa.field("run_id", pa.string(), nullable=False),
+            pa.field("artifact_id", pa.string(), nullable=False),
+            pa.field("case_id", pa.string(), nullable=False),
+            pa.field("output_name", pa.string(), nullable=False),
+            pa.field("case_status", pa.string(), nullable=False),
+            pa.field("output_status", pa.string(), nullable=False),
+            pa.field("coverage_complete", pa.bool_(), nullable=False),
+            pa.field("producer", pa.string(), nullable=False),
+            pa.field("producer_version", pa.string()),
+            pa.field("reference_name", pa.string(), nullable=False),
+            pa.field("reference_version", pa.string()),
+            pa.field("reference_identity", pa.string(), nullable=False),
+            pa.field("device", pa.string(), nullable=False),
+            pa.field("seed", pa.int64()),
+            pa.field("dimensions_json", pa.string(), nullable=False),
+            pa.field("inputs_json", pa.string(), nullable=False),
+            pa.field("dtype", pa.string(), nullable=False),
+            pa.field("shape", pa.list_(pa.int64()), nullable=False),
+            pa.field("representative_failures_json", pa.string(), nullable=False),
+            pa.field("limitations", pa.list_(pa.string()), nullable=False),
+        ),
+    ),
+    "kernel_validation_metrics": _schema(
+        "kernel_validation_metrics",
+        (
+            pa.field("metric_id", pa.string(), nullable=False),
+            pa.field("case_output_id", pa.string(), nullable=False),
+            pa.field("run_id", pa.string(), nullable=False),
+            pa.field("artifact_id", pa.string(), nullable=False),
+            pa.field("case_id", pa.string(), nullable=False),
+            pa.field("output_name", pa.string(), nullable=False),
+            pa.field("metric_name", pa.string(), nullable=False),
+            pa.field("value", pa.float64()),
+            pa.field("comparator", pa.string()),
+            pa.field("threshold", pa.float64()),
+            pa.field("unit", pa.string(), nullable=False),
+            pa.field("status", pa.string(), nullable=False),
+            pa.field("limitation", pa.string()),
         ),
     ),
     "pipeline_comparisons": _schema(

--- a/src/flameox/mcp/resources.py
+++ b/src/flameox/mcp/resources.py
@@ -6,6 +6,7 @@ from typing import Literal, Protocol, cast
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 
+from flameox.adapters.kernel_validation import kernel_validation_json_schema
 from flameox.application import (
     ArtifactService,
     EvidenceLookupService,
@@ -29,6 +30,14 @@ def _workspace(ctx: Context) -> Workspace:
 
 def register_resources[T: WorkspaceContext](server: MCPServer[T]) -> None:  # noqa: C901
     """Register resource projections independently from the MCP tool transport."""
+
+    @server.resource(
+        "flameox://schemas/kernel-validation/v1",
+        mime_type="application/schema+json",
+        description="Published JSON Schema for flameox.kernel-validation.v1.",
+    )
+    async def kernel_validation_schema_resource() -> str:
+        return json.dumps(kernel_validation_json_schema(), indent=2, sort_keys=True)
 
     def error_payload(error: DomainError) -> str:
         return json.dumps({"ok": False, "error": error.to_detail()})

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -21,10 +21,14 @@ from flameox import __version__
 from flameox.adapters import (
     BenchmarkSamplesExtractionResult,
     BenchmarkSamplesExtractor,
+    ComputeSanitizerExtractionResult,
+    ComputeSanitizerExtractor,
     CoverageExtractionResult,
     CoverageExtractor,
     InferenceArtifactExtractor,
     InferenceExtractionResult,
+    KernelValidationExtractionResult,
+    KernelValidationExtractor,
     MemrayExtractionResult,
     MemrayExtractor,
     NsightSystemsExtractionResult,
@@ -2077,6 +2081,7 @@ def create_server(
                 "py-spy",
                 "memray",
                 "coverage",
+                "compute-sanitizer",
                 "pyperf",
                 "pytest",
                 "aiperf",
@@ -3157,6 +3162,82 @@ def create_server(
                 result,
                 f"Extracted {result.measurement_count} measured values and "
                 f"{result.warmup_count} warmups.",
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="extract_kernel_validation", annotations=ADDITIVE)
+    async def extract_kernel_validation_tool(
+        run_id: Annotated[str, Field(min_length=1, max_length=200)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[KernelValidationExtractionResult]]:
+        """Extract bounded per-case metrics from kernel-validation v1 evidence."""
+        try:
+            await ctx.report_progress(0, 2, "Kernel-validation extraction started")
+            result = await run_atomic_thread(
+                lambda: KernelValidationExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
+            await ctx.report_progress(1, 2, "Kernel-validation evidence published")
+            run_uri = f"flameox://runs/{result.run_id}"
+            artifact_uri = f"flameox://artifacts/{result.artifact_id}"
+            await ctx.report_progress(2, 2, "Kernel-validation result ready")
+            return _success(
+                result,
+                f"Extracted {result.case_count} validation cases with status {result.status}.",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Run {result.run_id}",
+                        uri=run_uri,
+                        description="Authoritative validation import run.",
+                        mime_type="application/json",
+                    ),
+                    ResourceLink(
+                        name=f"Artifact {result.artifact_id}",
+                        uri=artifact_uri,
+                        description="Authoritative kernel-validation artifact metadata.",
+                        mime_type="application/json",
+                    ),
+                ),
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="extract_compute_sanitizer", annotations=ADDITIVE)
+    async def extract_compute_sanitizer_tool(
+        run_id: Annotated[str, Field(min_length=1, max_length=200)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[ComputeSanitizerExtractionResult]]:
+        """Extract bounded findings from an official Compute Sanitizer XML report."""
+        try:
+            await ctx.report_progress(0, 2, "Compute Sanitizer extraction started")
+            result = await run_atomic_thread(
+                lambda: ComputeSanitizerExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
+            await ctx.report_progress(1, 2, "Compute Sanitizer evidence published")
+            run_uri = f"flameox://runs/{result.run_id}"
+            artifact_uri = f"flameox://artifacts/{result.artifact_id}"
+            await ctx.report_progress(2, 2, "Compute Sanitizer result ready")
+            return _success(
+                result,
+                f"Compute Sanitizer extraction returned {result.finding_count} findings.",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Run {result.run_id}",
+                        uri=run_uri,
+                        description="Authoritative sanitizer run manifest.",
+                        mime_type="application/json",
+                    ),
+                    ResourceLink(
+                        name=f"Artifact {result.artifact_id}",
+                        uri=artifact_uri,
+                        description="Authoritative Compute Sanitizer report metadata.",
+                        mime_type="application/json",
+                    ),
+                ),
             )
         except DomainError as error:
             return _failure(error)

--- a/src/flameox/schemas/kernel-validation-v1.schema.json
+++ b/src/flameox/schemas/kernel-validation-v1.schema.json
@@ -1,0 +1,506 @@
+{
+  "$defs": {
+    "KernelValidationCase": {
+      "additionalProperties": false,
+      "properties": {
+        "case_id": {
+          "maxLength": 200,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+          "title": "Case Id",
+          "type": "string"
+        },
+        "device": {
+          "maxLength": 200,
+          "minLength": 1,
+          "title": "Device",
+          "type": "string"
+        },
+        "dimensions": {
+          "maxProperties": 32,
+          "patternProperties": {
+            "^[A-Za-z0-9][A-Za-z0-9._:/-]*$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "maxLength": 200,
+            "minLength": 1
+          },
+          "title": "Dimensions",
+          "type": "object"
+        },
+        "inputs": {
+          "maxProperties": 32,
+          "patternProperties": {
+            "^[A-Za-z0-9][A-Za-z0-9._:/-]*$": {
+              "$ref": "#/$defs/KernelValidationInput"
+            }
+          },
+          "propertyNames": {
+            "maxLength": 200,
+            "minLength": 1
+          },
+          "title": "Inputs",
+          "type": "object"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "outputs": {
+          "items": {
+            "$ref": "#/$defs/KernelValidationOutput"
+          },
+          "maxItems": 32,
+          "minItems": 1,
+          "title": "Outputs",
+          "type": "array"
+        },
+        "seed": {
+          "anyOf": [
+            {
+              "maximum": 9223372036854775807,
+              "minimum": -9223372036854775808,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Seed"
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "fail",
+            "inconclusive",
+            "unsupported"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "case_id",
+        "device",
+        "status",
+        "outputs"
+      ],
+      "title": "KernelValidationCase",
+      "type": "object"
+    },
+    "KernelValidationFailure": {
+      "additionalProperties": false,
+      "properties": {
+        "absolute_error": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Absolute Error"
+        },
+        "actual": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Actual"
+        },
+        "coordinates": {
+          "default": [],
+          "items": {
+            "type": "integer"
+          },
+          "maxItems": 16,
+          "title": "Coordinates",
+          "type": "array"
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Detail"
+        },
+        "expected": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expected"
+        },
+        "relative_error": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relative Error"
+        }
+      },
+      "title": "KernelValidationFailure",
+      "type": "object"
+    },
+    "KernelValidationInput": {
+      "additionalProperties": false,
+      "properties": {
+        "dtype": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Dtype",
+          "type": "string"
+        },
+        "role": {
+          "anyOf": [
+            {
+              "maxLength": 100,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Role"
+        },
+        "shape": {
+          "items": {
+            "maximum": 9223372036854775807,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          "maxItems": 16,
+          "title": "Shape",
+          "type": "array"
+        }
+      },
+      "required": [
+        "dtype",
+        "shape"
+      ],
+      "title": "KernelValidationInput",
+      "type": "object"
+    },
+    "KernelValidationMetric": {
+      "additionalProperties": false,
+      "properties": {
+        "comparator": {
+          "anyOf": [
+            {
+              "enum": [
+                "<=",
+                ">="
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Comparator"
+        },
+        "limitation": {
+          "anyOf": [
+            {
+              "maxLength": 500,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limitation"
+        },
+        "name": {
+          "enum": [
+            "max_abs_error",
+            "max_rel_error",
+            "mse",
+            "rmse",
+            "psnr",
+            "cosine_similarity"
+          ],
+          "title": "Name",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "fail",
+            "inconclusive",
+            "unsupported"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "threshold": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Threshold"
+        },
+        "unit": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Unit",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "name",
+        "value",
+        "comparator",
+        "threshold",
+        "unit",
+        "status"
+      ],
+      "title": "KernelValidationMetric",
+      "type": "object"
+    },
+    "KernelValidationOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "dtype": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Dtype",
+          "type": "string"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "metrics": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/KernelValidationMetric"
+          },
+          "maxItems": 16,
+          "title": "Metrics",
+          "type": "array"
+        },
+        "name": {
+          "maxLength": 200,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "representative_failures": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/KernelValidationFailure"
+          },
+          "maxItems": 8,
+          "title": "Representative Failures",
+          "type": "array"
+        },
+        "shape": {
+          "items": {
+            "maximum": 9223372036854775807,
+            "minimum": -9223372036854775808,
+            "type": "integer"
+          },
+          "maxItems": 16,
+          "title": "Shape",
+          "type": "array"
+        },
+        "status": {
+          "enum": [
+            "pass",
+            "fail",
+            "inconclusive",
+            "unsupported"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "dtype",
+        "shape",
+        "status"
+      ],
+      "title": "KernelValidationOutput",
+      "type": "object"
+    },
+    "KernelValidationReference": {
+      "additionalProperties": false,
+      "properties": {
+        "identity": {
+          "maxLength": 500,
+          "minLength": 1,
+          "title": "Identity",
+          "type": "string"
+        },
+        "name": {
+          "maxLength": 200,
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "maxLength": 200,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        }
+      },
+      "required": [
+        "name",
+        "identity"
+      ],
+      "title": "KernelValidationReference",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "cases": {
+      "items": {
+        "$ref": "#/$defs/KernelValidationCase"
+      },
+      "maxItems": 1000,
+      "minItems": 1,
+      "title": "Cases",
+      "type": "array"
+    },
+    "coverage_complete": {
+      "title": "Coverage Complete",
+      "type": "boolean"
+    },
+    "limitations": {
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "maxItems": 20,
+      "title": "Limitations",
+      "type": "array"
+    },
+    "producer": {
+      "maxLength": 200,
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+      "title": "Producer",
+      "type": "string"
+    },
+    "producer_version": {
+      "anyOf": [
+        {
+          "maxLength": 200,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Producer Version"
+    },
+    "reference": {
+      "$ref": "#/$defs/KernelValidationReference"
+    },
+    "schema_version": {
+      "const": "flameox.kernel-validation.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "pass",
+        "fail",
+        "inconclusive",
+        "unsupported"
+      ],
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "producer",
+    "reference",
+    "status",
+    "coverage_complete",
+    "cases"
+  ],
+  "title": "KernelValidationV1",
+  "type": "object"
+}

--- a/src/flameox/workers/compute_sanitizer.py
+++ b/src/flameox/workers/compute_sanitizer.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from defusedxml.ElementTree import iterparse  # type: ignore[import-untyped]
+
+_KNOWN_RECORD_FIELDS = {"kind", "level", "who", "what", "where", "hostStack"}
+
+
+def _text(element: ET.Element | None, name: str) -> str | None:
+    if element is None:
+        return None
+    child = element.find(name)
+    if child is None or child.text is None:
+        return None
+    value = child.text.strip()
+    return value or None
+
+
+def _integer(element: ET.Element | None, name: str) -> int | None:
+    value = _text(element, name)
+    if value is None:
+        return None
+    parsed = int(value, 16 if value.casefold().startswith(("0x", "-0x")) else 10)
+    if not -(2**31) <= parsed <= 2**31 - 1:
+        raise ValueError(f"{name} is outside the supported 32-bit range")
+    return parsed
+
+
+def _normalize_path(value: str | None, project_root: Path) -> str | None:
+    if value is None:
+        return None
+    path = Path(value)
+    try:
+        return path.resolve().relative_to(project_root).as_posix()
+    except (OSError, ValueError):
+        return f"<external>/{path.name}" if path.name else "<external>"
+
+
+def _axes(element: ET.Element | None) -> dict[str, int] | None:
+    if element is None:
+        return None
+    values = {
+        axis: value for axis in ("x", "y", "z") if (value := _integer(element, axis)) is not None
+    }
+    return values or None
+
+
+def _classification(kind: str | None, message: str | None, error: str | None) -> str:
+    normalized_kind = (kind or "").casefold()
+    combined = " ".join(item for item in (kind, message, error) if item).casefold()
+    if normalized_kind in {"api", "api error"}:
+        return "api_error"
+    if normalized_kind in {"sanitizer", "sanitizer error"}:
+        return "sanitizer_error"
+    if normalized_kind in {"race", "hazard"}:
+        return "race"
+    if normalized_kind in {"initcheck", "uninitialized"}:
+        return "uninitialized_memory"
+    if normalized_kind in {"synccheck", "synchronization"}:
+        return "synchronization"
+    if normalized_kind == "precise":
+        return "memory_access"
+    if re.search(r"\b(race|hazard)\b", combined):
+        return "race"
+    if re.search(r"\b(uninitialized|initcheck)\b", combined):
+        return "uninitialized_memory"
+    if re.search(r"\b(sync|synccheck|barrier)\b", combined):
+        return "synchronization"
+    if re.search(r"\bapi\b", combined):
+        return "api_error"
+    if any(item in combined for item in ("out of bounds", "misaligned", "memory", "leak")):
+        return "memory_access"
+    if re.search(r"\b(sanitizer|internal)\b", combined):
+        return "sanitizer_error"
+    return "unknown"
+
+
+def _record(
+    element: ET.Element,
+    *,
+    project_root: Path,
+    max_frames: int,
+) -> tuple[dict[str, object], tuple[str, ...]]:
+    kind = _text(element, "kind")
+    level = _text(element, "level")
+    what = element.find("what")
+    where = element.find("where")
+    message = _text(what, "text")
+    error = _text(what, "error")
+    who = element.find("who")
+    stack = element.find("hostStack")
+    frames: list[dict[str, object]] = []
+    frame_elements = list(stack.findall("frame")) if stack is not None else []
+    for frame in frame_elements[:max_frames]:
+        frames.append(
+            {
+                "function": _text(frame, "func"),
+                "module": _normalize_path(_text(frame, "module"), project_root),
+                "path": _normalize_path(_text(frame, "path"), project_root),
+                "line": _integer(frame, "line"),
+                "pc": _text(frame, "pc"),
+            }
+        )
+    limitations = [
+        f"Unknown Compute Sanitizer record element: {child.tag}."
+        for child in element
+        if child.tag not in _KNOWN_RECORD_FIELDS
+    ]
+    if len(frame_elements) > max_frames:
+        limitations.append(f"Host stack was truncated to {max_frames} frames.")
+    return (
+        {
+            "kind": kind,
+            "level": level,
+            "classification": _classification(kind, message, error),
+            "message": message,
+            "memory_space": _text(what, "space"),
+            "access_size": _integer(what, "size"),
+            "direction": _text(what, "direction"),
+            "error": error,
+            "function": _text(where, "func"),
+            "path": _normalize_path(_text(where, "path"), project_root),
+            "line": _integer(where, "line"),
+            "pc": _text(where, "pc"),
+            "thread": _axes(who.find("threadIdx") if who is not None else None),
+            "block": _axes(who.find("blockIdx") if who is not None else None),
+            "frames": frames,
+        },
+        tuple(limitations),
+    )
+
+
+def _extract(
+    artifact_path: Path,
+    *,
+    project_root: Path,
+    max_records: int,
+    max_frames: int,
+) -> dict[str, object]:
+    records: list[dict[str, object]] = []
+    limitations: list[str] = []
+    root_seen = False
+    truncated = False
+    for event, element in iterparse(artifact_path, events=("start", "end")):
+        if event == "start" and not root_seen:
+            root_seen = True
+            if element.tag != "ComputeSanitizerOutput":
+                raise ValueError("root element is not ComputeSanitizerOutput")
+        if event != "end":
+            continue
+        if element.tag == "record":
+            if len(records) >= max_records:
+                truncated = True
+            else:
+                record, record_limitations = _record(
+                    element,
+                    project_root=project_root,
+                    max_frames=max_frames,
+                )
+                records.append(record)
+                limitations.extend(record_limitations)
+            element.clear()
+        elif element.tag not in {
+            "ComputeSanitizerOutput",
+            "kind",
+            "level",
+            "who",
+            "threadIdx",
+            "blockIdx",
+            "x",
+            "y",
+            "z",
+            "what",
+            "text",
+            "space",
+            "size",
+            "direction",
+            "error",
+            "address",
+            "where",
+            "func",
+            "path",
+            "line",
+            "pc",
+            "hostStack",
+            "saveLocation",
+            "frame",
+            "module",
+        }:
+            limitations.append(f"Unknown Compute Sanitizer XML element: {element.tag}.")
+    if not root_seen:
+        raise ValueError("XML document is empty")
+    if truncated:
+        limitations.append(f"Sanitizer records were truncated to {max_records} entries.")
+    classifications: dict[str, int] = {}
+    for record in records:
+        name = str(record["classification"])
+        classifications[name] = classifications.get(name, 0) + 1
+    return {
+        "ok": True,
+        "records": records,
+        "classifications": classifications,
+        "limitations": list(dict.fromkeys(limitations)),
+        "truncated": truncated,
+    }
+
+
+def _write_response(path: Path, payload: dict[str, object]) -> None:
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(payload, allow_nan=False, separators=(",", ":"), sort_keys=True)
+    )
+    os.replace(temporary, path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True)
+    parser.add_argument("--response", required=True)
+    options = parser.parse_args()
+    try:
+        request = json.loads(Path(options.request).read_text())
+        payload = _extract(
+            Path(request["artifact_path"]),
+            project_root=Path(request["project_root"]).resolve(),
+            max_records=int(request["max_records"]),
+            max_frames=int(request["max_frames"]),
+        )
+    except (OSError, ET.ParseError, ValueError, KeyError, TypeError) as exc:
+        payload = {
+            "ok": False,
+            "code": "ARTIFACT_PARSE_FAILED",
+            "message": f"Compute Sanitizer XML is unsupported or invalid: {exc}",
+        }
+    _write_response(Path(options.response), payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/adapters/test_compute_sanitizer.py
+++ b/tests/adapters/test_compute_sanitizer.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from flameox.adapters.builtins import build_capture_invocation
+from flameox.adapters.compute_sanitizer import ComputeSanitizerExtractor
+from flameox.adapters.options import bind_adapter_options
+from flameox.application import (
+    CaptureService,
+    ExecutionPolicy,
+    ImportArtifactRequest,
+    ImportService,
+)
+from flameox.catalog import Catalog
+from flameox.domain import (
+    ArtifactKind,
+    CapabilityReport,
+    CapabilityStatus,
+    DomainError,
+    ErrorCode,
+)
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+
+def _report(*records: str, extra: str = "") -> str:
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        "<ComputeSanitizerOutput>" + "".join(records) + extra + "</ComputeSanitizerOutput>"
+    )
+
+
+def _precise_record(*, unknown: str = "") -> str:
+    return f"""
+    <record>
+      <kind>Precise</kind><level>Error</level>
+      <who><threadIdx><x>0</x><y>1</y><z>2</z></threadIdx>
+        <blockIdx><x>3</x><y>4</y><z>5</z></blockIdx></who>
+      <what><text>Invalid __global__ write of size 4 bytes: Access is out of bounds</text>
+        <space>__global__</space><size>4</size><direction>write</direction>
+        <error>out of bounds</error><address>0x1234</address></what>
+      <where><func>write_values</func><path>/project/src/kernel.cu</path>
+        <line>8</line><pc>0xe0</pc></where>
+      <hostStack><saveLocation>kernel launch time</saveLocation>
+        <frame><func>main</func><path>/project/src/main.cc</path><line>12</line>
+          <module>/project/build/app</module><pc>0x1</pc></frame></hostStack>
+      {unknown}
+    </record>
+    """
+
+
+def _import(workspace: Workspace, source: Path) -> str:
+    return (
+        ImportService(workspace)
+        .import_artifact(
+            ImportArtifactRequest(
+                path=source,
+                kind=ArtifactKind.SANITIZER_REPORT,
+                producer="compute-sanitizer",
+                producer_version="2026.2.1",
+            )
+        )
+        .run.run_id
+    )
+
+
+def test_compute_sanitizer_extracts_precise_memory_findings(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "report.xml"
+    source.write_text(_report(_precise_record().replace("/project", str(tmp_path))))
+    run_id = _import(workspace, source)
+
+    result = ComputeSanitizerExtractor(workspace).extract(run_id)
+    repeated = ComputeSanitizerExtractor(workspace).extract(run_id)
+
+    assert result.status == "findings"
+    assert result.finding_count == 1
+    assert result.classifications == {"memory_access": 1}
+    assert result.limitations == ()
+    assert repeated.corpus_commit_id == result.corpus_commit_id
+    with Catalog(workspace).open_snapshot() as snapshot:
+        rows = snapshot.execute(
+            "SELECT name, file, line_from, value_json FROM observations "
+            "WHERE kind = 'sanitizer.finding'"
+        ).fetchall()
+    assert rows[0][:3] == ("memory_access", "src/kernel.cu", 8)
+    assert '"thread":{"x":0,"y":1,"z":2}' in rows[0][3]
+
+
+def test_compute_sanitizer_accepts_clean_empty_report(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "clean.xml"
+    source.write_text('<?xml version="1.0"?><ComputeSanitizerOutput/>')
+
+    result = ComputeSanitizerExtractor(workspace).extract(_import(workspace, source))
+
+    assert result.status == "clean"
+    assert result.finding_count == 0
+
+
+def test_compute_sanitizer_reports_unknown_record_shapes(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "unknown.xml"
+    source.write_text(_report(_precise_record(unknown="<futureField>value</futureField>")))
+
+    result = ComputeSanitizerExtractor(workspace).extract(_import(workspace, source))
+
+    assert result.finding_count == 1
+    assert "Unknown Compute Sanitizer record element: futureField." in result.limitations
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        "<ComputeSanitizerOutput><record>",
+        "<OtherOutput/>",
+        '<!DOCTYPE x [<!ENTITY boom "x">]><ComputeSanitizerOutput>&boom;</ComputeSanitizerOutput>',
+        "<!--" + ("padding" * 800) + "-->"
+        '<!DOCTYPE x [<!ENTITY boom "x">]><ComputeSanitizerOutput>&boom;</ComputeSanitizerOutput>',
+    ),
+    ids=("truncated", "wrong-root", "entity", "entity-after-prefix"),
+)
+def test_compute_sanitizer_rejects_malformed_or_unsafe_xml(
+    tmp_path: Path,
+    payload: str,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "bad.xml"
+    source.write_text(payload)
+    run_id = _import(workspace, source)
+
+    with pytest.raises(DomainError) as error:
+        ComputeSanitizerExtractor(workspace).extract(run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_compute_sanitizer_uses_record_kind_before_message_substrings(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "async.xml"
+    source.write_text(
+        _report(
+            _precise_record().replace(
+                "Invalid __global__ write of size 4 bytes: Access is out of bounds",
+                "Invalid asynchronous memory copy API access",
+            )
+        )
+    )
+
+    result = ComputeSanitizerExtractor(workspace).extract(_import(workspace, source))
+
+    assert result.classifications == {"memory_access": 1}
+
+
+@pytest.mark.parametrize(
+    ("kind", "message", "classification"),
+    (
+        ("Api", "CUDA API call failed", "api_error"),
+        ("Sanitizer", "Sanitizer internal error", "sanitizer_error"),
+        ("Race", "Write-after-write hazard", "race"),
+        ("Initcheck", "Uninitialized global read", "uninitialized_memory"),
+        ("Synccheck", "Barrier divergence", "synchronization"),
+    ),
+)
+def test_compute_sanitizer_classifies_known_record_kinds(
+    tmp_path: Path,
+    kind: str,
+    message: str,
+    classification: str,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "known.xml"
+    record = _precise_record().replace("<kind>Precise</kind>", f"<kind>{kind}</kind>")
+    record = record.replace(
+        "Invalid __global__ write of size 4 bytes: Access is out of bounds",
+        message,
+    )
+    source.write_text(_report(record))
+
+    result = ComputeSanitizerExtractor(workspace).extract(_import(workspace, source))
+
+    assert result.classifications == {classification: 1}
+
+
+def test_compute_sanitizer_truncates_records_at_publication_budget(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    config = workspace.config.model_copy(
+        update={
+            "storage": workspace.config.storage.model_copy(update={"max_rows_per_generation": 4})
+        }
+    )
+    workspace.paths.config.write_text(config.to_toml())
+    source = tmp_path / "many.xml"
+    source.write_text(
+        _report(
+            _precise_record(),
+            _precise_record(),
+            _precise_record(),
+            _precise_record(),
+        )
+    )
+
+    result = ComputeSanitizerExtractor(workspace).extract(_import(workspace, source))
+
+    assert result.finding_count == 3
+    assert "Sanitizer records were truncated to 3 entries." in result.limitations
+
+
+def test_compute_sanitizer_options_are_strict_and_bind_suppression_digest(
+    tmp_path: Path,
+) -> None:
+    suppression = tmp_path / "tools" / "sanitizer.supp"
+    suppression.parent.mkdir()
+    suppression.write_text("# fixture\n")
+
+    bound = bind_adapter_options(
+        "compute-sanitizer",
+        {
+            "tool": "racecheck",
+            "launch_skip": 2,
+            "launch_count": 3,
+            "target_processes": "all",
+            "target_processes_filter": "regex:worker-[0-9]+",
+            "kernel_name": "kernel_substring=attention",
+            "demangle": "simple",
+            "suppression_file": "tools/sanitizer.supp",
+        },
+        project_root=tmp_path,
+    )
+
+    assert bound["suppression_file"] == "tools/sanitizer.supp"
+    assert str(bound["suppression_digest"]).startswith("sha256:")
+    invocation = build_capture_invocation(
+        "compute-sanitizer",
+        ("python", "kernel.py"),
+        tmp_path / "output",
+        executable="/opt/cuda/bin/compute-sanitizer",
+        options=cast(dict[str, object], bound),
+        project_root=tmp_path,
+    )
+    assert invocation.argv == (
+        "/opt/cuda/bin/compute-sanitizer",
+        "--tool",
+        "racecheck",
+        "--xml",
+        "--save",
+        str(tmp_path / "output" / "compute-sanitizer.xml"),
+        "--error-exitcode",
+        "86",
+        "--launch-skip",
+        "2",
+        "--launch-count",
+        "3",
+        "--target-processes",
+        "all",
+        "--demangle",
+        "simple",
+        "--target-processes-filter",
+        "regex:worker-[0-9]+",
+        "--kernel-name",
+        "kernel_substring=attention",
+        "--suppressions",
+        str(suppression),
+        "python",
+        "kernel.py",
+    )
+    suppression.write_text("# changed after planning\n")
+    with pytest.raises(DomainError) as changed:
+        build_capture_invocation(
+            "compute-sanitizer",
+            ("python", "kernel.py"),
+            tmp_path / "output",
+            executable="/opt/cuda/bin/compute-sanitizer",
+            options=cast(dict[str, object], bound),
+            project_root=tmp_path,
+        )
+    assert changed.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+    with pytest.raises(DomainError) as error:
+        bind_adapter_options(
+            "compute-sanitizer",
+            {"arbitrary_flag": "--destroy-on-device-error=kernel"},
+            project_root=tmp_path,
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+@pytest.mark.anyio
+async def test_compute_sanitizer_rejects_suppression_changed_after_planning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sanitizer = tmp_path / "fake-compute-sanitizer"
+    marker = tmp_path / "sanitizer-ran"
+    sanitizer.write_text(f"#!/bin/sh\ntouch {marker}\n")
+    sanitizer.chmod(sanitizer.stat().st_mode | stat.S_IXUSR)
+    suppression = tmp_path / "sanitizer.supp"
+    suppression.write_text("# planned bytes\n")
+    (tmp_path / "flameox.toml").write_text(
+        "schema_version = 1\n[workloads.probe]\nargv = ['/bin/true']\ncwd = '.'\n"
+    )
+    workspace = Workspace.initialize(tmp_path)
+    disable_containment(workspace)
+    capability = CapabilityReport(
+        adapter="compute-sanitizer",
+        status=CapabilityStatus.AVAILABLE,
+        executable=str(sanitizer),
+        version="fixture",
+        supported_modes=("memcheck", "racecheck", "initcheck", "synccheck"),
+        supported_formats=("compute-sanitizer-xml",),
+        permission_status="granted",
+        probe_kind="active",
+    )
+    service = CaptureService(workspace)
+    monkeypatch.setattr(service.capabilities, "get", lambda _adapter: capability)
+
+    async def probe(_adapter: str, *, refresh: bool = False) -> CapabilityReport:
+        assert refresh
+        return capability
+
+    monkeypatch.setattr(service.capabilities, "probe", probe)
+    plan = await service.plan(
+        workload_name="probe",
+        adapter="compute-sanitizer",
+        adapter_options={"suppression_file": "sanitizer.supp"},
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    suppression.write_text("# bytes changed after authorization\n")
+
+    with pytest.raises(DomainError) as changed:
+        await service.execute(plan.plan_id)
+    assert changed.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+    assert not marker.exists()
+
+
+def test_compute_sanitizer_rejects_suppression_escape_and_symlink(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside.supp"
+    outside.write_text("fixture")
+    with pytest.raises(DomainError):
+        bind_adapter_options(
+            "compute-sanitizer",
+            {"suppression_file": "../outside.supp"},
+            project_root=tmp_path,
+        )
+    link = tmp_path / "linked.supp"
+    link.symlink_to(outside)
+    with pytest.raises(DomainError):
+        bind_adapter_options(
+            "compute-sanitizer",
+            {"suppression_file": "linked.supp"},
+            project_root=tmp_path,
+        )

--- a/tests/adapters/test_compute_sanitizer_live.py
+++ b/tests/adapters/test_compute_sanitizer_live.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters.compute_sanitizer import ComputeSanitizerExtractor
+from flameox.application import (
+    CaptureService,
+    ExecutionPolicy,
+    ImportArtifactRequest,
+    ImportService,
+)
+from flameox.domain import ArtifactKind, ExecutionStatus, ValidationStatus
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_live_compute_sanitizer_clean_and_out_of_bounds_reports(tmp_path: Path) -> None:
+    sanitizer = shutil.which("compute-sanitizer")
+    nvcc = shutil.which("nvcc")
+    if sanitizer is None or nvcc is None:
+        pytest.skip("Compute Sanitizer live proof requires compute-sanitizer and nvcc")
+    executable = tmp_path / "kernel-probe"
+    subprocess.run(
+        (
+            nvcc,
+            "-lineinfo",
+            "-arch=sm_86",
+            str(PROJECT_ROOT / "tests" / "fixtures" / "compute_sanitizer" / "kernel_probe.cu"),
+            "-o",
+            str(executable),
+        ),
+        check=True,
+        timeout=60,
+    )
+    workspace = Workspace.initialize(tmp_path)
+
+    def collect(name: str, *arguments: str) -> tuple[int, int]:
+        report = tmp_path / f"{name}.xml"
+        process = subprocess.run(
+            (
+                sanitizer,
+                "--tool",
+                "memcheck",
+                "--xml",
+                "--save",
+                str(report),
+                "--error-exitcode",
+                "86",
+                "--target-processes",
+                "application-only",
+                str(executable),
+                *arguments,
+            ),
+            check=False,
+            capture_output=True,
+            timeout=60,
+        )
+        imported = ImportService(workspace).import_artifact(
+            ImportArtifactRequest(
+                path=report,
+                kind=ArtifactKind.SANITIZER_REPORT,
+                producer="compute-sanitizer",
+                producer_version="live",
+            )
+        )
+        extracted = ComputeSanitizerExtractor(workspace).extract(imported.run.run_id)
+        return process.returncode, extracted.finding_count
+
+    assert collect("clean") == (0, 0)
+    finding_exit, finding_count = collect("out-of-bounds", "oob")
+    assert finding_exit == 86
+    assert finding_count > 0
+
+
+@pytest.mark.anyio
+async def test_live_compute_sanitizer_wrapper_preserves_finding_as_validation(
+    tmp_path: Path,
+) -> None:
+    sanitizer = shutil.which("compute-sanitizer")
+    nvcc = shutil.which("nvcc")
+    if sanitizer is None or nvcc is None:
+        pytest.skip("Compute Sanitizer live proof requires compute-sanitizer and nvcc")
+    executable = tmp_path / "kernel-probe"
+    subprocess.run(
+        (
+            nvcc,
+            "-lineinfo",
+            "-arch=sm_86",
+            str(PROJECT_ROOT / "tests" / "fixtures" / "compute_sanitizer" / "kernel_probe.cu"),
+            "-o",
+            str(executable),
+        ),
+        check=True,
+        timeout=60,
+    )
+    workspace = Workspace.initialize(tmp_path)
+    (tmp_path / "flameox.toml").write_text(
+        "schema_version = 1\n"
+        "[workloads.out_of_bounds]\n"
+        f"argv = [{str(executable)!r}, 'oob']\n"
+        "cwd = '.'\n"
+        "timeout_seconds = 30\n"
+    )
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="out_of_bounds",
+        adapter="compute-sanitizer",
+        adapter_options={"tool": "memcheck", "finding_exit_code": 86},
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    result = await service.execute(plan.plan_id)
+
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.validation_status is ValidationStatus.FAILED
+    report = next(
+        item for item in result.run.artifacts if item.kind is ArtifactKind.SANITIZER_REPORT
+    )
+    extracted = ComputeSanitizerExtractor(workspace).extract(result.run.run_id)
+    assert extracted.artifact_id == report.artifact_id
+    assert extracted.finding_count > 0

--- a/tests/adapters/test_kernel_validation.py
+++ b/tests/adapters/test_kernel_validation.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from flameox.adapters.kernel_validation import (
+    KernelValidationExtractor,
+    KernelValidationV1,
+    kernel_validation_json_schema,
+)
+from flameox.application import ImportArtifactRequest, ImportService
+from flameox.catalog import Catalog
+from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.storage import Workspace
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _document() -> dict[str, Any]:
+    return {
+        "schema_version": "flameox.kernel-validation.v1",
+        "producer": "kernel-tests",
+        "producer_version": "1.2.3",
+        "reference": {
+            "name": "torch.reference",
+            "version": "2.9",
+            "identity": "sha256:" + "a" * 64,
+        },
+        "status": "pass",
+        "coverage_complete": True,
+        "cases": [
+            {
+                "case_id": "square-fp32-128",
+                "dimensions": {"size": 128, "transposed": False},
+                "inputs": {"left": {"dtype": "float32", "shape": [128, 128], "role": "input"}},
+                "seed": 42,
+                "device": "cuda:0-sm86",
+                "status": "pass",
+                "outputs": [
+                    {
+                        "name": "result",
+                        "dtype": "float32",
+                        "shape": [128, 128],
+                        "status": "pass",
+                        "metrics": [
+                            {
+                                "name": "max_abs_error",
+                                "value": 0.0001,
+                                "comparator": "<=",
+                                "threshold": 0.001,
+                                "unit": "absolute",
+                                "status": "pass",
+                            },
+                            {
+                                "name": "cosine_similarity",
+                                "value": 0.9999,
+                                "comparator": ">=",
+                                "threshold": 0.999,
+                                "unit": "ratio",
+                                "status": "pass",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _import(workspace: Workspace, path: Path) -> str:
+    return (
+        ImportService(workspace)
+        .import_artifact(ImportArtifactRequest(path=path, kind=ArtifactKind.VALIDATION_OUTPUT))
+        .run.run_id
+    )
+
+
+def test_kernel_validation_round_trips_and_extracts_idempotently(tmp_path: Path) -> None:
+    document = KernelValidationV1.model_validate(_document())
+    assert KernelValidationV1.model_validate_json(document.model_dump_json()) == document
+    assert kernel_validation_json_schema()["additionalProperties"] is False
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "validation.json"
+    source.write_text(document.model_dump_json())
+    run_id = _import(workspace, source)
+
+    result = KernelValidationExtractor(workspace).extract(run_id)
+    repeated = KernelValidationExtractor(workspace).extract(run_id)
+
+    assert result.status == "pass"
+    assert result.case_count == 1
+    assert result.output_count == 1
+    assert result.metric_count == 2
+    assert repeated.corpus_commit_id == result.corpus_commit_id
+    with Catalog(workspace).open_snapshot() as snapshot:
+        cases = snapshot.execute(
+            "SELECT case_id, output_name, shape FROM kernel_validation_cases"
+        ).fetchall()
+        metrics = snapshot.execute(
+            "SELECT metric_name, comparator, status FROM kernel_validation_metrics "
+            "ORDER BY metric_name"
+        ).fetchall()
+    assert cases == [("square-fp32-128", "result", [128, 128])]
+    assert metrics == [
+        ("cosine_similarity", ">=", "pass"),
+        ("max_abs_error", "<=", "pass"),
+    ]
+
+
+def test_published_kernel_validation_schema_matches_the_model() -> None:
+    published = json.loads(
+        (
+            PROJECT_ROOT / "src" / "flameox" / "schemas" / "kernel-validation-v1.schema.json"
+        ).read_text()
+    )
+
+    assert published == kernel_validation_json_schema()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    (
+        (lambda value: value.update(status="fail"), "document status contradicts"),
+        (
+            lambda value: value["cases"][0]["outputs"][0]["metrics"][0].update(comparator=">="),
+            "requires comparator",
+        ),
+        (
+            lambda value: value["cases"][0]["outputs"][0]["metrics"][0].update(value=float("nan")),
+            "must be finite",
+        ),
+        (
+            lambda value: value.update(coverage_complete=False),
+            "document status contradicts",
+        ),
+    ),
+)
+def test_kernel_validation_rejects_contradictory_or_nonfinite_documents(
+    mutation: object,
+    match: str,
+) -> None:
+    payload = _document()
+    assert callable(mutation)
+    mutation(payload)
+
+    with pytest.raises(ValidationError, match=match):
+        KernelValidationV1.model_validate(payload)
+
+
+def test_kernel_validation_failed_output_requires_bounded_examples() -> None:
+    payload = _document()
+    metric = payload["cases"][0]["outputs"][0]["metrics"][0]
+    metric.update(value=0.1, status="fail")
+    payload["cases"][0]["outputs"][0].update(status="fail")
+    payload["cases"][0].update(status="fail")
+    payload.update(status="fail")
+
+    with pytest.raises(ValidationError, match="representative failure"):
+        KernelValidationV1.model_validate(payload)
+
+    payload["cases"][0]["outputs"][0]["representative_failures"] = [
+        {"coordinates": [3, 7], "expected": 1.0, "actual": 1.1, "absolute_error": 0.1}
+    ]
+    assert KernelValidationV1.model_validate(payload).status == "fail"
+
+
+def test_kernel_validation_extractor_rejects_unknown_schema(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    source = tmp_path / "validation.json"
+    payload = _document()
+    payload["schema_version"] = "flameox.kernel-validation.v2"
+    source.write_text(json.dumps(payload))
+    run_id = _import(workspace, source)
+
+    with pytest.raises(DomainError) as error:
+        KernelValidationExtractor(workspace).extract(run_id)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_kernel_validation_does_not_allow_passing_without_metric_evidence() -> None:
+    payload = _document()
+    payload["cases"][0]["outputs"][0]["metrics"] = []
+
+    with pytest.raises(ValidationError, match="without metrics"):
+        KernelValidationV1.model_validate(payload)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        lambda payload: payload["cases"][0].update(seed=2**63),
+        lambda payload: payload["cases"][0]["inputs"]["left"].update(shape=[2**63]),
+        lambda payload: payload["cases"][0]["outputs"][0].update(shape=[2**63]),
+    ),
+)
+def test_kernel_validation_rejects_values_outside_evidence_int64(
+    mutation: object,
+) -> None:
+    payload = _document()
+    assert callable(mutation)
+    mutation(payload)
+
+    with pytest.raises(ValidationError):
+        KernelValidationV1.model_validate(payload)

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 891
+expected_test_count = 923
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -33,11 +33,14 @@ expected_test_count = 891
 'tests/analysis/test_recipes.py' = '87ea564890d57d16d9e6303089121662be325905ff4ee485d489c8efeb8d6d7e'
 'tests/application/test_records_and_comparisons.py' = 'd052ad24e744c16d0058b1c01ab76a18d84bce0729d63cf824d5cd23046d0759'
 'tests/application/test_workloads_and_capture.py' = '3213ed7c619a233587e807d4e79f8601291762645e5c985aba68f632590e5d73'
-'tests/mcp/test_server.py' = '195b3514597eaa57d6ad818b76b4c3795d50a9313ab33ccecd151e4bc99a62b5'
+'tests/mcp/test_server.py' = 'b2cd9e86fd2bad216eb66541772b52bed480839fd7a69d63b8bc2890401a64f3'
 'tests/test_cli_setup.py' = '2e1c3a607b7b4cefecb44f98c88c2e65ccbc0afaae39201c2c443eef0204c561'
 
 [files]
 'tests/adapters/test_benchmark_samples.py' = { count = 8, digest = '71e398543a29c75f059be8b1ba659ee80952b9407ef0295b7fa9bfe736ad05d3' }
+'tests/adapters/test_compute_sanitizer.py' = { count = 17, digest = '0a44b26ba1816dee25ceb541819e23c8f64fc5f833efdd4d53a40750e4de14e6' }
+'tests/adapters/test_compute_sanitizer_live.py' = { count = 2, digest = 'ed25601a0ea6a107634c87cde1bf6c7ead550feeb1dc9dfa74c7852966e691cc' }
+'tests/adapters/test_kernel_validation.py' = { count = 12, digest = '86a12a5fb7f6a3cf94a68be67fd68cb1ea34736f5be7a68a7bee2b9145bf0f37' }
 'tests/adapters/test_inference_artifacts.py' = { count = 86, digest = '9a9ccc9c7cfa6204fa5dc02a04b1b23c4899b5b719ed98ce846608d80a43d739' }
 'tests/adapters/test_coverage.py' = { count = 3, digest = 'a9aa85687b6f34101ebcf2d6b69c22c866f9279436bdb9cbaff2793dba714891' }
 'tests/adapters/test_memray.py' = { count = 3, digest = '929b943d44dd1e64914730a760870fb7f87154c0a036e7d6ef355ce42d858c66' }
@@ -105,7 +108,7 @@ expected_test_count = 891
 'tests/golden/test_memory_regression.py' = { count = 1, digest = '7898013cd64ec203e28d00b6549f002586a2d23f0c06eba6f1c979478f1aac1e' }
 'tests/golden/test_reverse_scan.py' = { count = 1, digest = '11e8db62d67d86b3e2be63a8e3425dbd7927329f4d405a3d6718251286a20bea' }
 'tests/mcp/test_agent_workflows.py' = { count = 7, digest = '1267ceb6cd3cdff4940461e8bcc50ce81e43c44815f6da85e947540e4395e5bd' }
-'tests/mcp/test_server.py' = { count = 48, digest = '195b3514597eaa57d6ad818b76b4c3795d50a9313ab33ccecd151e4bc99a62b5' }
+'tests/mcp/test_server.py' = { count = 49, digest = 'b2cd9e86fd2bad216eb66541772b52bed480839fd7a69d63b8bc2890401a64f3' }
 'tests/collectors/test_torch_launcher.py' = { count = 1, digest = 'b875d2f61ff086520d190513676e50fd1e6cf7152a9697e7b3c3d61d360736a3' }
 'tests/performance/test_catalog_scale.py' = { count = 4, digest = '1c7587225525c2e0cc877bf62105c1d2447ec5d230e0a9d0eaef0ae7322e9214' }
 'tests/security/test_offline.py' = { count = 1, digest = 'a9de75a583146be9fccb27627ae4fdd6d6f3265912dad9423fe97415ba833fd3' }

--- a/tests/fixtures/compute_sanitizer/kernel_probe.cu
+++ b/tests/fixtures/compute_sanitizer/kernel_probe.cu
@@ -1,0 +1,26 @@
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+
+__global__ void write_values(int *values, int count, bool out_of_bounds) {
+    int index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index < count) {
+        values[index + (out_of_bounds ? count : 0)] = index;
+    }
+}
+
+int main(int argc, char **argv) {
+    constexpr int count = 32;
+    int *values = nullptr;
+    if (cudaMalloc(&values, count * sizeof(int)) != cudaSuccess) {
+        return 2;
+    }
+    write_values<<<1, count>>>(values, count, argc > 1);
+    cudaError_t status = cudaDeviceSynchronize();
+    cudaFree(values);
+    if (status != cudaSuccess) {
+        std::fprintf(stderr, "%s\n", cudaGetErrorString(status));
+        return 3;
+    }
+    return 0;
+}

--- a/tests/mcp/test_workflows.py
+++ b/tests/mcp/test_workflows.py
@@ -277,6 +277,87 @@ async def test_mcp_import_list_get_and_resource_workflow(tmp_path: Path) -> None
 
 
 @pytest.mark.anyio
+async def test_mcp_kernel_validation_extraction_reports_progress_and_resources(
+    tmp_path: Path,
+) -> None:
+    validation = {
+        "schema_version": "flameox.kernel-validation.v1",
+        "producer": "kernel-tests",
+        "producer_version": "1.0",
+        "reference": {"name": "cpu-reference", "identity": "reference-v1"},
+        "status": "pass",
+        "coverage_complete": True,
+        "cases": [
+            {
+                "case_id": "vector-add-fp32",
+                "dimensions": {"elements": 32},
+                "inputs": {"left": {"dtype": "float32", "shape": [32], "role": "input"}},
+                "device": "cuda:0-sm86",
+                "status": "pass",
+                "outputs": [
+                    {
+                        "name": "result",
+                        "dtype": "float32",
+                        "shape": [32],
+                        "status": "pass",
+                        "metrics": [
+                            {
+                                "name": "max_abs_error",
+                                "value": 0.0,
+                                "comparator": "<=",
+                                "threshold": 1e-6,
+                                "unit": "absolute",
+                                "status": "pass",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    (tmp_path / "validation.json").write_text(json.dumps(validation))
+    Workspace.initialize(tmp_path)
+    recorded_progress: list[tuple[float, float | None, str | None]] = []
+
+    async def record(progress: float, total: float | None, message: str | None) -> None:
+        recorded_progress.append((progress, total, message))
+
+    async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+        imported = await client.call_tool(
+            "import_artifact",
+            {
+                "path": "validation.json",
+                "kind": "validation_output",
+                "sensitivity": "internal",
+            },
+        )
+        assert imported.structured_content is not None
+        run_id = imported.structured_content["result"]["run_id"]
+        extracted = await client.call_tool(
+            "extract_kernel_validation",
+            {"run_id": run_id},
+            progress_callback=record,
+        )
+        run_resource = await client.read_resource(f"flameox://runs/{run_id}")
+
+    assert extracted.is_error is False
+    assert extracted.structured_content is not None
+    result = extracted.structured_content["result"]
+    assert result["status"] == "pass"
+    assert result["case_count"] == 1
+    assert [item[0] for item in recorded_progress] == [0, 1, 2]
+    assert {item[1] for item in recorded_progress} == {2}
+    assert all(item[2] for item in recorded_progress)
+    assert {item.uri for item in extracted.content if item.type == "resource_link"} == {
+        f"flameox://runs/{run_id}",
+        f"flameox://artifacts/{result['artifact_id']}",
+    }
+    contents = run_resource.contents[0]
+    assert isinstance(contents, TextResourceContents)
+    assert run_id in contents.text
+
+
+@pytest.mark.anyio
 async def test_mcp_run_discovery_filters_pages_and_rejects_stale_cursor(tmp_path: Path) -> None:
     for name in ("one.json", "two.json", "three.json"):
         (tmp_path / name).write_text(f'{{"name": "{name}"}}')

--- a/tests/ownership.toml
+++ b/tests/ownership.toml
@@ -23,11 +23,19 @@ markers = ["integration", "optional", "requires_memray"]
 owner = "adapters"
 lane = "adapters"
 paths = [
-  "tests/adapters/test_benchmark_samples.py",
-  "tests/adapters/test_pyperf.py",
+    "tests/adapters/test_benchmark_samples.py",
+    "tests/adapters/test_compute_sanitizer.py",
+    "tests/adapters/test_kernel_validation.py",
+    "tests/adapters/test_pyperf.py",
   "tests/adapters/test_python_startup.py",
 ]
 markers = ["unit"]
+
+[[ownership]]
+owner = "compute-sanitizer-live"
+lane = "adapters"
+paths = ["tests/adapters/test_compute_sanitizer_live.py"]
+markers = ["integration", "optional", "process", "serial", "requires_compute_sanitizer"]
 
 
 [[ownership]]

--- a/tests/support/providers.py
+++ b/tests/support/providers.py
@@ -15,6 +15,7 @@ PACKAGE_PROVIDERS = {
 EXECUTABLE_PROVIDERS = {
     "requires_bwrap": "bwrap",
     "requires_cargo": "cargo",
+    "requires_compute_sanitizer": "compute-sanitizer",
     "requires_perf": "perf",
     "requires_pyspy": "py-spy",
     "requires_systemd": "systemd-run",

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -144,7 +144,8 @@ def test_missing_base_selects_full_plan(monkeypatch: pytest.MonkeyPatch) -> None
     assert plan["full"] is True
     assert plan["fallback_reason"] == "missing_base_revision"
     assert plan["lanes"] == list(runner.TEST_LANES)
-    assert plan["optional_lanes"] == list(runner.PROVIDER_LANES)
+    assert plan["optional_lanes"] == list(runner.CI_PROVIDER_LANES)
+    assert set(plan["optional_lanes"]).isdisjoint(runner.GPU_PROVIDER_LANES)
 
 
 def _remove_schema_version(plan: dict[str, Any]) -> None:

--- a/tools/generate_contract_schemas.py
+++ b/tools/generate_contract_schemas.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from flameox.adapters.kernel_validation import kernel_validation_json_schema
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_ROOT = PROJECT_ROOT / "src" / "flameox" / "schemas"
+
+
+def main() -> None:
+    SCHEMA_ROOT.mkdir(parents=True, exist_ok=True)
+    schemas = {"kernel-validation-v1.schema.json": kernel_validation_json_schema()}
+    for filename, schema in schemas.items():
+        path = SCHEMA_ROOT / filename
+        path.write_text(
+            json.dumps(schema, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test.py
+++ b/tools/test.py
@@ -65,15 +65,25 @@ PLAN_KEYS = {
     "run_performance",
 }
 PROVIDER_LANES = {
+    "optional-compute-sanitizer": "optional and requires_compute_sanitizer",
     "optional-coverage": "optional and requires_coverage",
     "optional-memray": "optional and requires_memray",
     "optional-perfetto": "optional and requires_perfetto",
     "optional-pyspy": "optional and requires_pyspy",
     "optional-torch": "optional and requires_torch",
     "optional-host": (
-        "optional and not requires_coverage and not requires_memray "
+        "optional and not requires_compute_sanitizer and not requires_coverage "
+        "and not requires_memray "
         "and not requires_perfetto and not requires_pyspy and not requires_torch"
     ),
+}
+GPU_PROVIDER_LANES = frozenset({"optional-compute-sanitizer"})
+# GitHub-hosted runners do not provide CUDA GPUs. Keep the live lane available
+# as an explicit local command without emitting a job that can only skip.
+CI_PROVIDER_LANES = {
+    lane: expression
+    for lane, expression in PROVIDER_LANES.items()
+    if lane not in GPU_PROVIDER_LANES
 }
 TEST_LANES = (
     "core",
@@ -108,7 +118,7 @@ FULL_CHANGE_PATHS = {
     "tests/ownership.toml",
     "tests/collection-baseline.toml",
 }
-ALL_PLANNED_LANES = (*TEST_LANES, "performance", *PROVIDER_LANES)
+ALL_PLANNED_LANES = (*TEST_LANES, "performance", *CI_PROVIDER_LANES)
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
@@ -136,7 +146,7 @@ def topology_digest(records: tuple[Ownership, ...]) -> str:
         {
             "test_lanes": list(TEST_LANES),
             "coverage_lanes": list(COVERAGE_LANES),
-            "provider_lanes": PROVIDER_LANES,
+            "provider_lanes": CI_PROVIDER_LANES,
             "full_change_paths": sorted(FULL_CHANGE_PATHS),
             "ownership": [
                 {
@@ -217,7 +227,7 @@ def _matrix(value: object) -> dict[str, list[dict[str, str]]]:
         raw_items = matrix[field]
         if not isinstance(raw_items, list) or len(raw_items) > PLAN_MAX_MATRIX_ITEMS:
             raise PlanValidationError(f"matrix.{field} exceeds the provider bound")
-        allowed = set(TEST_LANES) if field == "lanes" else set(PROVIDER_LANES)
+        allowed = set(TEST_LANES) if field == "lanes" else set(CI_PROVIDER_LANES)
         items: list[dict[str, str]] = []
         seen: set[str] = set()
         for index, raw in enumerate(raw_items):
@@ -321,7 +331,7 @@ def _validate_plan_lanes(plan: Mapping[str, object]) -> list[str]:
         raise PlanValidationError("legacy lane fields do not match the matrix")
     if any(lane not in TEST_LANES for lane in lanes):
         raise PlanValidationError("lanes contains an unknown lane")
-    if any(lane not in PROVIDER_LANES for lane in optional_lanes):
+    if any(lane not in CI_PROVIDER_LANES for lane in optional_lanes):
         raise PlanValidationError("optional_lanes contains an unknown lane")
     return lanes
 
@@ -702,6 +712,7 @@ def affected_plan(  # noqa: C901
                 coverage = True
                 _reason_map_add(lane_reasons, record.lane, f"owned test path: {path}")
             provider_markers = (
+                ("requires_compute_sanitizer", "optional-compute-sanitizer"),
                 ("requires_coverage", "optional-coverage"),
                 ("requires_memray", "optional-memray"),
                 ("requires_perfetto", "optional-perfetto"),
@@ -711,13 +722,14 @@ def affected_plan(  # noqa: C901
             marked_provider = False
             for marker, provider_lane in provider_markers:
                 if marker in record.markers:
-                    optional_lanes.add(provider_lane)
                     marked_provider = True
-                    _reason_map_add(
-                        optional_reasons,
-                        provider_lane,
-                        f"owned provider test path: {path}",
-                    )
+                    if provider_lane in CI_PROVIDER_LANES:
+                        optional_lanes.add(provider_lane)
+                        _reason_map_add(
+                            optional_reasons,
+                            provider_lane,
+                            f"owned provider test path: {path}",
+                        )
             if "optional" in record.markers and not marked_provider:
                 optional_lanes.add("optional-host")
                 _reason_map_add(
@@ -731,7 +743,7 @@ def affected_plan(  # noqa: C901
 
     if full:
         lanes.update(TEST_LANES)
-        optional_lanes.update(PROVIDER_LANES)
+        optional_lanes.update(CI_PROVIDER_LANES)
         performance = True
         coverage = True
         npm = True
@@ -739,7 +751,7 @@ def affected_plan(  # noqa: C901
         for lane in TEST_LANES:
             _reason_map_add(lane_reasons, lane, f"conservative full plan: {reason}")
         _reason_map_add(lane_reasons, "performance", f"conservative full plan: {reason}")
-        for lane in PROVIDER_LANES:
+        for lane in CI_PROVIDER_LANES:
             _reason_map_add(optional_reasons, lane, f"conservative full plan: {reason}")
     elif coverage:
         for lane in COVERAGE_LANES:
@@ -747,7 +759,7 @@ def affected_plan(  # noqa: C901
             _reason_map_add(lane_reasons, lane, "coverage aggregation for affected tests")
 
     ordered_lanes = [lane for lane in TEST_LANES if lane in lanes]
-    ordered_optional = [lane for lane in PROVIDER_LANES if lane in optional_lanes]
+    ordered_optional = [lane for lane in CI_PROVIDER_LANES if lane in optional_lanes]
     fallback = _fallback_reason(fallback_reasons)
     selected = (
         [

--- a/uv.lock
+++ b/uv.lock
@@ -1088,6 +1088,7 @@ name = "flameox"
 version = "0.1.13"
 source = { editable = "." }
 dependencies = [
+    { name = "defusedxml" },
     { name = "anyio" },
     { name = "duckdb" },
     { name = "ijson" },
@@ -1175,6 +1176,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "defusedxml", specifier = ">=0.7.1,<0.8" },
     { name = "aiperf", marker = "extra == 'all'", specifier = ">=0.12,<0.13" },
     { name = "aiperf", marker = "extra == 'inference'", specifier = ">=0.12,<0.13" },
     { name = "anyio", specifier = ">=4.9,<5" },


### PR DESCRIPTION
## Description

Flameox can preserve trial verdicts and benchmark samples, but it could not retain bounded per-case numerical evidence for GPU kernel validation or collect NVIDIA Compute Sanitizer findings as first-class evidence.

This PR adds those two correctness layers while keeping the upstream tools authoritative.

Relates to #131.
Relates to #135.

## Approach

- Define the strict `flameox.kernel-validation.v1` contract, publish its generated JSON Schema, and extract case/output identities and declared metrics into additive Parquet tables.
- Add CLI and MCP extraction with typed structured results, progress, schema resources, and links to authoritative artifacts.
- Wrap the official `compute-sanitizer` CLI with closed options, fixed XML output, bounded isolated parsing, and preservation of stdout, stderr, reports, and failed attempts.
- Bind suppression-file bytes into capture identity. Execution reopens without following links, verifies the planned digest, stages a read-only copy, and rejects post-plan mutation before launching the tool.
- Keep native JSON/XML authoritative; normalized evidence remains rebuildable.

Suggested review order:

1. `src/flameox/adapters/kernel_validation.py` and the published schema
2. `src/flameox/adapters/compute_sanitizer.py` and its worker
3. capture planning/execution and evidence publication
4. CLI/MCP surfaces, tests, and adapter compatibility notes

## Commands run

```console
# Focused kernel-validation, Compute Sanitizer, and MCP tests: 42 passed
uv run python tools/test.py optional-compute-sanitizer
# 2 passed on the local NVIDIA host

uv run ruff check src tests tools
uv run ruff format --check src tests tools
uv run mypy src tests tools
uv run lint-imports
uv run python tools/test.py ownership
uv run python tools/test.py collection
```

The collection receipt covers 923 node IDs across 84 files. Both import-boundary contracts pass, and generated-schema regeneration leaves no diff.

## Compatibility

The evidence schema advances additively from 1.8 to 1.9. Historical generations receive typed empty validation views and are not rewritten.

Compute Sanitizer capture requires the official NVIDIA executable and a compatible CUDA GPU. Deterministic fixtures cover clean, malformed, truncated, unknown, and bounded-report behavior; the local provider lane also passed clean and intentional out-of-bounds kernels. GitHub-hosted CI runs the fixture and simulated-process coverage and does not schedule a GPU lane that could pass only by skipping.
