### PR TITLE
feat(adapters): add GPU benchmark and compiler evidence

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -427,6 +427,80 @@ out-of-bounds captures. Deterministic tests use synthetic XML and cover clean, m
 sanitizer, malformed, truncated, unknown, and oversized reports. Observed claims come from XML;
 classification and path normalization are deterministic derivations; no root cause is inferred.
 
++#### `nvbench`
+
+The NVBench integration targets the JSON schema and JSON-binary behavior verified at
+`NVIDIA/nvbench@c18488992e313240166f588b9ee4da3e0de76004`. NVBench is linked into each benchmark
+executable, so Flameox runs the declared benchmark directly and injects exactly one official
+output mode: `--jsonbin <path>` to preserve JSON plus binary samples, or `--json <path>` for
+JSON-only output. Existing JSON output arguments are rejected instead of being overridden.
+
+Provider import reads the bounded JSON first and selects only the `file/sample_times` and
+`file/sample_freqs` sidecars it declares. Relative paths must remain inside the JSON bundle;
+unknown file encodings, missing declarations, traversal, symlinks, hard links, duplicate paths,
+count/byte mismatches, and bundles over 100 members or the workspace byte quotas fail explicitly.
+The current binary encoding is little-endian float32, with element counts serialized by NVBench
+as decimal strings. JSON and sidecars remain unchanged and authoritative. Extraction publishes
+raw timing samples in seconds and frequency samples in hertz through the existing measurements
+table; derived benchmark conclusions are not synthesized.
+
+Deterministic fixtures are generated in `tests/adapters/test_nvbench.py` from the pinned upstream
+shape and contain only Flameox-authored metadata and float32 samples under the project MIT
+license. They cover nested sidecar paths, strict encodings, partial process output, integrity and
+quota failures, and idempotent extraction. A local build of the pinned official
+`nvbench.example.cpp17.stream` benchmark ran through the managed adapter on CUDA 13.3 and an
+`sm_86` RTX 3060. The live test preserved the JSON, timing and frequency float32 sidecars, and
+then published their samples idempotently. That build used GCC 15, which is newer than NVBench's
+published GCC 7–14 compatibility range, so it is observed local compatibility rather than a
+supported-version claim. Linux and Windows CUDA hosts are expected upstream platforms; GPU
+access, the benchmark's own CUDA compatibility, and workload-dependent benchmark overhead remain
+operator responsibilities. Flameox owns containment, quotas, cancellation, and artifact
+registration; NVBench owns the native bytes.
+
+Observed claims are benchmark/state identity, producer/schema versions, device index, declared
+sample type and count, and preserved float32 samples. Derived claims are stable measurement IDs,
+SI-unit labeling from the two documented hints, and bounded row counts. Inferred claims: none —
+samples alone do not establish correctness, representativeness, or a performance improvement.
+
+#### `triton.compiler` and `cute.compiler`
+
+Compiler capture uses only upstream dump controls. Triton support is verified against Triton
+`3.7.1` (`triton-lang/triton@f797708c0626e5f9840ca5b0a98790e2c7cb09ad`) with
+`TRITON_DUMP_DIR`, `TRITON_KERNEL_DUMP`, and optional `TRITON_REPRODUCER_PATH`. CuTe DSL controls
+and retained kinds were verified against CUTLASS `4.6.2`
+(`NVIDIA/cutlass@6c65a175668952f09bcbf66cb97a8de1b734b4a0`) using
+`CUTE_DSL_DUMP_DIR` and the documented `CUTE_DSL_KEEP` tokens. Conflicting workload environment
+values are rejected unless identical. Flameox never deletes or rewrites a compiler cache.
+
+The wrappers run the named workload directly, inventory only allowlisted native files inside the
+staging root, enforce the shared 100-member and byte quotas, and atomically write a strict
+`flameox.kernel-build.v1` manifest even when compilation fails. TTIR, TTGIR, LLVM IR, PTX,
+AMDGCN, SASS, CUBIN, HSACO, metadata, debug IR, and reproducers remain immutable native
+artifacts; Flameox does not parse or translate them. The manifest records deterministic inventory
+stages, artifact integrity, producer/workload identity, cache status when known, normalized
+official environment values, diagnostics, and limitations. Import verifies declared size and
+digest through the shared bounded bundle importer and registers the result in the existing
+`ArtifactPipeline` service, enabling the existing comparison path rather than a second compiler
+pipeline store. Managed captures register that same pipeline directly. Provider dumps do not
+declare predecessor lineage, so Flameox leaves predecessor edges unset rather than deriving them
+from filenames or directories.
+
+A local `sm_86` run with Triton `3.7.1` produced and registered real compiler dumps through the
+managed adapter. Deterministic process tests cover both wrappers, failed compilation, missing
+output, environment conflicts, CuTe IR retention, absent lineage, containment, links, and
+reproducer handling. CUTLASS/CuTe DSL `4.6.2` was installed from its official CUDA 13 wheel, and
+the pinned official Ampere `call_bypass_dlpack.py` GEMM ran through the managed adapter on the
+same `sm_86` GPU. It verified its output against PyTorch and preserved MLIR, PTX, and SM86 CUBIN
+artifacts. Both integrations require a workload that actually invokes the matching compiler and
+a compatible accelerator/toolchain; compile and dump overhead is workload- and cache-dependent.
+The normal execution policy owns containment, staging, timeout, cancellation, and quotas.
+
+Observed claims are compiler exit status, preserved filenames/bytes/digests, producer version,
+and declared dump environment. Derived claims are deterministic inventory ordering, normalized
+staging paths, manifest outcome, and pipeline identity. Cache
+status remains `unknown` unless the producer supplies evidence. Inferred claims: none — an
+available stage does not prove semantic correctness, optimal code generation, or a cache hit.
+
 ### Candidate adapters
 
 - GDB/LLDB and elfutils for core metadata, with user init files, autoload, and

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -139,12 +139,16 @@ these actions runs a workload.
 flameox capture plan <adapter> --workload <name> [--parameters '<json>'] [--adapter-options '<json>']
 flameox capture run <adapter> --workload <name> [--parameters '<json>'] [--adapter-options '<json>']
 flameox import <path> [--kind KIND]
+flameox import-nvbench <path>
+flameox import-kernel-build <manifest>
 ```
 
 `capture plan` is side-effect free. `capture run` prints the plan before
 execution unless `--json` is used, in which case the plan is part of the result.
 Both commands require a named workload and reject `argv`, `cwd`, and trailing
 `-- <argv...>` arguments. Every import creates a new import run.
+Provider bundle imports select only files declared by the primary native
+document; the generic import remains single-file.
 
 ### Inference commands
 
@@ -239,6 +243,8 @@ flameox trace operation-window <artifact-id> --start NS --end NS
 flameox trace transitions <artifact-id> [--trace-id TRACE]
 flameox trace gaps <artifact-id>
 flameox extract otlp <run-id> [--artifact-id ARTIFACT]
+flameox pipelines register <request.json>
+flameox pipelines compare <baseline-pipeline-id> <candidate-pipeline-id>
 flameox open <artifact-id>
 ```
 
@@ -404,7 +410,7 @@ The supported tools are grouped as follows:
 | Family | Tools |
 | --- | --- |
 | Workspace | `initialize_workspace`, `workspace_status`, `workload_configuration_status`, `configure_workload`, `list_capabilities`, `start_capability_setup`, `get_capability_setup`, `cancel_capability_setup`, `prepare_adapter`, `prepare_workload_dependencies`, `validate_workspace` |
-| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `extract_benchmark_samples`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_nsight_systems`, `extract_kernel_validation`, `extract_compute_sanitizer`, `extract_observations` |
+| Capture and import | `plan_capture`, `execute_capture_plan`, `import_artifact`, `import_nvbench`, `import_kernel_build`, `extract_benchmark_samples`, `extract_pyperf`, `extract_python_startup`, `extract_pytest`, `extract_coverage`, `extract_memray`, `extract_perfetto`, `extract_nsight_systems`, `extract_kernel_validation`, `extract_compute_sanitizer`, `extract_nvbench`, `extract_observations` |
 | Detached capture | `start_detached_capture`, `get_detached_capture`, `cancel_detached_capture` |
 | Discovery | `list_declared_workflows`, `get_declared_workflow`, `list_runs`, `list_findings` |
 | Investigations | `create_investigation`, `list_investigations`, `get_investigation`, `record_hypothesis`, `get_hypothesis` |
@@ -821,7 +827,9 @@ flameox://experiments/{experiment_id}
 flameox://experiments/{experiment_id}/trials
 flameox://experiments/{experiment_id}/trials/{trial_id}
 flameox://run-sets/{run_set_id}
+flameox://pipelines/{pipeline_id}
 flameox://schemas/kernel-validation/v1
+flameox://schemas/kernel-build/v1
 ```
 
 Resources return JSON or text summaries. Large native artifacts are represented

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ markers = [
     "requires_systemd: requires a systemd user manager",
     "requires_toxiproxy: requires the pinned Toxiproxy server binary",
     "requires_torch: requires the optional PyTorch provider",
+    "requires_triton: requires the optional Triton provider and a compatible GPU",
+    "requires_nvbench: requires a configured NVBench benchmark executable and compatible GPU",
+    "requires_cute: requires the optional CuTe DSL provider and a compatible GPU",
 ]
 xfail_strict = true
 

--- a/src/flameox/adapters/__init__.py
+++ b/src/flameox/adapters/__init__.py
@@ -11,9 +11,11 @@ if TYPE_CHECKING:
     from flameox.adapters.compute_sanitizer import *  # noqa: F403
     from flameox.adapters.coverage import *  # noqa: F403
     from flameox.adapters.inference import *  # noqa: F403
+    from flameox.adapters.kernel_build import *  # noqa: F403
     from flameox.adapters.kernel_validation import *  # noqa: F403
     from flameox.adapters.memray import *  # noqa: F403
     from flameox.adapters.nsight_systems import *  # noqa: F403
+    from flameox.adapters.nvbench import *  # noqa: F403
     from flameox.adapters.observations import *  # noqa: F403
     from flameox.adapters.options import *  # noqa: F403
     from flameox.adapters.perfetto import *  # noqa: F403
@@ -32,9 +34,11 @@ _MODULES = (
     "compute_sanitizer",
     "coverage",
     "inference",
+    "kernel_build",
     "kernel_validation",
     "memray",
     "nsight_systems",
+    "nvbench",
     "observations",
     "options",
     "perfetto",
@@ -49,6 +53,7 @@ _MODULES = (
 
 __all__ = [
     "ALL_SETUP_CLIENTS",
+    "KERNEL_BUILD_SCHEMA_VERSION",
     "AIPerfCorrelationSummary",
     "AIPerfInputsIndex",
     "AIPerfRecordParser",
@@ -67,8 +72,13 @@ __all__ = [
     "ComputeSanitizerOptions",
     "CoverageExtractionResult",
     "CoverageExtractor",
+    "CuteCompilerOptions",
+    "CuteDslKeepToken",
     "InferenceArtifactExtractor",
     "InferenceExtractionResult",
+    "KernelBuildArtifact",
+    "KernelBuildManifestV1",
+    "KernelBuildStage",
     "KernelValidationExtractionResult",
     "KernelValidationExtractor",
     "KernelValidationV1",
@@ -81,6 +91,13 @@ __all__ = [
     "MooncakeTraceSummary",
     "NsightSystemsExtractionResult",
     "NsightSystemsExtractor",
+    "NvbenchBenchmark",
+    "NvbenchExtractionResult",
+    "NvbenchExtractor",
+    "NvbenchJsonDocument",
+    "NvbenchOptions",
+    "NvbenchState",
+    "NvbenchSummary",
     "ObservationExtractionResult",
     "ObservationExtractor",
     "PerfettoExtractionResult",
@@ -105,6 +122,7 @@ __all__ = [
     "TraceEvent",
     "TraceProcessorInstallation",
     "TraceWindowResult",
+    "TritonCompilerOptions",
     "VllmAggregateMetrics",
     "VllmMeasurementRow",
     "VllmResultDocument",
@@ -112,6 +130,7 @@ __all__ = [
     "WholeEntrypointTorchProfilerOptions",
     "bind_adapter_options",
     "install_trace_processor",
+    "kernel_build_json_schema",
 ]
 
 

--- a/src/flameox/adapters/builtins.py
+++ b/src/flameox/adapters/builtins.py
@@ -10,6 +10,9 @@ from flameox.adapters.options import (
     adapter_accepts_options,
     compute_sanitizer_options,
     compute_sanitizer_suppression_path,
+    cute_compiler_options,
+    nvbench_options,
+    triton_compiler_options,
 )
 from flameox.adapters.torch_profiler import SdkTorchProfilerOptions, torch_profiler_options
 from flameox.domain import ArtifactKind, DomainError, ErrorCode
@@ -251,6 +254,84 @@ BUILTIN_ADAPTERS = {
             preserve_artifact_on_nonzero=True,
         ),
         BuiltinAdapter(
+            name="nvbench",
+            dependency_kind="internal",
+            dependency=None,
+            supported_modes=("benchmark",),
+            supported_formats=("nvbench-json", "nvbench-jsonbin"),
+            features=("gpu_benchmark", "sample_times", "sample_freqs"),
+            remediation=(
+                "Build the benchmark executable with NVBench linked "
+                "(nvbench::main or NVBENCH_MAIN); verify CUDA toolkit and GPU access.",
+            ),
+            version_args=("--version",),
+            supported_platforms=("linux",),
+            output_filename="nvbench.json",
+            artifact_kinds=(ArtifactKind.BENCHMARK_SAMPLES,),
+            expected_overhead=(
+                "GPU benchmark with configurable stopping criterion and sample count."
+            ),
+            capture_limitations=(
+                "NVBench is linked into each benchmark executable; "
+                "the workload argv[0] is the benchmark binary, not a wrapper.",
+                "The adapter injects --jsonbin (or --json) into the declared argv; "
+                "pre-existing --json or --jsonbin flags are rejected as conflicts.",
+                "NVBench JSON schema is versioned; extraction is bounded to documented fields.",
+                "Binary sidecars store sample data as little-endian float32.",
+                "Warm-up samples are not separated in the jsonbin sidecar data.",
+            ),
+            preserve_artifact_on_nonzero=True,
+        ),
+        BuiltinAdapter(
+            name="triton.compiler",
+            dependency_kind="internal",
+            dependency=None,
+            supported_modes=("env_dump",),
+            supported_formats=("ttir", "ttgir", "llir", "ptx", "cubin"),
+            features=("compiler_ir", "ptx", "cubin"),
+            remediation=(
+                "Install Triton and ensure the workload invokes triton.compile or "
+                "@triton.jit kernels.",
+            ),
+            output_filename="kernel-build.json",
+            artifact_kinds=(ArtifactKind.KERNEL_BUILD,),
+            expected_overhead=(
+                "Env-var dump adds per-kernel IR emission overhead; no separate process is "
+                "launched."
+            ),
+            capture_limitations=(
+                "Only TRITON_DUMP_DIR, TRITON_KERNEL_DUMP, and TRITON_REPRODUCER_PATH are set; "
+                "the broker runs the workload directly.",
+                "Only allowlisted native extensions are inventoried; unknown files are ignored.",
+                "The manifest is emitted after success or compiler nonzero exit.",
+            ),
+            preserve_artifact_on_nonzero=True,
+        ),
+        BuiltinAdapter(
+            name="cute.compiler",
+            dependency_kind="internal",
+            dependency=None,
+            supported_modes=("env_dump",),
+            supported_formats=("cute_dsl_ir", "ptx", "cubin"),
+            features=("compiler_ir", "ptx", "cubin"),
+            remediation=(
+                "Install CuTe DSL and ensure the workload invokes cute.compiler kernels.",
+            ),
+            output_filename="kernel-build.json",
+            artifact_kinds=(ArtifactKind.KERNEL_BUILD,),
+            expected_overhead=(
+                "Env-var dump adds per-kernel IR emission overhead; no separate process is "
+                "launched."
+            ),
+            capture_limitations=(
+                "Only CUTE_DSL_DUMP_DIR and CUTE_DSL_KEEP are set; the broker runs the workload "
+                "directly.",
+                "Only allowlisted native extensions matching CUTE_DSL_KEEP are inventoried.",
+                "The manifest is emitted after success or compiler nonzero exit.",
+            ),
+            preserve_artifact_on_nonzero=True,
+        ),
+        BuiltinAdapter(
             name="coverage",
             dependency_kind="package",
             dependency="coverage",
@@ -362,6 +443,28 @@ def build_capture_invocation(
             options=options,
             project_root=project_root,
         )
+    elif adapter_name == "nvbench":
+        return _nvbench_capture_invocation(
+            adapter,
+            workload_argv,
+            output,
+            executable=executable,
+            options=options,
+        )
+    elif adapter_name == "triton.compiler":
+        return _triton_compiler_capture_invocation(
+            adapter,
+            workload_argv,
+            output_root,
+            options=options,
+        )
+    elif adapter_name == "cute.compiler":
+        return _cute_compiler_capture_invocation(
+            adapter,
+            workload_argv,
+            output_root,
+            options=options,
+        )
     elif adapter_name == "pyperf":
         python, _ = _python_target(workload_argv)
         argv = (
@@ -419,68 +522,6 @@ def build_capture_invocation(
         limitations=limitations,
         environment=environment,
     )
-
-
-def _compute_sanitizer_capture_invocation(
-    adapter: BuiltinAdapter,
-    workload_argv: tuple[str, ...],
-    output: str,
-    *,
-    executable: str | None,
-    options: dict[str, object] | None,
-    project_root: Path | None,
-) -> CaptureInvocation:
-    selected = compute_sanitizer_options(options)
-    argv_parts: list[str] = [
-        _require_executable(adapter.name, executable),
-        "--tool",
-        selected.tool,
-        "--xml",
-        "--save",
-        output,
-        "--error-exitcode",
-        str(selected.finding_exit_code),
-        "--launch-skip",
-        str(selected.launch_skip),
-        "--launch-count",
-        str(selected.launch_count),
-        "--target-processes",
-        selected.target_processes,
-        "--demangle",
-        selected.demangle,
-    ]
-    if selected.target_processes_filter is not None:
-        argv_parts.extend(("--target-processes-filter", selected.target_processes_filter))
-    if selected.kernel_name is not None:
-        argv_parts.extend(("--kernel-name", selected.kernel_name))
-    suppression = compute_sanitizer_suppression_path(
-        selected,
-        project_root=project_root or Path.cwd(),
-    )
-    if suppression is not None:
-        argv_parts.extend(("--suppressions", str(suppression)))
-    return CaptureInvocation(
-        argv=(*argv_parts, *workload_argv),
-        artifact_kinds=adapter.artifact_kinds,
-        expected_overhead=adapter.expected_overhead or "",
-        limitations=adapter.capture_limitations,
-        environment={},
-    )
-
-
-def replace_compute_sanitizer_suppression(
-    argv: tuple[str, ...],
-    staged_path: Path,
-) -> tuple[str, ...]:
-    """Point a planned Compute Sanitizer invocation at its verified staged input."""
-    indexes = [index for index, value in enumerate(argv[:-1]) if value == "--suppressions"]
-    if len(indexes) != 1:
-        raise DomainError(
-            ErrorCode.INTERNAL_ERROR,
-            "Planned Compute Sanitizer suppression argument is missing or ambiguous.",
-        )
-    index = indexes[0] + 1
-    return (*argv[:index], str(staged_path), *argv[index + 1 :])
 
 
 def _torch_capture_invocation(
@@ -588,6 +629,189 @@ def _torch_capture_invocation(
             *feature_limitations,
         ),
         environment={},
+    )
+
+
+def _compute_sanitizer_capture_invocation(
+    adapter: BuiltinAdapter,
+    workload_argv: tuple[str, ...],
+    output: str,
+    *,
+    executable: str | None,
+    options: dict[str, object] | None,
+    project_root: Path | None,
+) -> CaptureInvocation:
+    selected = compute_sanitizer_options(options)
+    argv_parts: list[str] = [
+        _require_executable(adapter.name, executable),
+        "--tool",
+        selected.tool,
+        "--xml",
+        "--save",
+        output,
+        "--error-exitcode",
+        str(selected.finding_exit_code),
+        "--launch-skip",
+        str(selected.launch_skip),
+        "--launch-count",
+        str(selected.launch_count),
+        "--target-processes",
+        selected.target_processes,
+        "--demangle",
+        selected.demangle,
+    ]
+    if selected.target_processes_filter is not None:
+        argv_parts.extend(("--target-processes-filter", selected.target_processes_filter))
+    if selected.kernel_name is not None:
+        argv_parts.extend(("--kernel-name", selected.kernel_name))
+    suppression = compute_sanitizer_suppression_path(
+        selected,
+        project_root=project_root or Path.cwd(),
+    )
+    if suppression is not None:
+        argv_parts.extend(("--suppressions", str(suppression)))
+    argv = (*argv_parts, *workload_argv)
+    return CaptureInvocation(
+        argv=argv,
+        artifact_kinds=adapter.artifact_kinds,
+        expected_overhead=adapter.expected_overhead or "",
+        limitations=adapter.capture_limitations,
+        environment={},
+    )
+
+
+def replace_compute_sanitizer_suppression(
+    argv: tuple[str, ...],
+    staged_path: Path,
+) -> tuple[str, ...]:
+    """Point a planned Compute Sanitizer invocation at its verified staged input."""
+    indexes = [index for index, value in enumerate(argv[:-1]) if value == "--suppressions"]
+    if len(indexes) != 1:
+        raise DomainError(
+            ErrorCode.INTERNAL_ERROR,
+            "Planned Compute Sanitizer suppression argument is missing or ambiguous.",
+        )
+    index = indexes[0] + 1
+    return (*argv[:index], str(staged_path), *argv[index + 1 :])
+
+
+def _nvbench_capture_invocation(
+    adapter: BuiltinAdapter,
+    workload_argv: tuple[str, ...],
+    output: str,
+    *,
+    executable: str | None,
+    options: dict[str, object] | None,
+) -> CaptureInvocation:
+    """Inject the official output flag into the declared benchmark argv.
+
+    NVBench is linked into each benchmark executable via ``NVBENCH_MAIN``
+    (``nvbench/main.cuh``); there is no universal ``nvbench`` wrapper that
+    runs a workload after ``--``.  The declared ``workload_argv[0]`` IS the
+    benchmark binary.  This function injects the official output flag
+    (verified from ``nvbench/option_parser.cu`` at commit c184889):
+
+    ``--json`` and ``--jsonbin`` are **alternative** output modes, not
+    complementary:
+
+    - ``--jsonbin <path>`` (default, ``enable_jsonbin=True``): creates a
+      ``json_printer`` with ``enable_binary_output=true`` that writes the
+      JSON document **and** binary sidecar directories ``<path>-bin/`` and
+      ``<path>-freqs-bin/``.
+    - ``--json <path>`` (``enable_jsonbin=False``): creates a
+      ``json_printer`` with ``enable_binary_output=false`` that writes only
+      the JSON document, with no binary sidecars.
+
+    Emitting both would create two competing JSON printers writing to the
+    same file, so exactly one is injected.
+
+    Pre-existing ``--json`` or ``--jsonbin`` flags (in either
+    space-separated ``--json <path>`` or equals-separated ``--json=<path>``
+    form) in ``workload_argv`` are rejected as conflicts.
+    Optional NVBench flags (``--stopping-criterion``, ``--min-samples``,
+    ``--timeout``, ``-d``) are injected before the workload's own arguments.
+    """
+    if not workload_argv:
+        raise DomainError(
+            ErrorCode.INVALID_CAPTURE_PLAN,
+            "NVBench capture requires a benchmark executable as workload argv[0].",
+        )
+    for arg in workload_argv:
+        if arg == "--json" or arg == "--jsonbin" or arg.startswith(("--json=", "--jsonbin=")):
+            raise DomainError(
+                ErrorCode.INVALID_CAPTURE_PLAN,
+                f"Workload argv already contains an NVBench output flag "
+                f"({arg!r}); the managed nvbench adapter injects its own "
+                "and conflicts must be removed.",
+            )
+    selected = nvbench_options(options)
+    benchmark_exe = workload_argv[0]
+    rest_argv = workload_argv[1:]
+    output_flag = "--jsonbin" if selected.enable_jsonbin else "--json"
+    injected: list[str] = [benchmark_exe, output_flag, output]
+    if selected.stopping_criterion is not None:
+        injected.extend(("--stopping-criterion", selected.stopping_criterion))
+    if selected.min_samples is not None:
+        injected.extend(("--min-samples", str(selected.min_samples)))
+    if selected.timeout is not None:
+        injected.extend(("--timeout", str(selected.timeout)))
+    if selected.devices is not None:
+        injected.extend(("-d", selected.devices))
+    argv = (*injected, *rest_argv)
+    return CaptureInvocation(
+        argv=argv,
+        artifact_kinds=adapter.artifact_kinds,
+        expected_overhead=adapter.expected_overhead or "",
+        limitations=adapter.capture_limitations,
+        environment={},
+    )
+
+
+def _triton_compiler_capture_invocation(
+    adapter: BuiltinAdapter,
+    workload_argv: tuple[str, ...],
+    output_root: Path,
+    *,
+    options: dict[str, object] | None,
+) -> CaptureInvocation:
+    """Set Triton env-var dump controls; the broker runs the workload directly."""
+    selected = triton_compiler_options(options)
+    dump_dir = output_root / selected.dump_subdir
+    environment: dict[str, str] = {
+        "TRITON_DUMP_DIR": str(dump_dir),
+        "TRITON_KERNEL_DUMP": "1" if selected.kernel_dump else "0",
+    }
+    if selected.reproducer_filename is not None:
+        environment["TRITON_REPRODUCER_PATH"] = str(output_root / selected.reproducer_filename)
+    return CaptureInvocation(
+        argv=workload_argv,
+        artifact_kinds=adapter.artifact_kinds,
+        expected_overhead=adapter.expected_overhead or "",
+        limitations=adapter.capture_limitations,
+        environment=environment,
+    )
+
+
+def _cute_compiler_capture_invocation(
+    adapter: BuiltinAdapter,
+    workload_argv: tuple[str, ...],
+    output_root: Path,
+    *,
+    options: dict[str, object] | None,
+) -> CaptureInvocation:
+    """Set CuTe DSL env-var dump controls; the broker runs the workload directly."""
+    selected = cute_compiler_options(options)
+    dump_dir = output_root / selected.dump_subdir
+    environment: dict[str, str] = {
+        "CUTE_DSL_DUMP_DIR": str(dump_dir),
+        "CUTE_DSL_KEEP": ",".join(selected.keep_allowlist),
+    }
+    return CaptureInvocation(
+        argv=workload_argv,
+        artifact_kinds=adapter.artifact_kinds,
+        expected_overhead=adapter.expected_overhead or "",
+        limitations=adapter.capture_limitations,
+        environment=environment,
     )
 
 

--- a/src/flameox/adapters/kernel_build.py
+++ b/src/flameox/adapters/kernel_build.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Annotated, Final, Literal, cast
+
+from pydantic import Field, model_validator
+
+from flameox.application.pipelines import (
+    PipelineStageDeclaration,
+    RegisteredPipelineStageDeclaration,
+    RegisterPipelineRequest,
+    UnregisteredPipelineStageDeclaration,
+)
+from flameox.models import ContractModel
+
+KERNEL_BUILD_SCHEMA_VERSION: Final[Literal["flameox.kernel-build.v1"]] = "flameox.kernel-build.v1"
+
+
+class KernelBuildArtifact(ContractModel):
+    path: Annotated[str, Field(min_length=1, max_length=500)]
+    byte_length: Annotated[int, Field(ge=0)]
+    sha256: Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+    media_type: Annotated[str, Field(min_length=1, max_length=100)] = "application/octet-stream"
+    role: Annotated[str, Field(min_length=1, max_length=100)] = "compiler_stage"
+
+    @model_validator(mode="after")
+    def relative_contained_path(self) -> KernelBuildArtifact:
+        path = PurePosixPath(self.path)
+        if path.is_absolute() or self.path in {".", ".."} or ".." in path.parts:
+            raise ValueError("kernel-build artifact paths must be contained relative POSIX paths")
+        if any(part in {"", "."} for part in path.parts):
+            raise ValueError("kernel-build artifact paths must be normalized")
+        return self
+
+
+class KernelBuildStage(ContractModel):
+    name: Annotated[str, Field(min_length=1, max_length=100)]
+    ordinal: Annotated[int, Field(ge=0, le=99)]
+    predecessor: Annotated[str, Field(min_length=1, max_length=100)] | None = None
+    status: Literal["available", "cached", "skipped", "unavailable", "failed"]
+    format: Annotated[str, Field(min_length=1, max_length=100)]
+    format_schema: Annotated[str, Field(min_length=1, max_length=100)]
+    artifact: KernelBuildArtifact | None = None
+    elapsed_ns: Annotated[int, Field(ge=0)] | None = None
+    limitations: Annotated[
+        tuple[Annotated[str, Field(min_length=1, max_length=500)], ...],
+        Field(max_length=20),
+    ] = ()
+
+    @model_validator(mode="after")
+    def artifact_matches_status(self) -> KernelBuildStage:
+        registered = self.status in {"available", "cached"}
+        if registered != (self.artifact is not None):
+            raise ValueError("available and cached stages require exactly one native artifact")
+        return self
+
+
+class KernelBuildManifestV1(ContractModel):
+    schema_version: Literal["flameox.kernel-build.v1"] = KERNEL_BUILD_SCHEMA_VERSION
+    producer: Literal["triton", "cute"]
+    producer_version: Annotated[str, Field(min_length=1, max_length=100)]
+    workload_identity: Annotated[str, Field(min_length=1, max_length=200)]
+    device_identity: Annotated[str, Field(min_length=1, max_length=500)] | None = None
+    outcome: Literal["succeeded", "failed", "inconclusive"]
+    cache_status: Literal["hit", "miss", "mixed", "unknown"] = "unknown"
+    stages: Annotated[tuple[KernelBuildStage, ...], Field(min_length=1, max_length=100)]
+    source_environment: dict[
+        Annotated[str, Field(min_length=1, max_length=100)],
+        Annotated[str, Field(max_length=500)],
+    ] = Field(default_factory=dict)
+    limitations: Annotated[
+        tuple[Annotated[str, Field(min_length=1, max_length=500)], ...],
+        Field(max_length=20),
+    ] = ()
+    diagnostics: Annotated[
+        tuple[Annotated[str, Field(min_length=1, max_length=2_000)], ...],
+        Field(max_length=50),
+    ] = ()
+
+    @model_validator(mode="after")
+    def ordered_pipeline(self) -> KernelBuildManifestV1:
+        if len(self.source_environment) > 20:
+            raise ValueError("source_environment is limited to 20 entries")
+        names = [stage.name for stage in self.stages]
+        ordinals = [stage.ordinal for stage in self.stages]
+        paths = [stage.artifact.path for stage in self.stages if stage.artifact is not None]
+        if len(names) != len(set(names)) or len(ordinals) != len(set(ordinals)):
+            raise ValueError("kernel-build stage names and ordinals must be unique")
+        if ordinals != sorted(ordinals):
+            raise ValueError("kernel-build stages must be declared in ordinal order")
+        if len(paths) != len(set(paths)):
+            raise ValueError("kernel-build artifact paths must be unique")
+        seen: set[str] = set()
+        for stage in self.stages:
+            if stage.predecessor is not None and stage.predecessor not in seen:
+                raise ValueError("stage predecessors must identify an earlier declared stage")
+            seen.add(stage.name)
+        if self.outcome == "succeeded" and any(
+            stage.status in {"failed", "unavailable"} for stage in self.stages
+        ):
+            raise ValueError("a successful build cannot contain failed or unavailable stages")
+        if self.outcome == "failed" and not any(stage.status == "failed" for stage in self.stages):
+            raise ValueError("a failed build requires a failed stage")
+        return self
+
+    def bundle_paths(self, manifest_path: Path) -> tuple[Path, ...]:
+        return tuple(
+            manifest_path.parent / stage.artifact.path
+            for stage in self.stages
+            if stage.artifact is not None
+        )
+
+    def pipeline_request(
+        self,
+        *,
+        run_id: str,
+        registration_ids_by_path: dict[str, str],
+    ) -> RegisterPipelineRequest:
+        declarations: list[PipelineStageDeclaration] = []
+        for stage in self.stages:
+            if stage.artifact is not None:
+                registration_id = registration_ids_by_path.get(stage.artifact.path)
+                if registration_id is None:
+                    raise ValueError(f"missing registration for {stage.artifact.path!r}")
+                declarations.append(
+                    RegisteredPipelineStageDeclaration(
+                        name=stage.name,
+                        ordinal=stage.ordinal,
+                        predecessor=stage.predecessor,
+                        format=stage.format,
+                        format_schema=stage.format_schema,
+                        elapsed_ns=stage.elapsed_ns,
+                        limitations=stage.limitations,
+                        status=cast(Literal["available", "cached"], stage.status),
+                        registration_id=registration_id,
+                    )
+                )
+            else:
+                declarations.append(
+                    UnregisteredPipelineStageDeclaration(
+                        name=stage.name,
+                        ordinal=stage.ordinal,
+                        predecessor=stage.predecessor,
+                        format=stage.format,
+                        format_schema=stage.format_schema,
+                        elapsed_ns=stage.elapsed_ns,
+                        limitations=stage.limitations,
+                        status=cast(Literal["skipped", "unavailable", "failed"], stage.status),
+                    )
+                )
+        limitations = list(self.limitations)
+        if self.diagnostics:
+            limitations.append("compiler diagnostics are preserved in the kernel-build manifest")
+        if self.device_identity is None:
+            limitations.append("device identity was not supplied by the producer")
+        return RegisterPipelineRequest(
+            run_id=run_id,
+            pipeline_name=f"{self.producer}.compiler",
+            pipeline_schema=KERNEL_BUILD_SCHEMA_VERSION,
+            producer=self.producer,
+            producer_version=self.producer_version,
+            stages=tuple(declarations),
+            limitations=tuple(dict.fromkeys(limitations)),
+        )
+
+
+def kernel_build_json_schema() -> dict[str, object]:
+    return KernelBuildManifestV1.model_json_schema()

--- a/src/flameox/adapters/nvbench.py
+++ b/src/flameox/adapters/nvbench.py
@@ -1,0 +1,551 @@
+"""NVBench JSON + jsonbin sidecar import and extraction.
+
+NVBench (https://github.com/NVIDIA/nvbench, pinned to main commit c184889)
+emits a JSON document via ``--json <path>`` and optional binary sidecars via
+``--jsonbin <path>``.  The sidecars contain ``sample_times`` and
+``sample_freqs`` as little-endian float32 values.  The JSON references each
+sidecar through a summary entry whose ``hint`` starts with ``file/`` and
+whose ``data`` array carries the relative ``filename`` (e.g.
+``out.json-bin/0.bin``) and float32 ``size`` (value count, serialized as a
+decimal string because json_printer.cu writes all int64 values as strings).
+
+This adapter preserves the native JSON and sidecar files through the bounded
+bundle import primitive, then extracts sample measurements as float values
+without lossy integer conversion.  NVBench reports times in seconds
+(``cuda_timer.get_duration()`` in ``nvbench/detail/measure_cold.cu``) and
+frequencies in hertz; the measurements table stores them in ``value_float``
+with ``unit="seconds"`` or ``unit="hertz"`` respectively.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+from pydantic import (
+    ConfigDict,
+    Field,
+    StringConstraints,
+    ValidationError,
+)
+
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, digest_model
+from flameox.domain.models import ArtifactRegistration
+from flameox.evidence import GenerationPublisher
+from flameox.models import ContractModel
+from flameox.storage import ArtifactStore, RunStore, Workspace
+
+_NVBENCH_PRODUCER = "nvbench"
+_SIDECAR_ROLE = "nvbench_sidecar"
+_SAMPLE_TIMES_HINT = "file/sample_times"
+_SAMPLE_FREQS_HINT = "file/sample_freqs"
+_MAX_STATES = 100_000
+_MAX_SUMMARIES_PER_STATE = 1_000
+_MAX_SAMPLES_PER_SERIES = 1_000_000
+
+BoundedString = Annotated[str, StringConstraints(min_length=1, max_length=500)]
+
+
+def _parse_decimal_size(raw: str) -> int:
+    """Parse a decimal string size from an NVBench int64 summary datum.
+
+    Rejects empty strings, negative values, non-decimal characters, and
+    values exceeding ``_MAX_SAMPLES_PER_SERIES``.
+    """
+    stripped = raw.strip()
+    if not stripped or not stripped.isascii() or not stripped.isdigit():
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar size {raw!r} is not a non-negative decimal integer.",
+        )
+    value = int(stripped)
+    if value > _MAX_SAMPLES_PER_SERIES:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar declares {value} samples, exceeding the limit.",
+        )
+    return value
+
+
+class _NvbenchModel(ContractModel):
+    """NVBench JSON fields are forward-compatible; allow unknown keys."""
+
+    model_config = ConfigDict(extra="allow", frozen=True, validate_default=True)
+
+
+class NvbenchSummaryDatum(_NvbenchModel):
+    """A single named value within an NVBench summary's ``data`` array."""
+
+    name: BoundedString
+    type: Literal["int64", "float64", "string"]
+    value: int | float | str
+
+
+_VALID_FILE_HINTS = frozenset({_SAMPLE_TIMES_HINT, _SAMPLE_FREQS_HINT})
+
+
+class NvbenchSummary(_NvbenchModel):
+    """An NVBench summary entry within a benchmark state."""
+
+    tag: BoundedString
+    name: str | None = None
+    description: str | None = None
+    hint: str | None = None
+    hide: str | None = None
+    data: tuple[NvbenchSummaryDatum, ...] = Field(default_factory=tuple, max_length=100)
+
+    @property
+    def is_file_sidecar(self) -> bool:
+        """True if this summary declares a binary sidecar via a known file hint."""
+        return self.hint in _VALID_FILE_HINTS
+
+    @property
+    def sidecar_filename(self) -> str | None:
+        """Return the relative sidecar filename if this summary references one.
+
+        Only the two documented file hints (``file/sample_times`` and
+        ``file/sample_freqs``) are recognised.  Any other ``file/`` hint
+        is an unknown encoding and must be rejected by the caller.
+        """
+        if not self.is_file_sidecar:
+            return None
+        for datum in self.data:
+            if (
+                datum.name == "filename"
+                and datum.type == "string"
+                and isinstance(datum.value, str)
+                and 1 <= len(datum.value) <= 500
+            ):
+                return datum.value
+        return None
+
+    @property
+    def sidecar_size(self) -> int | None:
+        """Return the declared float32 value count if this summary references a sidecar.
+
+        NVBench's json_printer.cu serializes all int64 named values as
+        decimal strings (JSON encodes numbers as double-precision floats,
+        which would truncate int64s).  The ``size`` datum therefore arrives
+        as a string like ``"27393"`` even though its ``type`` is
+        ``"int64"``.  We parse the decimal string, rejecting negatives,
+        non-decimal characters, and overflow beyond ``_MAX_SAMPLES_PER_SERIES``.
+        """
+        if not self.is_file_sidecar:
+            return None
+        for datum in self.data:
+            if datum.name != "size":
+                continue
+            if datum.type == "int64" and isinstance(datum.value, str):
+                return _parse_decimal_size(datum.value)
+            return None
+        return None
+
+
+class NvbenchAxisValue(_NvbenchModel):
+    """A single value along an NVBench axis."""
+
+    input_string: str | None = None
+    description: str | None = None
+    value: int | float | str | None = None
+    is_active: bool | None = None
+
+
+class NvbenchAxis(_NvbenchModel):
+    """An NVBench axis specification."""
+
+    name: BoundedString
+    type: Literal["type", "int64", "float64", "string"]
+    flags: str | None = None
+    values: tuple[NvbenchAxisValue, ...] = Field(default_factory=tuple, max_length=10_000)
+
+
+class NvbenchState(_NvbenchModel):
+    """An NVBench benchmark execution state."""
+
+    name: str | None = None
+    device: int | None = None
+    type_config_index: int | None = None
+    is_skipped: bool = False
+    skip_reason: str | None = None
+    summaries: tuple[NvbenchSummary, ...] = Field(
+        default_factory=tuple,
+        max_length=_MAX_SUMMARIES_PER_STATE,
+    )
+
+
+class NvbenchBenchmark(_NvbenchModel):
+    """An NVBench benchmark entry."""
+
+    name: BoundedString
+    index: int | None = None
+    states: tuple[NvbenchState, ...] = Field(default_factory=tuple, max_length=_MAX_STATES)
+
+
+class NvbenchJsonVersion(_NvbenchModel):
+    """The NVBench JSON schema version."""
+
+    major: int
+    minor: int
+    patch: int
+    string: str | None = None
+
+
+class NvbenchNvbenchVersion(_NvbenchModel):
+    """The NVBench tool version."""
+
+    major: int
+    minor: int
+    patch: int
+    string: str | None = None
+
+
+class NvbenchMeta(_NvbenchModel):
+    """The NVBench JSON metadata section."""
+
+    argv: tuple[str, ...] = Field(default_factory=tuple, max_length=10_000)
+    version: dict[str, Any] = Field(default_factory=dict)
+
+
+class NvbenchJsonDocument(_NvbenchModel):
+    """A bounded subset of the NVBench JSON output document.
+
+    Only the fields required for sample extraction and provenance are modeled.
+    Unknown fields are ignored so that forward-compatible NVBench versions do
+    not break extraction.
+    """
+
+    meta: NvbenchMeta = Field(default_factory=NvbenchMeta)
+    benchmarks: tuple[NvbenchBenchmark, ...] = Field(
+        default_factory=tuple,
+        max_length=10_000,
+    )
+
+    @property
+    def json_version(self) -> NvbenchJsonVersion | None:
+        raw = self.meta.version.get("json")
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return NvbenchJsonVersion.model_validate(raw)
+        except ValidationError:
+            return None
+
+    @property
+    def nvbench_version(self) -> NvbenchNvbenchVersion | None:
+        raw = self.meta.version.get("nvbench")
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return NvbenchNvbenchVersion.model_validate(raw)
+        except ValidationError:
+            return None
+
+
+class NvbenchExtractionResult(ContractModel):
+    schema_version: int = 1
+    run_id: str
+    artifact_id: str
+    producer_version: str | None
+    benchmark_count: int
+    measurement_count: int
+    corpus_commit_id: str
+    limitations: tuple[str, ...] = ()
+
+
+class NvbenchExtractor:
+    """Extract NVBench sample measurements from a preserved JSON + sidecar bundle.
+
+    The run must contain exactly one primary NVBench JSON artifact (role
+    ``"primary"``) and zero or more sidecar artifacts (role
+    ``"nvbench_sidecar"``).  Sidecars are matched to JSON summary references
+    by their display name (the relative filename stored in the JSON).
+    """
+
+    name = "nvbench.json"
+    version = "1"
+    compatibility_family = "nvbench.json.2026.v1"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+        self.runs = RunStore(workspace)
+        self.artifacts = ArtifactStore(workspace)
+        self.publisher = GenerationPublisher(workspace)
+
+    def extract(self, run_id: str) -> NvbenchExtractionResult:
+        run = self.runs.read(run_id)
+        nvbench_artifacts = tuple(
+            item
+            for item in run.artifacts
+            if item.kind is ArtifactKind.BENCHMARK_SAMPLES
+            and item.producer in {_NVBENCH_PRODUCER, "flameox.import"}
+        )
+        primaries = tuple(item for item in nvbench_artifacts if item.role == "primary")
+        if len(primaries) != 1:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The run must contain exactly one primary NVBench JSON artifact.",
+                run_id=run_id,
+            )
+        primary = primaries[0]
+        sidecars = {
+            item.display_name: item for item in nvbench_artifacts if item.role == _SIDECAR_ROLE
+        }
+        stored = self.artifacts.get(primary.artifact_id)
+        document = self._load_json(stored.payload_path)
+        producer_version = self._producer_version(document, primary)
+        declared_rows = self._declared_measurement_count(document, run_id=run_id)
+        max_rows = self.workspace.config.storage.max_rows_per_generation
+        if declared_rows > max_rows:
+            raise DomainError(
+                ErrorCode.QUERY_BUDGET_EXCEEDED,
+                "NVBench extraction exceeds the workspace generation row limit.",
+                details={"rows": declared_rows, "max_rows": max_rows},
+            )
+
+        limitations: list[str] = []
+        consumed_sidecar_ids: set[str] = set()
+        json_version = document.json_version
+        if json_version is None:
+            limitations.append("The NVBench JSON schema version was missing or invalid.")
+        if producer_version is None:
+            limitations.append("The NVBench producer version was not declared.")
+
+        rows: list[dict[str, object]] = []
+        for bench in document.benchmarks:
+            for state_index, state in enumerate(bench.states):
+                if state.is_skipped:
+                    continue
+                for summary in state.summaries:
+                    series_rows, sidecar_artifact_id = self._extract_summary(
+                        run_id=run_id,
+                        benchmark_name=bench.name,
+                        state_index=state_index,
+                        state=state,
+                        summary=summary,
+                        sidecars=sidecars,
+                    )
+                    rows.extend(series_rows)
+                    if sidecar_artifact_id is not None:
+                        consumed_sidecar_ids.add(sidecar_artifact_id)
+
+        input_artifact_ids = (
+            primary.artifact_id,
+            *sorted(consumed_sidecar_ids - {primary.artifact_id}),
+        )
+        published = self.publisher.publish_rows_idempotent(
+            {"measurements": rows},
+            publisher=self.name,
+            publisher_version=self.version,
+            input_run_ids=(run_id,),
+            input_artifact_ids=input_artifact_ids,
+            operation_identity={
+                "compatibility_family": self.compatibility_family,
+                "producer_version": producer_version,
+                "json_version": (
+                    f"{json_version.major}.{json_version.minor}.{json_version.patch}"
+                    if json_version
+                    else None
+                ),
+                "measurement_count": len(rows),
+            },
+        )
+        return NvbenchExtractionResult(
+            run_id=run_id,
+            artifact_id=primary.artifact_id,
+            producer_version=producer_version,
+            benchmark_count=len(document.benchmarks),
+            measurement_count=len(rows),
+            corpus_commit_id=published.commit.commit_id,
+            limitations=tuple(dict.fromkeys(limitations)),
+        )
+
+    def _extract_summary(
+        self,
+        *,
+        run_id: str,
+        benchmark_name: str,
+        state_index: int,
+        state: NvbenchState,
+        summary: NvbenchSummary,
+        sidecars: dict[str, ArtifactRegistration],
+    ) -> tuple[list[dict[str, object]], str | None]:
+        size = self._declared_sidecar_size(summary, run_id=run_id)
+        if size is None:
+            return [], None
+        filename = summary.sidecar_filename
+        if filename is None:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"NVBench summary with hint {summary.hint!r} is missing "
+                "the required filename datum.",
+                run_id=run_id,
+            )
+        registration = sidecars.get(filename)
+        if registration is None:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"NVBench sidecar {filename!r} was not preserved in the run.",
+                run_id=run_id,
+            )
+        stored = self.artifacts.get(registration.artifact_id)
+        samples = self._decode_float32_sidecar(stored.payload_path, size)
+        if any(not math.isfinite(value) for value in samples):
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"NVBench sidecar {filename!r} contains a non-finite sample.",
+                run_id=run_id,
+            )
+        unit = self._unit_for_hint(summary.hint)
+        measurement_name = f"nvbench.{benchmark_name}.sample_times"
+        if summary.hint == _SAMPLE_FREQS_HINT:
+            measurement_name = f"nvbench.{benchmark_name}.sample_freqs"
+        dimensions: dict[str, str] = {
+            "nvbench_benchmark": benchmark_name,
+            "nvbench_state_index": str(state_index),
+        }
+        if state.device is not None:
+            dimensions["device.index"] = str(state.device)
+        if state.name:
+            dimensions["nvbench_state"] = state.name
+        if summary.tag:
+            dimensions["nvbench_summary_tag"] = summary.tag
+        rows: list[dict[str, object]] = []
+        for value_index, value in enumerate(samples):
+            identity = {
+                "run_id": run_id,
+                "artifact_id": registration.artifact_id,
+                "benchmark_name": benchmark_name,
+                "state_index": state_index,
+                "summary_tag": summary.tag,
+                "value_index": value_index,
+            }
+            rows.append(
+                {
+                    "measurement_id": digest_model(identity),
+                    "run_id": run_id,
+                    "artifact_id": registration.artifact_id,
+                    "name": measurement_name,
+                    "value_int": None,
+                    "value_float": float(value),
+                    "unit": unit,
+                    "aggregation": "sample",
+                    "scope": "device",
+                    "trial_id": None,
+                    "worker_id": None,
+                    "worker_run_index": None,
+                    "value_index": value_index,
+                    "loop_count": None,
+                    "is_warmup": False,
+                    "block_id": None,
+                    "variant_id": None,
+                    "order_in_block": None,
+                    "phase": None,
+                    "dimensions": dimensions,
+                    "evidence_level": "observed",
+                }
+            )
+        return rows, registration.artifact_id
+
+    @classmethod
+    def _declared_measurement_count(
+        cls,
+        document: NvbenchJsonDocument,
+        *,
+        run_id: str,
+    ) -> int:
+        total = 0
+        for benchmark in document.benchmarks:
+            for state in benchmark.states:
+                if state.is_skipped:
+                    continue
+                for summary in state.summaries:
+                    size = cls._declared_sidecar_size(summary, run_id=run_id)
+                    if size is not None:
+                        total += size
+        return total
+
+    @staticmethod
+    def _declared_sidecar_size(summary: NvbenchSummary, *, run_id: str) -> int | None:
+        if summary.hint is None or not summary.hint.startswith("file/"):
+            return None
+        if not summary.is_file_sidecar:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"Unknown NVBench file hint {summary.hint!r}; "
+                "only file/sample_times and file/sample_freqs are supported.",
+                run_id=run_id,
+            )
+        size = summary.sidecar_size
+        if size is None:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"NVBench summary with hint {summary.hint!r} is missing "
+                "a valid decimal-string size datum.",
+                run_id=run_id,
+            )
+        return size
+
+    @staticmethod
+    def _decode_float32_sidecar(path: Path, count: int) -> list[float]:
+        expected_bytes = count * 4
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "NVBench sidecar payload could not be read.",
+            ) from exc
+        if len(raw) != expected_bytes:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"NVBench sidecar size mismatch: expected {expected_bytes} bytes, got {len(raw)}.",
+            )
+        return list(struct.unpack(f"<{count}f", raw))
+
+    @staticmethod
+    def _unit_for_hint(hint: str | None) -> str:
+        """Return the SI unit for a sidecar hint.
+
+        Units are pinned to NVIDIA/nvbench main (commit c184889):
+
+        - ``file/sample_times``: ``cuda_timer.get_duration()`` returns
+          seconds (``nvbench/detail/measure_cold.cu`` feeds
+          ``m_cuda_times`` to ``do_process_bulk_data_float64`` with
+          ``hint="sample_times"``).  The ``stdrel_criterion`` compares
+          ``total_measured_time`` against ``min-time`` (default 0.5 s),
+          confirming seconds.
+        - ``file/sample_freqs``: sample frequencies are raw hertz
+          (1/seconds), written via the same bulk-data path with
+          ``hint="sample_freqs"``.
+        """
+        if hint == _SAMPLE_TIMES_HINT:
+            return "seconds"
+        if hint == _SAMPLE_FREQS_HINT:
+            return "hertz"
+        return "unknown"
+
+    @staticmethod
+    def _producer_version(
+        document: NvbenchJsonDocument,
+        registration: ArtifactRegistration,
+    ) -> str | None:
+        nvbench_version = document.nvbench_version
+        if nvbench_version is not None and nvbench_version.string:
+            return nvbench_version.string
+        if nvbench_version is not None:
+            return f"{nvbench_version.major}.{nvbench_version.minor}.{nvbench_version.patch}"
+        return registration.producer_version
+
+    @staticmethod
+    def _load_json(path: Path) -> NvbenchJsonDocument:
+        try:
+            with path.open(encoding="utf-8") as stream:
+                return NvbenchJsonDocument.model_validate(json.load(stream))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+            raise DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                "The artifact is not a valid NVBench JSON document.",
+            ) from exc

--- a/src/flameox/adapters/options.py
+++ b/src/flameox/adapters/options.py
@@ -49,8 +49,76 @@ class ComputeSanitizerOptions(ContractModel):
         return self
 
 
+class NvbenchOptions(ContractModel):
+    """Bounded capture options for the NVBench CLI (``--json`` and ``--jsonbin``)."""
+
+    enable_jsonbin: bool = True
+    stopping_criterion: Annotated[str, StringConstraints(min_length=1, max_length=100)] | None = (
+        None
+    )
+    min_samples: Annotated[int, Field(ge=1, le=1_000_000)] | None = None
+    timeout: Annotated[float, Field(gt=0, le=86_400)] | None = None
+    devices: Annotated[str, StringConstraints(min_length=1, max_length=200)] | None = None
+
+
+_BoundedSubdir = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=200, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+]
+
+
+_BoundedFilename = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=200, pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+]
+
+
+class TritonCompilerOptions(ContractModel):
+    """Bounded capture options for the managed triton.compiler env-var adapter.
+
+    ``reproducer_filename`` sets ``TRITON_REPRODUCER_PATH`` to a bounded
+    filename inside the output root (not inside the dump directory).  The
+    reproducer file is inventoried explicitly if it exists after the run.
+    """
+
+    dump_subdir: _BoundedSubdir = "triton-dumps"
+    kernel_dump: bool = True
+    reproducer_filename: _BoundedFilename | None = None
+
+
+CuteDslKeepToken = Literal["ir", "ir-debug", "ptx", "cubin", "sass", "llvm", "all"]
+
+
+class CuteCompilerOptions(ContractModel):
+    """Bounded capture options for the managed cute.compiler env-var adapter.
+
+    ``keep_allowlist`` accepts the official ``CUTE_DSL_KEEP`` tokens documented
+    by CuTe DSL: ``ir``, ``ir-debug``, ``ptx``, ``cubin``, ``sass``, ``llvm``,
+    and ``all``.  The ``all`` token is mutually exclusive with the others.
+    """
+
+    dump_subdir: _BoundedSubdir = "cute-dsl-dumps"
+    keep_allowlist: Annotated[
+        tuple[CuteDslKeepToken, ...],
+        Field(min_length=1, max_length=20),
+    ] = ("ir", "ptx", "cubin")
+
+    @model_validator(mode="after")
+    def unique_and_consistent_allowlist(self) -> CuteCompilerOptions:
+        if len(set(self.keep_allowlist)) != len(self.keep_allowlist):
+            raise ValueError("CUTE_DSL_KEEP allowlist entries must be unique")
+        if "all" in self.keep_allowlist and len(self.keep_allowlist) > 1:
+            raise ValueError("CUTE_DSL_KEEP 'all' is mutually exclusive with other tokens")
+        if {"ir", "ir-debug"}.issubset(self.keep_allowlist):
+            raise ValueError("CUTE_DSL_KEEP 'ir' and 'ir-debug' are mutually exclusive")
+        return self
+
+
 _ADAPTER_OPTION_MODELS: dict[str, type[ContractModel]] = {
     "compute-sanitizer": ComputeSanitizerOptions,
+    "cute.compiler": CuteCompilerOptions,
+    "nvbench": NvbenchOptions,
+    "triton.compiler": TritonCompilerOptions,
 }
 
 
@@ -178,6 +246,18 @@ def read_compute_sanitizer_suppression(
             remediation=("Create a new capture plan after updating the suppression file.",),
         )
     return payload
+
+
+def nvbench_options(options: dict[str, object] | None) -> NvbenchOptions:
+    return cast(NvbenchOptions, _validate_adapter_options("nvbench", options))
+
+
+def triton_compiler_options(options: dict[str, object] | None) -> TritonCompilerOptions:
+    return cast(TritonCompilerOptions, _validate_adapter_options("triton.compiler", options))
+
+
+def cute_compiler_options(options: dict[str, object] | None) -> CuteCompilerOptions:
+    return cast(CuteCompilerOptions, _validate_adapter_options("cute.compiler", options))
 
 
 def _contained_project_file(project_root: Path, relative: str) -> Path:

--- a/src/flameox/application/__init__.py
+++ b/src/flameox/application/__init__.py
@@ -30,8 +30,10 @@ if TYPE_CHECKING:
     from flameox.application.inference_profiling import *  # noqa: F403
     from flameox.application.inference_providers import *  # noqa: F403
     from flameox.application.integrity import *  # noqa: F403
+    from flameox.application.kernel_builds import *  # noqa: F403
     from flameox.application.lifecycle import *  # noqa: F403
     from flameox.application.native_reducer import *  # noqa: F403
+    from flameox.application.nvbench_imports import *  # noqa: F403
     from flameox.application.operations import *  # noqa: F403
     from flameox.application.otlp import *  # noqa: F403
     from flameox.application.pipelines import *  # noqa: F403
@@ -72,7 +74,9 @@ _MODULES = (
     "native_reducer",
     "otlp",
     "integrity",
+    "kernel_builds",
     "inference_providers",
+    "nvbench_imports",
     "operations",
     "pipelines",
     "preflight",
@@ -200,6 +204,9 @@ __all__ = [
     "IntegrityService",
     "InvestigationListResult",
     "InvestigationService",
+    "KernelBuildCaptureCollector",
+    "KernelBuildImportResult",
+    "KernelBuildImportService",
     "LatencyFault",
     "LifecycleEvidenceService",
     "LifecycleItem",
@@ -222,6 +229,8 @@ __all__ = [
     "NativeViewerPlan",
     "NativeViewerService",
     "NsightSystemsProfilingPlan",
+    "NvbenchImportResult",
+    "NvbenchImportService",
     "OperationFailure",
     "OperationItemOutcome",
     "OperationProgress",

--- a/src/flameox/application/capture.py
+++ b/src/flameox/application/capture.py
@@ -26,6 +26,7 @@ from flameox.adapters.builtins import (
     replace_compute_sanitizer_suppression,
 )
 from flameox.adapters.compute_sanitizer import inspect_compute_sanitizer_report
+from flameox.adapters.kernel_build import KernelBuildManifestV1
 from flameox.adapters.options import (
     bind_adapter_options,
     compute_sanitizer_options,
@@ -46,7 +47,16 @@ from flameox.application.evidence_rows import (
 )
 from flameox.application.execution_identity import ExecutionIdentityService
 from flameox.application.execution_policy import ExecutionPolicy
+from flameox.application.kernel_builds import KernelBuildCaptureCollector
+from flameox.application.nvbench_imports import (
+    collect_nvbench_sidecar_specs,
+    load_nvbench_document_with_integrity,
+    load_nvbench_sidecar_specs,
+    resolve_nvbench_sidecar_path,
+    validate_nvbench_sidecar_file,
+)
 from flameox.application.oracle_receipts import parse_oracle_receipt
+from flameox.application.pipelines import ArtifactPipelineService
 from flameox.application.preflight import PreflightService
 from flameox.application.proc import read_boot_id, read_proc_stat_start_identity
 from flameox.application.quarantine import QuarantineService
@@ -752,6 +762,8 @@ class CaptureService:
         output_root.mkdir(parents=True, exist_ok=False)
         for binding in plan.writable_roots:
             Path(binding.storage_path).mkdir(parents=True, exist_ok=False)
+        if plan.adapter in {"triton.compiler", "cute.compiler"}:
+            self._create_kernel_build_dump_dir(plan, output_root)
         capture = _CaptureExecution(
             service=self,
             plan=plan,
@@ -1177,6 +1189,9 @@ class CaptureService:
             and not outcome.process.timed_out
             and preserve_nonzero_artifact
         ):
+            # Provider configured to preserve partial artifacts:
+            # keep nonempty invalid/partial native output as partial evidence
+            # rather than quarantining.  A nonzero limitation is already recorded.
             reason = (
                 "Collector completed without every expected native output."
                 if not any(path.exists() for path in native_paths)
@@ -1196,6 +1211,7 @@ class CaptureService:
             )
 
         registrations: list[tuple[ArtifactRegistration, int]] = []
+        kernel_build_manifest: KernelBuildManifestV1 | None = None
         process_snapshot_rows: list[dict[str, object]] = []
         process_snapshot_entries: list[dict[str, object]] = []
         adapter_extraction_rows: list[dict[str, object]] = []
@@ -1484,7 +1500,18 @@ class CaptureService:
                         media_type=media_type,
                     )
                 )
-            if plan.adapter_execution_plan is not None and collector_succeeded:
+            if plan.adapter in {"triton.compiler", "cute.compiler"}:
+                (
+                    kernel_build_registrations,
+                    kernel_build_manifest,
+                ) = await self._collect_kernel_build(
+                    plan,
+                    output_root,
+                    run_id,
+                    outcome.process.exit_code if outcome.process.exit_code is not None else 1,
+                )
+                registrations.extend(kernel_build_registrations)
+            elif plan.adapter_execution_plan is not None and collector_succeeded:
                 (
                     plugin_registrations,
                     plugin_extractions,
@@ -1612,6 +1639,21 @@ class CaptureService:
                             producer_version=plan.adapter_version,
                         )
                     )
+                if plan.adapter == "nvbench" and valid_native_paths:
+                    primary_registration = next(
+                        registered
+                        for registered in registrations
+                        if registered[0].kind is ArtifactKind.BENCHMARK_SAMPLES
+                        and registered[0].role == "primary"
+                    )
+                    sidecar_regs = await self._register_nvbench_sidecars(
+                        plan,
+                        output_root,
+                        run_id,
+                        primary_registration=primary_registration,
+                        partial=not native_complete or not collector_succeeded,
+                    )
+                    registrations.extend(sidecar_regs)
             observations = output_root / "observations.jsonl"
             if observations.is_file():
                 registrations.append(
@@ -1734,6 +1776,12 @@ class CaptureService:
                         (succeeded and (not native_paths or native_complete))
                         or (preserve_nonzero_artifact and bool(valid_native_paths))
                         or (timed_out and bool(valid_native_paths))
+                        or (
+                            plan.adapter in {"triton.compiler", "cute.compiler"}
+                            and any(
+                                reg.kind is ArtifactKind.KERNEL_BUILD for reg, _ in registrations
+                            )
+                        )
                     )
                     else CaptureStatus.FAILED
                 ),
@@ -1762,6 +1810,33 @@ class CaptureService:
         )
         self.runs.append(terminal, expected_revision=running.revision)
         capture.run = terminal
+        if kernel_build_manifest is not None:
+            registration_ids_by_path = {
+                registration.display_name: registration.registration_id
+                for registration in terminal.artifacts
+                if registration.role.startswith("compiler_stage:")
+            }
+            try:
+                await run_atomic_thread(
+                    lambda: ArtifactPipelineService(self.workspace).register(
+                        kernel_build_manifest.pipeline_request(
+                            run_id=terminal.run_id,
+                            registration_ids_by_path=registration_ids_by_path,
+                        )
+                    )
+                )
+            except DomainError as error:
+                pipeline_failed = terminal.model_copy(
+                    update={
+                        "revision": terminal.revision + 1,
+                        "execution_status": ExecutionStatus.FAILED,
+                        "limitations": (*terminal.limitations, error.message),
+                    }
+                )
+                self.runs.append(pipeline_failed, expected_revision=terminal.revision)
+                capture.run = pipeline_failed
+                error.run_id = pipeline_failed.run_id
+                raise
         measurement_rows: list[dict[str, object]] = []
         if terminal.process is not None and terminal.process.wall_time_ns is not None:
             measurement_rows.append(
@@ -1977,10 +2052,200 @@ class CaptureService:
         definition = builtin_adapter(plan.adapter)
         if definition is None or plan.adapter == "command" or definition.output_filename is None:
             return ()
+        if plan.adapter in {"triton.compiler", "cute.compiler"}:
+            return ()
         if plan.adapter == "torch.profiler":
             options = torch_profiler_options(cast(dict[str, object], plan.adapter_options))
             return tuple(output_root / filename for filename in options.output_filenames)
         return (output_root / definition.output_filename,)
+
+    async def _register_nvbench_sidecars(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+        run_id: str,
+        *,
+        primary_registration: tuple[ArtifactRegistration, int],
+        partial: bool = False,
+    ) -> list[tuple[ArtifactRegistration, int]]:
+        """Register provider-declared NVBench jsonbin sidecars.
+
+        Parses the primary JSON via the shared selector
+        (``load_nvbench_sidecar_specs``) to discover which sidecar files
+        the document references.  Only those files are registered with
+        ``role="nvbench_sidecar"`` and ``display_name`` matching the
+        declared relative path.  No sibling globbing is performed.
+
+        Every declared filename is validated as a normalized relative
+        POSIX path that resolves under ``output_root``.  Each sidecar
+        file must be a regular non-linked file with exact declared byte
+        length before registration.
+
+        When ``partial`` is False (successful capture), any parse error,
+        unsupported hint, missing/mismatched sidecar, or path escape
+        raises ``DomainError`` so that
+        ``_native_output_manifest_is_valid`` returns ``False`` and the
+        run fails with a bounded limitation.
+
+        When ``partial`` is True (nonzero exit), parse failures and
+        missing/mismatched sidecars are silently skipped — the missing
+        sidecar evidence is a bounded limitation/proof gap, not a
+        trigger for globbing.
+        """
+        definition = builtin_adapter(plan.adapter)
+        if definition is None or definition.output_filename is None:
+            return []
+        json_path = output_root / definition.output_filename
+        max_bytes = self.workspace.config.capture.max_artifact_bytes
+        try:
+            document, document_bytes, document_sha256 = load_nvbench_document_with_integrity(
+                json_path,
+                max_bytes=max_bytes,
+            )
+            self._require_registered_integrity(
+                primary_registration,
+                expected_byte_length=document_bytes,
+                expected_sha256=document_sha256,
+            )
+            specs = collect_nvbench_sidecar_specs(document)
+        except DomainError:
+            if not partial:
+                raise
+            return []
+        registrations: list[tuple[ArtifactRegistration, int]] = []
+        for spec in specs:
+            try:
+                sidecar_path = resolve_nvbench_sidecar_path(spec.filename, output_root)
+                validate_nvbench_sidecar_file(sidecar_path, spec.byte_length)
+            except DomainError:
+                if not partial:
+                    raise
+                continue
+            registered = await self._register_path_async(
+                run_id,
+                sidecar_path,
+                kind=plan.expected_artifact_kinds[0],
+                role="nvbench_sidecar",
+                media_type="application/octet-stream",
+                producer=plan.adapter,
+                producer_version=plan.adapter_version,
+                display_name=spec.filename,
+            )
+            self._require_registered_integrity(
+                registered,
+                expected_byte_length=spec.byte_length,
+            )
+            registrations.append(registered)
+        return registrations
+
+    @staticmethod
+    def _create_kernel_build_dump_dir(plan: CapturePlan, output_root: Path) -> None:
+        env_key = "TRITON_DUMP_DIR" if plan.adapter == "triton.compiler" else "CUTE_DSL_DUMP_DIR"
+        dump_path = plan.collector_environment.get(env_key)
+        if dump_path is not None:
+            Path(dump_path).mkdir(parents=True, exist_ok=True)
+
+    async def _collect_kernel_build(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+        run_id: str,
+        exit_code: int,
+    ) -> tuple[list[tuple[ArtifactRegistration, int]], KernelBuildManifestV1]:
+        env_key = "TRITON_DUMP_DIR" if plan.adapter == "triton.compiler" else "CUTE_DSL_DUMP_DIR"
+        dump_path = plan.collector_environment.get(env_key)
+        dump_dir = Path(dump_path) if dump_path is not None else output_root / "dumps"
+        source_environment = {
+            key: value
+            for key, value in plan.collector_environment.items()
+            if key not in {"FLAMEOX_OBSERVATIONS_PATH"}
+        }
+        cute_keep: tuple[str, ...] | None = None
+        if plan.adapter == "cute.compiler":
+            keep_value = plan.adapter_options.get("keep_allowlist")
+            if isinstance(keep_value, list):
+                cute_keep = tuple(str(item) for item in keep_value)
+        reproducer_path: Path | None = None
+        reproducer_env = plan.collector_environment.get("TRITON_REPRODUCER_PATH")
+        if reproducer_env is not None:
+            reproducer_path = Path(reproducer_env)
+        collector = KernelBuildCaptureCollector(self.workspace)
+        manifest, manifest_path, native_paths = await run_atomic_thread(
+            lambda: collector.collect(
+                adapter=plan.adapter,
+                dump_dir=dump_dir,
+                output_root=output_root,
+                workload_name=plan.workload_name,
+                exit_code=exit_code,
+                producer_version=plan.adapter_version,
+                source_environment=source_environment,
+                cute_keep_allowlist=cute_keep,
+                reproducer_path=reproducer_path,
+            )
+        )
+        registrations: list[tuple[ArtifactRegistration, int]] = []
+        declarations = {
+            stage.artifact.path: stage for stage in manifest.stages if stage.artifact is not None
+        }
+        for native in native_paths:
+            relative = native.relative_to(output_root).as_posix()
+            stage = declarations[relative]
+            stage_role = f"compiler_stage:{stage.name}"
+            registered = await self._register_path_async(
+                run_id,
+                native,
+                kind=ArtifactKind.KERNEL_BUILD,
+                role=stage_role,
+                media_type=mimetypes.guess_type(native.name)[0] or "application/octet-stream",
+                producer=plan.adapter,
+                producer_version=plan.adapter_version,
+                display_name=relative,
+            )
+            declaration = stage.artifact
+            assert declaration is not None
+            self._require_registered_integrity(
+                registered,
+                expected_byte_length=declaration.byte_length,
+                expected_sha256=declaration.sha256,
+            )
+            registrations.append(registered)
+        manifest_bytes = manifest_path.stat().st_size
+        with manifest_path.open("rb") as stream:
+            manifest_sha256 = hashlib.file_digest(stream, "sha256").hexdigest()
+        registered_manifest = await self._register_path_async(
+            run_id,
+            manifest_path,
+            kind=ArtifactKind.KERNEL_BUILD,
+            role="kernel_build_manifest",
+            media_type="application/json",
+            producer=plan.adapter,
+            producer_version=plan.adapter_version,
+        )
+        self._require_registered_integrity(
+            registered_manifest,
+            expected_byte_length=manifest_bytes,
+            expected_sha256=manifest_sha256,
+        )
+        registrations.append(registered_manifest)
+        return registrations, manifest
+
+    def _require_registered_integrity(
+        self,
+        registered: tuple[ArtifactRegistration, int],
+        *,
+        expected_byte_length: int,
+        expected_sha256: str | None = None,
+    ) -> None:
+        registration, byte_length = registered
+        stored = self.artifacts.get(registration.artifact_id)
+        if byte_length != expected_byte_length or (
+            expected_sha256 is not None
+            and stored.content.integrity.sha256 != expected_sha256.removeprefix("sha256:").lower()
+        ):
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                f"Registered artifact {registration.display_name!r} changed after inventory.",
+            )
 
     def _valid_native_output_paths(
         self,
@@ -2018,11 +2283,61 @@ class CaptureService:
             if path not in expected
         )
 
+    def _nvbench_manifest_is_valid(
+        self,
+        plan: CapturePlan,
+        output_root: Path,
+    ) -> bool:
+        """Validate the NVBench JSON and all declared sidecars.
+
+        Returns ``True`` only if the JSON parses successfully, every
+        declared sidecar filename is a safe relative path under
+        ``output_root``, and each sidecar file exists as a regular
+        non-linked file with exact declared byte length.  Any parse
+        error, unsupported hint, missing/mismatched sidecar, or path
+        escape returns ``False``.
+        """
+        definition = builtin_adapter(plan.adapter)
+        if definition is None or definition.output_filename is None:
+            return False
+        json_path = output_root / definition.output_filename
+        max_bytes = self.workspace.config.capture.max_artifact_bytes
+        try:
+            specs = load_nvbench_sidecar_specs(json_path, max_bytes=max_bytes)
+        except DomainError:
+            return False
+        for spec in specs:
+            try:
+                sidecar_path = resolve_nvbench_sidecar_path(spec.filename, output_root)
+                validate_nvbench_sidecar_file(sidecar_path, spec.byte_length)
+            except DomainError:
+                return False
+        return True
+
     def _native_output_manifest_is_valid(
         self,
         plan: CapturePlan,
         output_root: Path,
     ) -> bool:
+        if plan.adapter == "nvbench":
+            return self._nvbench_manifest_is_valid(plan, output_root)
+        if plan.adapter == "compute-sanitizer":
+            path = output_root / "compute-sanitizer.xml"
+            try:
+                if (
+                    path.is_symlink()
+                    or path.stat().st_size > self.workspace.config.capture.max_artifact_bytes
+                ):
+                    return False
+                with path.open("rb") as stream:
+                    prefix = stream.read(1_024)
+                    stream.seek(max(0, path.stat().st_size - 1_024))
+                    suffix = stream.read(1_024)
+            except OSError:
+                return False
+            return b"<ComputeSanitizerOutput" in prefix and (
+                b"</ComputeSanitizerOutput>" in suffix or b"<ComputeSanitizerOutput/>" in suffix
+            )
         if plan.adapter != "torch.profiler":
             return True
         options = torch_profiler_options(cast(dict[str, object], plan.adapter_options))
@@ -2148,6 +2463,26 @@ class CaptureService:
                 options=cast(dict[str, object] | None, options),
                 project_root=self.workspace.project_root,
             )
+            if invocation.environment:
+                conflicts = {
+                    key: {
+                        "workload_value": workload.env_overrides[key],
+                        "adapter_value": invocation.environment[key],
+                    }
+                    for key in invocation.environment
+                    if key in workload.env_overrides
+                    and workload.env_overrides[key] != invocation.environment[key]
+                }
+                if conflicts:
+                    raise DomainError(
+                        ErrorCode.INVALID_CAPTURE_PLAN,
+                        f"Workload env_overrides conflict with {adapter} adapter environment.",
+                        details={"conflicts": conflicts},
+                        remediation=(
+                            "Remove the conflicting env_override from the workload or set it "
+                            "to the identical value required by the adapter.",
+                        ),
+                    )
             return _AdapterBinding(
                 argv=invocation.argv,
                 artifact_kinds=invocation.artifact_kinds,
@@ -2829,6 +3164,7 @@ class CaptureService:
         producer: str = "flameox.capture",
         producer_version: str | None = None,
         sensitivity: Sensitivity = Sensitivity.INTERNAL,
+        display_name: str | None = None,
     ) -> tuple[ArtifactRegistration, int]:
         stored = self.artifacts.import_path(
             path,
@@ -2839,7 +3175,7 @@ class CaptureService:
             registration_id=new_id(),
             run_id=run_id,
             artifact_id=stored.content.artifact_id,
-            display_name=path.name,
+            display_name=display_name or path.name,
             media_type=media_type,
             kind=kind,
             role=role,
@@ -2860,6 +3196,7 @@ class CaptureService:
         producer: str = "flameox.capture",
         producer_version: str | None = None,
         sensitivity: Sensitivity = Sensitivity.INTERNAL,
+        display_name: str | None = None,
     ) -> tuple[ArtifactRegistration, int]:
         return await run_atomic_thread(
             lambda: self._register_path(
@@ -2871,6 +3208,7 @@ class CaptureService:
                 producer=producer,
                 producer_version=producer_version,
                 sensitivity=sensitivity,
+                display_name=display_name,
             )
         )
 

--- a/src/flameox/application/imports.py
+++ b/src/flameox/application/imports.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import json
 import mimetypes
+import stat
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
+
+from pydantic import Field, StringConstraints
 
 from flameox.application.environment import collect_environment
 from flameox.application.evidence_rows import (
@@ -26,10 +29,43 @@ from flameox.domain.models import (
 )
 from flameox.evidence import GenerationPublisher
 from flameox.models import ContractModel
-from flameox.storage import ArtifactStore, RunStore, Workspace
+from flameox.storage import ArtifactStore, RunStore, StoredArtifact, Workspace
 
 if TYPE_CHECKING:
     from flameox.application.otlp import OtlpExtractionResult
+
+_MAX_BUNDLE_MEMBERS = 100
+
+
+def _verify_declared_integrity(
+    member: BundleMember,
+    stored: StoredArtifact,
+) -> None:
+    """Verify imported content against provider-declared integrity.
+
+    Closes the TOCTOU gap between provider preflight and registration:
+    if the source changed between the provider's manifest declaration
+    and the actual import, the ``StoredArtifact`` digest/size will not
+    match and the bundle is rejected before any registration is
+    constructed or committed.
+    """
+    if member.expected_byte_length is not None:
+        actual = stored.content.byte_length
+        if actual != member.expected_byte_length:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                f"Bundle member {member.path!s} byte length mismatch: "
+                f"expected {member.expected_byte_length}, got {actual}.",
+            )
+    if member.expected_sha256 is not None:
+        expected_hex = member.expected_sha256.removeprefix("sha256:").lower()
+        actual_hex = stored.content.integrity.sha256.lower()
+        if actual_hex != expected_hex:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                f"Bundle member {member.path!s} sha256 mismatch: "
+                f"expected {expected_hex}, got {actual_hex}.",
+            )
 
 
 class ImportArtifactRequest(ContractModel):
@@ -46,6 +82,59 @@ class ImportArtifactRequest(ContractModel):
 class ImportResult(ContractModel):
     run: RunManifest
     artifact_id: str
+    corpus_commit_id: str
+
+
+class BundleMember(ContractModel):
+    """A single file within a bounded multi-file import bundle.
+
+    ``display_name`` overrides the default basename used in
+    ``ArtifactRegistration``.  Multi-file producers like NVBench store
+    relative paths (e.g. ``out.json-bin/0.bin``) in their JSON summaries;
+    setting ``display_name`` to that relative path lets the extractor
+    match sidecars by the exact key the producer declared.
+
+    ``expected_byte_length`` and ``expected_sha256`` bind declared
+    integrity from a provider manifest.  When set, the imported
+    ``StoredArtifact`` is verified immediately after ``import_path``
+    returns and before any registration is constructed, closing the
+    TOCTOU gap between provider preflight and registration commit.
+    """
+
+    path: Path
+    role: str = "primary"
+    media_type: str | None = None
+    display_name: (
+        Annotated[str, StringConstraints(min_length=1, max_length=500, pattern=r"^[^\x00\r\n]+$")]
+        | None
+    ) = None
+    expected_byte_length: Annotated[int, Field(ge=0)] | None = None
+    expected_sha256: (
+        Annotated[str, StringConstraints(pattern=r"^(?:sha256:)?[0-9a-fA-F]{64}$")] | None
+    ) = None
+
+
+class ImportBundleRequest(ContractModel):
+    """A bounded multi-file import that preserves a primary artifact and its sidecars in one run.
+
+    The bundle is capped at 100 total members (primary + sidecars) by a
+    dedicated typed-provider limit independent of the generic single-file
+    import quota.
+    """
+
+    primary: BundleMember
+    sidecars: Annotated[tuple[BundleMember, ...], Field(max_length=99)] = ()
+    kind: ArtifactKind = ArtifactKind.BENCHMARK_SAMPLES
+    sensitivity: Sensitivity = Sensitivity.INTERNAL
+    producer: str | None = None
+    producer_version: str | None = None
+    allow_external_path: bool = False
+
+
+class ImportBundleResult(ContractModel):
+    run: RunManifest
+    primary_artifact_id: str
+    sidecar_artifact_ids: tuple[str, ...]
     corpus_commit_id: str
 
 
@@ -151,6 +240,202 @@ class ImportService:
             artifact_id=stored.content.artifact_id,
             corpus_commit_id=published.commit.commit_id,
         )
+
+    def _import_provider_bundle(self, request: ImportBundleRequest) -> ImportBundleResult:
+        """Import a primary artifact and its bounded sidecars into a single run.
+
+        Enforces a hard 100-member bundle cap independent of the generic
+        single-file import quota, preflights every member (containment,
+        regular non-linked file, duplicate paths, per-file and total byte
+        limits) before any ``ArtifactStore`` import so registration is atomic,
+        while allowing distinct bundle members to reference the same immutable content.
+        """
+        members = (request.primary, *request.sidecars)
+        total_files = len(members)
+        if total_files > _MAX_BUNDLE_MEMBERS:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                f"Bundle import has {total_files} members but the typed provider "
+                f"bundle limit is {_MAX_BUNDLE_MEMBERS}.",
+            )
+        max_bytes = self.workspace.config.capture.max_artifact_bytes
+        max_total_bytes = self.workspace.config.storage.max_staging_bytes
+        allowed_roots = [self.workspace.project_root]
+        if request.allow_external_path:
+            allowed_roots.append(request.primary.path.absolute().parent)
+        self._preflight_bundle_members(members, allowed_roots, max_bytes, max_total_bytes)
+
+        environment = collect_environment()
+        source_state = collect_partial_source_state(self.workspace)
+        run_id = new_id()
+        initial = ImportRunManifest(
+            run_id=run_id,
+            capture_status=CaptureStatus.PENDING,
+            validation_status=ValidationStatus.NOT_REQUESTED,
+            environment_id=environment.environment_id,
+            source_state_id=source_state.source_state_id,
+            collector="import",
+        )
+        self.runs.create(initial)
+
+        registrations: list[ArtifactRegistration] = []
+        artifact_ids: list[str] = []
+        registration_rows: list[dict[str, object]] = []
+        imported_total_bytes = 0
+        try:
+            for member in members:
+                stored = self.artifacts.import_path(
+                    member.path,
+                    allowed_roots=tuple(allowed_roots),
+                    max_bytes=max_bytes,
+                )
+                artifact_ids.append(stored.content.artifact_id)
+                _verify_declared_integrity(member, stored)
+                imported_total_bytes += stored.content.byte_length
+                if imported_total_bytes > max_total_bytes:
+                    raise DomainError(
+                        ErrorCode.ARTIFACT_TOO_LARGE,
+                        "Imported provider bundle exceeds the configured total staging limit.",
+                    )
+                media_type = member.media_type or mimetypes.guess_type(member.path.name)[0]
+                registration = ArtifactRegistration(
+                    registration_id=new_id(),
+                    run_id=run_id,
+                    artifact_id=stored.content.artifact_id,
+                    display_name=member.display_name or member.path.name,
+                    media_type=media_type or "application/octet-stream",
+                    kind=request.kind,
+                    role=member.role,
+                    producer=request.producer or "flameox.import",
+                    producer_version=request.producer_version,
+                    sensitivity=request.sensitivity,
+                )
+                registrations.append(registration)
+                registration_rows.append(
+                    artifact_registration_row(
+                        registration,
+                        byte_length=stored.content.byte_length,
+                    )
+                )
+        except DomainError as error:
+            failed = initial.model_copy(
+                update={
+                    "revision": 1,
+                    "capture_status": CaptureStatus.FAILED,
+                    "limitations": (error.message,),
+                }
+            )
+            self.runs.append(failed, expected_revision=0)
+            error.run_id = run_id
+            raise
+
+        registered = initial.model_copy(
+            update={
+                "revision": 1,
+                "capture_status": CaptureStatus.REGISTERED,
+                "artifacts": tuple(registrations),
+            }
+        )
+        self.runs.append(registered, expected_revision=0)
+        published = self.publisher.publish_rows(
+            {
+                "runs": [run_row(registered)],
+                "artifact_registrations": registration_rows,
+                "environments": [environment_row(environment)],
+                "source_states": [source_state_row(source_state)],
+            },
+            publisher="flameox.import",
+            publisher_version="1",
+            input_run_ids=(run_id,),
+            input_artifact_ids=tuple(artifact_ids),
+        )
+        return ImportBundleResult(
+            run=registered,
+            primary_artifact_id=artifact_ids[0],
+            sidecar_artifact_ids=tuple(artifact_ids[1:]),
+            corpus_commit_id=published.commit.commit_id,
+        )
+
+    @staticmethod
+    def _preflight_bundle_members(
+        members: tuple[BundleMember, ...],
+        allowed_roots: list[Path],
+        max_bytes: int,
+        max_total_bytes: int,
+    ) -> None:
+        """Validate every bundle member before any artifact import.
+
+        Checks containment within allowed roots, regular non-linked file
+        status (no symlinks, no hard links), duplicate path detection,
+        per-file byte limits (``max_bytes`` = ``max_artifact_bytes``), and
+        the aggregate bundle byte limit (``max_total_bytes`` =
+        ``max_staging_bytes``).  All checks run before any
+        ``ArtifactStore.import_path`` call so that a preflight failure
+        leaves no partially-imported artifacts.  The per-artifact
+        ``StorageQuota`` enforcement still applies during import.
+        """
+        seen_paths: set[Path] = set()
+        seen_display_names: set[str] = set()
+        total_bytes = 0
+        for member in members:
+            source = member.path.absolute()
+            resolved = source.resolve()
+            if resolved in seen_paths:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    f"Bundle member {member.path!s} is a duplicate path.",
+                )
+            seen_paths.add(resolved)
+            display_name = member.display_name or member.path.name
+            if display_name in seen_display_names:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    f"Bundle member display name {display_name!r} is duplicated.",
+                )
+            seen_display_names.add(display_name)
+            contained = False
+            for root in allowed_roots:
+                try:
+                    relative = resolved.relative_to(root.resolve())
+                except ValueError:
+                    continue
+                if relative.parts:
+                    contained = True
+                    break
+            if not contained:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    f"Bundle member {member.path!s} is outside the allowed roots.",
+                )
+            try:
+                stat_result = source.lstat()
+            except OSError as exc:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    f"Bundle member {member.path!s} could not be stat'd.",
+                ) from exc
+            if not stat.S_ISREG(stat_result.st_mode):
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    f"Bundle member {member.path!s} is not a regular file.",
+                )
+            if stat_result.st_nlink != 1:
+                raise DomainError(
+                    ErrorCode.EXECUTION_REFUSED,
+                    f"Bundle member {member.path!s} is hard-linked and cannot be imported.",
+                )
+            if stat_result.st_size > max_bytes:
+                raise DomainError(
+                    ErrorCode.ARTIFACT_TOO_LARGE,
+                    f"Bundle member {member.path!s} exceeds the {max_bytes}-byte limit.",
+                )
+            total_bytes += stat_result.st_size
+        if total_bytes > max_total_bytes:
+            raise DomainError(
+                ErrorCode.ARTIFACT_TOO_LARGE,
+                f"Bundle total {total_bytes} bytes exceeds the "
+                f"{max_total_bytes}-byte staging limit.",
+            )
 
     def extract_otlp_trace(
         self, run_id: str, artifact_id: str | None = None

--- a/src/flameox/application/kernel_builds.py
+++ b/src/flameox/application/kernel_builds.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from pydantic import ValidationError
+
+from flameox.adapters.kernel_build import (
+    KernelBuildArtifact,
+    KernelBuildManifestV1,
+    KernelBuildStage,
+)
+from flameox.application.imports import (
+    BundleMember,
+    ImportBundleRequest,
+    ImportService,
+)
+from flameox.application.pipelines import ArtifactPipeline, ArtifactPipelineService
+from flameox.atomic import atomic_write_json
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, RunManifest, Sensitivity
+from flameox.models import ContractModel
+from flameox.storage import Workspace
+
+_MAX_KERNEL_BUILD_MEMBERS = 100
+
+# Triton dump extensions: NVIDIA (ttir/ttgir/llir/ptx/cubin/sass) and
+# AMD (amdgcn/hsaco) targets, plus metadata files emitted alongside IR.
+_TRITON_EXTENSION_MAP: dict[str, tuple[str, str, str]] = {
+    ".ttir": ("ttir", "triton-ttir", "text/plain"),
+    ".ttgir": ("ttgir", "triton-ttgir", "text/plain"),
+    ".llir": ("llir", "llvm-ir", "text/plain"),
+    ".ptx": ("ptx", "nvidia-ptx", "text/plain"),
+    ".cubin": ("cubin", "nvidia-cubin", "application/octet-stream"),
+    ".sass": ("sass", "nvidia-sass", "text/plain"),
+    ".amdgcn": ("amdgcn", "amd-amdgcn", "text/plain"),
+    ".hsaco": ("hsaco", "amd-hsaco", "application/octet-stream"),
+    ".metadata": ("metadata", "triton-metadata", "text/plain"),
+    ".json": ("metadata", "triton-metadata", "application/json"),
+}
+
+# CuTe DSL CUTE_DSL_KEEP token → retained file extensions.
+# Official tokens: ir, ir-debug, ptx, cubin, sass, llvm, all.
+_CUTE_TOKEN_EXTENSIONS: dict[str, tuple[str, ...]] = {
+    "ir": (".mlir", ".cute_dsl_ir"),
+    "ir-debug": (".mlir", ".cute_dsl_ir"),
+    "ptx": (".ptx",),
+    "cubin": (".cubin",),
+    "sass": (".sass",),
+    "llvm": (".ll", ".llvm"),
+    "all": (
+        ".mlir",
+        ".cute_dsl_ir",
+        ".ptx",
+        ".cubin",
+        ".sass",
+        ".ll",
+        ".llvm",
+    ),
+}
+
+_CUTE_EXTENSION_INFO: dict[str, tuple[str, str, str]] = {
+    ".mlir": ("cute_dsl_ir", "cute-dsl-mlir", "text/plain"),
+    ".cute_dsl_ir": ("cute_dsl_ir", "cute-dsl-ir", "text/plain"),
+    ".ptx": ("ptx", "nvidia-ptx", "text/plain"),
+    ".cubin": ("cubin", "nvidia-cubin", "application/octet-stream"),
+    ".sass": ("sass", "nvidia-sass", "text/plain"),
+    ".ll": ("llvm", "llvm-ir", "text/plain"),
+    ".llvm": ("llvm", "llvm-ir", "text/plain"),
+}
+
+# Reproducer file format info (lives outside dump_dir, in output_root).
+_REPRODUCER_FORMAT_INFO: tuple[str, str, str] = (
+    "reproducer",
+    "triton-reproducer-mlir",
+    "text/plain",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class KernelBuildInventoryEntry:
+    path: Path
+    relative_path: str
+    byte_length: int
+    sha256: str
+    extension: str
+    format: str
+    format_schema: str
+    media_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class KernelBuildInventory:
+    entries: tuple[KernelBuildInventoryEntry, ...]
+    limitations: tuple[str, ...]
+    dump_dir: Path | None
+
+
+class KernelBuildCaptureCollector:
+    """Inventory allowlisted staged native extensions and emit a kernel-build manifest.
+
+    This collector walks the dump directory produced by the compiler's env-var
+    controls, filters to a fixed extension allowlist, enforces hard
+    member/byte/containment/symlink bounds, preserves files unchanged, and
+    builds a ``flameox.kernel-build.v1`` manifest. It does not parse or rewrite
+    compiler files.
+    """
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+
+    def collect(
+        self,
+        *,
+        adapter: str,
+        dump_dir: Path,
+        output_root: Path,
+        workload_name: str,
+        exit_code: int,
+        producer_version: str | None,
+        source_environment: dict[str, str],
+        cute_keep_allowlist: tuple[str, ...] | None = None,
+        reproducer_path: Path | None = None,
+    ) -> tuple[KernelBuildManifestV1, Path, tuple[Path, ...]]:
+        if adapter == "triton.compiler":
+            extension_map = _TRITON_EXTENSION_MAP
+        elif adapter == "cute.compiler":
+            extension_map = self._cute_extension_map(cute_keep_allowlist)
+        else:
+            raise DomainError(
+                ErrorCode.INTERNAL_ERROR,
+                f"Unsupported kernel-build adapter {adapter!r}.",
+            )
+        inventory = self._inventory(dump_dir, output_root, extension_map)
+        entries = list(inventory.entries)
+        limitations: list[str] = list(inventory.limitations)
+        # The reproducer file lives outside dump_dir (in output_root) and is
+        # inventoried explicitly if it exists.
+        reproducer_entry: KernelBuildInventoryEntry | None = None
+        if reproducer_path is not None and reproducer_path.is_file():
+            reproducer_entry = self._inspect_single_file(
+                reproducer_path,
+                output_root,
+                _REPRODUCER_FORMAT_INFO,
+            )
+            if reproducer_entry is not None:
+                if len(entries) >= _MAX_KERNEL_BUILD_MEMBERS - 1:
+                    limitations.append(
+                        f"Kernel-build member count is limited to {_MAX_KERNEL_BUILD_MEMBERS} "
+                        "including the manifest; the reproducer was skipped."
+                    )
+                elif (
+                    sum(entry.byte_length for entry in entries) + reproducer_entry.byte_length
+                    > self.workspace.config.storage.max_staging_bytes
+                ):
+                    limitations.append(
+                        "The reproducer would exceed the total kernel-build staging budget; "
+                        "it was skipped."
+                    )
+                else:
+                    entries.append(reproducer_entry)
+            else:
+                limitations.append(
+                    f"Reproducer file {reproducer_path.name!r} was not a valid regular file."
+                )
+        entries_tuple = tuple(entries)
+        if entries_tuple:
+            limitations.append(
+                "Compiler artifact predecessor lineage is not declared by the provider output."
+            )
+        outcome: Literal["succeeded", "failed", "inconclusive"]
+        if exit_code == 0 and entries_tuple:
+            outcome = "succeeded"
+        elif exit_code != 0:
+            outcome = "failed"
+        else:
+            outcome = "inconclusive"
+        stages = self._build_stages(entries_tuple, outcome=outcome)
+        if not entries_tuple and exit_code != 0:
+            limitations.append("No allowlisted native artifacts were found after compiler failure.")
+        if outcome == "inconclusive":
+            limitations.append(
+                "Compiler exited successfully but produced no allowlisted native artifacts."
+            )
+        manifest = KernelBuildManifestV1(
+            producer="triton" if adapter == "triton.compiler" else "cute",
+            producer_version=producer_version or "unknown",
+            workload_identity=workload_name,
+            outcome=outcome,
+            cache_status="unknown",
+            stages=stages,
+            source_environment=self._normalized_environment(source_environment, output_root),
+            limitations=tuple(dict.fromkeys(limitations)),
+        )
+        manifest_path = output_root / "kernel-build.json"
+        atomic_write_json(manifest_path, manifest.model_dump(mode="json"))
+        native_paths = tuple(entry.path for entry in entries_tuple)
+        return manifest, manifest_path, native_paths
+
+    @staticmethod
+    def _cute_extension_map(
+        keep_allowlist: tuple[str, ...] | None,
+    ) -> dict[str, tuple[str, str, str]]:
+        """Build an extension→info map from the CUTE_DSL_KEEP token allowlist."""
+        tokens = keep_allowlist or ("ir", "ptx", "cubin")
+        allowed_exts: set[str] = set()
+        for token in tokens:
+            for ext in _CUTE_TOKEN_EXTENSIONS.get(token, ()):
+                allowed_exts.add(ext)
+        return {ext: info for ext, info in _CUTE_EXTENSION_INFO.items() if ext in allowed_exts}
+
+    def _inspect_single_file(
+        self,
+        path: Path,
+        output_root: Path,
+        format_info: tuple[str, str, str],
+    ) -> KernelBuildInventoryEntry | None:
+        """Inspect a single file outside the dump directory (e.g. reproducer)."""
+        try:
+            relative = path.relative_to(output_root).as_posix()
+        except ValueError:
+            return None
+        contained = PurePosixPath(relative)
+        if contained.is_absolute() or ".." in contained.parts:
+            return None
+        try:
+            metadata = path.lstat()
+        except OSError:
+            return None
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+            return None
+        if metadata.st_size > self.workspace.config.capture.max_artifact_bytes:
+            return None
+        try:
+            with path.open("rb") as stream:
+                digest = hashlib.file_digest(stream, "sha256").hexdigest()
+        except OSError:
+            return None
+        fmt, fmt_schema, media_type = format_info
+        return KernelBuildInventoryEntry(
+            path=path,
+            relative_path=relative,
+            byte_length=metadata.st_size,
+            sha256=digest,
+            extension=path.suffix.lower(),
+            format=fmt,
+            format_schema=fmt_schema,
+            media_type=media_type,
+        )
+
+    @staticmethod
+    def _normalized_environment(environment: dict[str, str], output_root: Path) -> dict[str, str]:
+        normalized: dict[str, str] = {}
+        resolved_root = output_root.resolve()
+        for key, value in environment.items():
+            candidate = Path(value)
+            if candidate.is_absolute():
+                try:
+                    relative = candidate.resolve().relative_to(resolved_root).as_posix()
+                except (OSError, ValueError):
+                    normalized[key] = value
+                else:
+                    normalized[key] = f"<staging>/{relative}"
+            else:
+                normalized[key] = value
+        return normalized
+
+    def _inventory(
+        self,
+        dump_dir: Path,
+        output_root: Path,
+        extension_map: dict[str, tuple[str, str, str]],
+    ) -> KernelBuildInventory:
+        if not dump_dir.is_dir():
+            return KernelBuildInventory(
+                entries=(),
+                limitations=(f"Dump directory {dump_dir.name!r} was not created.",),
+                dump_dir=None,
+            )
+        limitations: list[str] = []
+        raw_entries: list[KernelBuildInventoryEntry] = []
+        total_bytes = 0
+        max_staging = self.workspace.config.storage.max_staging_bytes
+        for path in sorted(dump_dir.rglob("*")):
+            if path.is_dir():
+                continue
+            try:
+                relative = path.relative_to(output_root).as_posix()
+            except ValueError:
+                limitations.append(f"File {path.name!r} is outside the staging root.")
+                continue
+            contained = PurePosixPath(relative)
+            if contained.is_absolute() or ".." in contained.parts:
+                limitations.append(f"File {path.name!r} escapes the staging root.")
+                continue
+            extension = self._matching_extension(path, extension_map)
+            if extension is None:
+                continue
+            try:
+                metadata = path.lstat()
+            except OSError as exc:
+                limitations.append(f"File {path.name!r} could not be inspected: {exc}.")
+                continue
+            if path.is_symlink() or not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                limitations.append(f"File {path.name!r} is not a regular non-linked file; skipped.")
+                continue
+            if metadata.st_size > self.workspace.config.capture.max_artifact_bytes:
+                limitations.append(
+                    f"File {path.name!r} exceeds the per-artifact byte limit; skipped."
+                )
+                continue
+            if total_bytes + metadata.st_size > max_staging:
+                limitations.append(
+                    "Total kernel-build artifact bytes exceed the staging budget; "
+                    "remaining files were skipped."
+                )
+                break
+            if len(raw_entries) >= _MAX_KERNEL_BUILD_MEMBERS - 1:
+                limitations.append(
+                    f"Kernel-build member count is limited to {_MAX_KERNEL_BUILD_MEMBERS} "
+                    "including the manifest; "
+                    "remaining files were skipped."
+                )
+                break
+            try:
+                with path.open("rb") as stream:
+                    digest = hashlib.file_digest(stream, "sha256").hexdigest()
+            except OSError as exc:
+                limitations.append(f"File {path.name!r} could not be read: {exc}.")
+                continue
+            fmt, fmt_schema, media_type = extension_map[extension]
+            total_bytes += metadata.st_size
+            raw_entries.append(
+                KernelBuildInventoryEntry(
+                    path=path,
+                    relative_path=relative,
+                    byte_length=metadata.st_size,
+                    sha256=digest,
+                    extension=extension,
+                    format=fmt,
+                    format_schema=fmt_schema,
+                    media_type=media_type,
+                )
+            )
+        return KernelBuildInventory(
+            entries=tuple(raw_entries),
+            limitations=tuple(dict.fromkeys(limitations)),
+            dump_dir=dump_dir,
+        )
+
+    @staticmethod
+    def _matching_extension(
+        path: Path,
+        extension_map: dict[str, tuple[str, str, str]],
+    ) -> str | None:
+        name = path.name.lower()
+        return next(
+            (
+                extension
+                for extension in sorted(extension_map, key=len, reverse=True)
+                if name.endswith(extension)
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _build_stages(
+        entries: tuple[KernelBuildInventoryEntry, ...],
+        *,
+        outcome: Literal["succeeded", "failed", "inconclusive"],
+    ) -> tuple[KernelBuildStage, ...]:
+        priority = {
+            ".ttir": 0,
+            ".ttgir": 1,
+            ".mlir": 0,
+            ".cute_dsl_ir": 0,
+            ".mlir.debug": 0,
+            ".cute_dsl_ir.debug": 0,
+            ".llir": 2,
+            ".ll": 2,
+            ".llvm": 2,
+            ".ptx": 3,
+            ".amdgcn": 3,
+            ".cubin": 4,
+            ".hsaco": 4,
+            ".sass": 5,
+            ".metadata": 6,
+            ".json": 6,
+        }
+        stages: list[KernelBuildStage] = []
+        name_counts: dict[str, int] = {}
+        ordered_entries = sorted(
+            entries,
+            key=lambda entry: (priority.get(entry.extension, 99), entry.relative_path),
+        )
+        for ordinal, entry in enumerate(ordered_entries):
+            base_name = entry.format
+            count = name_counts.get(base_name, 0)
+            name_counts[base_name] = count + 1
+            stage_name = base_name if count == 0 else f"{base_name}_{count + 1}"
+            stages.append(
+                KernelBuildStage(
+                    name=stage_name,
+                    ordinal=ordinal,
+                    predecessor=None,
+                    status="available",
+                    format=entry.format,
+                    format_schema=entry.format_schema,
+                    artifact=KernelBuildArtifact(
+                        path=entry.relative_path,
+                        byte_length=entry.byte_length,
+                        sha256=entry.sha256,
+                        media_type=entry.media_type,
+                    ),
+                )
+            )
+        if not stages:
+            empty_status: Literal["failed", "unavailable"] = (
+                "failed" if outcome == "failed" else "unavailable"
+            )
+            stages.append(
+                KernelBuildStage(
+                    name="empty",
+                    ordinal=0,
+                    status=empty_status,
+                    format="unknown",
+                    format_schema="unknown",
+                )
+            )
+        elif outcome == "failed":
+            stages.append(
+                KernelBuildStage(
+                    name="build_failed",
+                    ordinal=len(stages),
+                    predecessor=None,
+                    status="failed",
+                    format="unknown",
+                    format_schema="unknown",
+                )
+            )
+        return tuple(stages)
+
+
+class KernelBuildImportResult(ContractModel):
+    run: RunManifest
+    manifest_artifact_id: str
+    pipeline: ArtifactPipeline
+    corpus_commit_id: str
+
+
+class KernelBuildImportService:
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+
+    def import_manifest(
+        self,
+        manifest_path: Path,
+        *,
+        sensitivity: Sensitivity = Sensitivity.INTERNAL,
+        allow_external_path: bool = False,
+    ) -> KernelBuildImportResult:
+        manifest, manifest_bytes, manifest_sha256 = self._load_manifest(manifest_path)
+        members: list[BundleMember] = []
+        for stage in manifest.stages:
+            if stage.artifact is None:
+                continue
+            path = manifest_path.parent / stage.artifact.path
+            members.append(
+                BundleMember(
+                    path=path,
+                    role=f"compiler_stage:{stage.name}",
+                    media_type=stage.artifact.media_type,
+                    display_name=stage.artifact.path,
+                    expected_byte_length=stage.artifact.byte_length,
+                    expected_sha256=stage.artifact.sha256,
+                )
+            )
+        if len(members) > _MAX_KERNEL_BUILD_MEMBERS - 1:
+            raise DomainError(
+                ErrorCode.EXECUTION_REFUSED,
+                "Kernel-build manifest exceeds the 99 native-artifact bundle limit.",
+            )
+        imported = ImportService(self.workspace)._import_provider_bundle(
+            ImportBundleRequest(
+                primary=BundleMember(
+                    path=manifest_path,
+                    role="kernel_build_manifest",
+                    media_type="application/json",
+                    expected_byte_length=manifest_bytes,
+                    expected_sha256=manifest_sha256,
+                ),
+                sidecars=tuple(members),
+                kind=ArtifactKind.KERNEL_BUILD,
+                sensitivity=sensitivity,
+                producer=manifest.producer,
+                producer_version=manifest.producer_version,
+                allow_external_path=allow_external_path,
+            )
+        )
+        registrations = imported.run.artifacts[1:]
+        artifact_paths = [
+            stage.artifact.path for stage in manifest.stages if stage.artifact is not None
+        ]
+        registration_ids_by_path = {
+            path: registration.registration_id
+            for path, registration in zip(artifact_paths, registrations, strict=True)
+        }
+        pipeline = ArtifactPipelineService(self.workspace).register(
+            manifest.pipeline_request(
+                run_id=imported.run.run_id,
+                registration_ids_by_path=registration_ids_by_path,
+            )
+        )
+        return KernelBuildImportResult(
+            run=imported.run,
+            manifest_artifact_id=imported.primary_artifact_id,
+            pipeline=pipeline,
+            corpus_commit_id=imported.corpus_commit_id,
+        )
+
+    def _load_manifest(self, path: Path) -> tuple[KernelBuildManifestV1, int, str]:
+        try:
+            size = path.stat().st_size
+            if size > self.workspace.config.capture.max_artifact_bytes:
+                raise DomainError(
+                    ErrorCode.ARTIFACT_TOO_LARGE,
+                    "Kernel-build manifest exceeds the configured per-artifact limit.",
+                )
+            raw = path.read_bytes()
+            if len(raw) != size:
+                raise DomainError(
+                    ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                    "Kernel-build manifest changed while it was read.",
+                    retryable=True,
+                )
+            payload = json.loads(raw.decode("utf-8"))
+            return (
+                KernelBuildManifestV1.model_validate(payload),
+                len(raw),
+                hashlib.sha256(raw).hexdigest(),
+            )
+        except DomainError:
+            raise
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as error:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                "Kernel-build manifest is missing, malformed, or unsupported.",
+                details={"validation_error": str(error)[:2_000]},
+            ) from error

--- a/src/flameox/application/nvbench_imports.py
+++ b/src/flameox/application/nvbench_imports.py
@@ -1,0 +1,361 @@
+"""Provider-defined import for NVBench JSON and declared jsonbin sidecars."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat as stat_module
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from pydantic import ValidationError
+
+from flameox.adapters.nvbench import NvbenchJsonDocument, NvbenchSummary
+from flameox.application.imports import (
+    BundleMember,
+    ImportBundleRequest,
+    ImportBundleResult,
+    ImportService,
+)
+from flameox.domain import ArtifactKind, DomainError, ErrorCode, RunManifest, Sensitivity
+from flameox.models import ContractModel
+from flameox.storage import Workspace
+
+_FLOAT32_SIZE = 4
+_MAX_SIDECARS = 99
+
+
+class NvbenchImportResult(ContractModel):
+    """Result of an NVBench provider-defined bundle import."""
+
+    run: RunManifest
+    primary_artifact_id: str
+    sidecar_artifact_ids: tuple[str, ...]
+    corpus_commit_id: str
+    sidecar_count: int
+
+
+class NvbenchImportService:
+    """Import an NVBench JSON document and its provider-declared sidecars.
+
+    The primary JSON is parsed first to discover which sidecar files the
+    document references.  Only those files are imported — no arbitrary
+    sibling files are accepted.  Each sidecar's ``expected_byte_length``
+    is bound to ``declared_size * 4`` (float32) and, if a digest is
+    provided, ``expected_sha256`` is bound too.  The ``import_bundle``
+    primitive verifies these declarations immediately after import and
+    before registration, closing the TOCTOU gap.
+    """
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.workspace = workspace
+
+    def import_json(
+        self,
+        json_path: Path,
+        *,
+        sensitivity: Sensitivity = Sensitivity.INTERNAL,
+        allow_external_path: bool = False,
+        expected_sha256: str | None = None,
+    ) -> NvbenchImportResult:
+        """Import an NVBench JSON and its declared sidecars as one bundle.
+
+        Parameters
+        ----------
+        json_path:
+            Path to the NVBench ``--json`` output file.
+        sensitivity:
+            Sensitivity classification for the imported artifacts.
+        allow_external_path:
+            When true, allow the JSON's parent directory as an import root
+            so sidecars outside the project root can be imported.
+        expected_sha256:
+            Optional declared digest for the primary JSON itself.  When
+            set, the imported JSON is verified against this digest.
+        """
+        if (
+            expected_sha256 is not None
+            and re.fullmatch(r"(?:sha256:)?[0-9a-fA-F]{64}", expected_sha256) is None
+        ):
+            raise DomainError(
+                ErrorCode.INVALID_CAPTURE_PLAN,
+                "NVBench expected_sha256 must be a SHA-256 digest.",
+            )
+        document, document_bytes, document_sha256 = load_nvbench_document_with_integrity(
+            json_path,
+            max_bytes=self.workspace.config.capture.max_artifact_bytes,
+        )
+        sidecar_specs = collect_nvbench_sidecar_specs(document)
+        sidecar_members: list[BundleMember] = []
+        json_dir = json_path.parent
+        for spec in sidecar_specs:
+            sidecar_path = resolve_nvbench_sidecar_path(spec.filename, json_dir)
+            sidecar_members.append(
+                BundleMember(
+                    path=sidecar_path,
+                    role="nvbench_sidecar",
+                    display_name=spec.filename,
+                    media_type="application/octet-stream",
+                    expected_byte_length=spec.byte_length,
+                )
+            )
+        primary_member = BundleMember(
+            path=json_path,
+            role="primary",
+            media_type="application/json",
+            display_name=json_path.name,
+            expected_byte_length=document_bytes,
+            expected_sha256=expected_sha256 or document_sha256,
+        )
+        imported = ImportService(self.workspace)._import_provider_bundle(
+            ImportBundleRequest(
+                primary=primary_member,
+                sidecars=tuple(sidecar_members),
+                kind=ArtifactKind.BENCHMARK_SAMPLES,
+                sensitivity=sensitivity,
+                producer="nvbench",
+                producer_version=self._producer_version(document),
+                allow_external_path=allow_external_path,
+            )
+        )
+        return self._build_result(imported, len(sidecar_members))
+
+    @staticmethod
+    def _producer_version(document: NvbenchJsonDocument) -> str | None:
+        version = document.nvbench_version
+        if version is None:
+            return None
+        return version.string or f"{version.major}.{version.minor}.{version.patch}"
+
+    @staticmethod
+    def _build_result(
+        imported: ImportBundleResult,
+        sidecar_count: int,
+    ) -> NvbenchImportResult:
+        return NvbenchImportResult(
+            run=imported.run,
+            primary_artifact_id=imported.primary_artifact_id,
+            sidecar_artifact_ids=imported.sidecar_artifact_ids,
+            corpus_commit_id=imported.corpus_commit_id,
+            sidecar_count=sidecar_count,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NvbenchSidecarSpec:
+    filename: str
+    byte_length: int
+
+
+def _sidecar_spec_from_summary(summary: NvbenchSummary) -> NvbenchSidecarSpec | None:
+    """Extract a sidecar specification from a summary entry.
+
+    Returns ``None`` if the summary does not reference a file sidecar.
+    Raises ``ARTIFACT_PARSE_FAILED`` if the summary has a known file hint
+    (``file/sample_times`` or ``file/sample_freqs``) but is missing the
+    filename or has an invalid/missing size, or if the hint starts with
+    ``file/`` but is not one of the two known encodings.
+    """
+    if summary.hint is None or not summary.hint.startswith("file/"):
+        return None
+    if not summary.is_file_sidecar:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"Unknown NVBench file hint {summary.hint!r}; "
+            "only file/sample_times and file/sample_freqs are supported.",
+        )
+    filename = summary.sidecar_filename
+    if filename is None:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench summary with hint {summary.hint!r} is missing the required filename datum.",
+        )
+    size = summary.sidecar_size
+    if size is None:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench summary with hint {summary.hint!r} is missing "
+            "a valid decimal-string size datum.",
+        )
+    return NvbenchSidecarSpec(filename=filename, byte_length=size * _FLOAT32_SIZE)
+
+
+def collect_nvbench_sidecar_specs(
+    document: NvbenchJsonDocument,
+) -> list[NvbenchSidecarSpec]:
+    """Collect unique sidecar declarations from an NVBench JSON document.
+
+    Shared provider-declared sidecar selector used by both
+    ``NvbenchImportService`` (import path) and ``CaptureService``
+    (capture path).  Each summary with a ``file/`` hint may declare a
+    sidecar filename and size.  Duplicate filenames with **identical**
+    sizes are collapsed to the first declaration (NVBench may reference
+    the same sidecar from multiple summaries).  Duplicate filenames with
+    **different** sizes are rejected as an ambiguous declaration.
+    """
+    seen: dict[str, int] = {}
+    specs: list[NvbenchSidecarSpec] = []
+    for bench in document.benchmarks:
+        for state in bench.states:
+            if state.is_skipped:
+                continue
+            for summary in state.summaries:
+                spec = _sidecar_spec_from_summary(summary)
+                if spec is None:
+                    continue
+                if spec.filename in seen:
+                    if seen[spec.filename] != spec.byte_length:
+                        raise DomainError(
+                            ErrorCode.ARTIFACT_PARSE_FAILED,
+                            f"NVBench document declares conflicting sizes "
+                            f"for sidecar {spec.filename!r}.",
+                        )
+                    continue
+                seen[spec.filename] = spec.byte_length
+                specs.append(spec)
+    if len(specs) > _MAX_SIDECARS:
+        raise DomainError(
+            ErrorCode.EXECUTION_REFUSED,
+            f"NVBench document declares {len(specs)} sidecars, "
+            f"exceeding the {_MAX_SIDECARS}-sidecar limit.",
+        )
+    return specs
+
+
+def load_nvbench_sidecar_specs(
+    json_path: Path,
+    *,
+    max_bytes: int,
+) -> list[NvbenchSidecarSpec]:
+    """Load an NVBench JSON and return its provider-declared sidecar specs.
+
+    Raises ``DomainError(ARTIFACT_PARSE_FAILED)`` if the JSON is missing,
+    too large, malformed, or contains unsupported file hints.  Raises
+    ``DomainError(ARTIFACT_TOO_LARGE)`` if the file exceeds ``max_bytes``.
+
+    The caller decides how to handle failures:
+    - Successful capture: let the exception propagate so
+      ``_native_output_manifest_is_valid`` returns ``False`` and the run
+      fails with a bounded limitation.
+    - Nonzero/partial capture: catch the exception to treat the missing
+      sidecar evidence as a bounded limitation/proof gap, not a trigger
+      for globbing.
+    """
+    return collect_nvbench_sidecar_specs(load_nvbench_document(json_path, max_bytes=max_bytes))
+
+
+def load_nvbench_document(json_path: Path, *, max_bytes: int) -> NvbenchJsonDocument:
+    document, _, _ = load_nvbench_document_with_integrity(json_path, max_bytes=max_bytes)
+    return document
+
+
+def load_nvbench_document_with_integrity(
+    json_path: Path,
+    *,
+    max_bytes: int,
+) -> tuple[NvbenchJsonDocument, int, str]:
+    try:
+        size = json_path.stat().st_size
+        if size > max_bytes:
+            raise DomainError(
+                ErrorCode.ARTIFACT_TOO_LARGE,
+                "NVBench JSON exceeds the configured per-artifact byte limit.",
+            )
+        raw = json_path.read_bytes()
+        if len(raw) != size:
+            raise DomainError(
+                ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+                "NVBench JSON changed while it was read.",
+                retryable=True,
+            )
+        document = NvbenchJsonDocument.model_validate(json.loads(raw.decode("utf-8")))
+        return document, len(raw), hashlib.sha256(raw).hexdigest()
+    except DomainError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            "The file is not a valid NVBench JSON document.",
+            details={"error": str(exc)[:2_000]},
+        ) from exc
+
+
+def resolve_nvbench_sidecar_path(
+    filename: str,
+    output_root: Path,
+) -> Path:
+    """Resolve a declared sidecar filename against the output root.
+
+    The filename must be a normalized relative POSIX path (no absolute
+    paths, no ``..`` components, no leading ``/``).  The resolved path
+    (after symlink expansion) must remain under ``output_root``.
+
+    Returns the **lexical** candidate path (``output_root / filename``),
+    not the symlink-resolved target.  This ensures that a symlink
+    inside the bundle is preserved for ``lstat`` so that
+    ``validate_nvbench_sidecar_file`` can reject it as non-regular.
+
+    Raises ``DomainError(ARTIFACT_PARSE_FAILED)`` if the filename is
+    not a safe relative path or escapes the output root.
+    """
+    relative = PurePosixPath(filename)
+    if (
+        not filename
+        or "\\" in filename
+        or relative.is_absolute()
+        or filename != relative.as_posix()
+        or any(part in {"", ".", ".."} for part in relative.parts)
+    ):
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar filename {filename!r} is not a normalized relative POSIX path.",
+        )
+    candidate = output_root.joinpath(*relative.parts)
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(output_root.resolve())
+    except ValueError:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar filename {filename!r} resolves outside the output root.",
+        ) from None
+    return candidate
+
+
+def validate_nvbench_sidecar_file(
+    path: Path,
+    expected_byte_length: int,
+) -> int:
+    """Validate a sidecar file on disk before registration.
+
+    Returns the actual byte length on success.  Raises
+    ``DomainError(ARTIFACT_PARSE_FAILED)`` if the file is missing, not a
+    regular file, is hard-linked, or its byte length does not match the
+    declared ``expected_byte_length``.
+    """
+    try:
+        stat_result = path.lstat()
+    except OSError as exc:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar {path!s} could not be stat'd.",
+            details={"error": str(exc)[:2_000]},
+        ) from exc
+    if not stat_module.S_ISREG(stat_result.st_mode):
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar {path!s} is not a regular file.",
+        )
+    if stat_result.st_nlink != 1:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar {path!s} is hard-linked and cannot be registered.",
+        )
+    if stat_result.st_size != expected_byte_length:
+        raise DomainError(
+            ErrorCode.ARTIFACT_PARSE_FAILED,
+            f"NVBench sidecar {path!s} byte length mismatch: "
+            f"expected {expected_byte_length}, got {stat_result.st_size}.",
+        )
+    return stat_result.st_size

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -25,6 +25,7 @@ from flameox.adapters import (
     KernelValidationExtractor,
     MemrayExtractor,
     NsightSystemsExtractor,
+    NvbenchExtractor,
     ObservationExtractor,
     PerfettoExtractor,
     PyPerfExtractor,
@@ -35,6 +36,7 @@ from flameox.adapters import (
 from flameox.analysis import RecipeService
 from flameox.application import (
     AnalysisMaterializationService,
+    ArtifactPipelineService,
     ArtifactService,
     CapabilityService,
     CaptureService,
@@ -61,14 +63,17 @@ from flameox.application import (
     InferenceReplayService,
     IntegrityService,
     InvestigationService,
+    KernelBuildImportService,
     LifecycleEvidenceService,
     MaterializeAnalysisRequest,
     NativeViewerService,
+    NvbenchImportService,
     OtlpTraceService,
     QuarantineService,
     RecordFindingRequest,
     RecordHypothesisRequest,
     RecoveryService,
+    RegisterPipelineRequest,
     RepairPlan,
     RepairService,
     RunDiscoveryService,
@@ -116,6 +121,7 @@ inference_app = typer.Typer(help="Configure, plan, and run local inference scena
 stacks_app = typer.Typer(help="Inspect bounded call relationships and stacks.")
 trace_app = typer.Typer(help="Inspect bounded temporal trace windows.")
 adapters_app = typer.Typer(help="Discover and approve third-party adapter entry points.")
+pipelines_app = typer.Typer(help="Register and compare immutable artifact pipelines.")
 app.add_typer(catalog_app, name="catalog")
 app.add_typer(runs_app, name="runs")
 app.add_typer(extract_app, name="extract")
@@ -137,6 +143,7 @@ app.add_typer(inference_app, name="inference")
 app.add_typer(stacks_app, name="stacks")
 app.add_typer(trace_app, name="trace")
 app.add_typer(adapters_app, name="adapters")
+app.add_typer(pipelines_app, name="pipelines")
 
 WorkspaceOption = Annotated[
     Path | None,
@@ -835,6 +842,101 @@ def import_artifact(
         )
     except DomainError as error:
         _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@app.command("import-kernel-build")
+def import_kernel_build(
+    path: Annotated[Path, typer.Argument(help="flameox.kernel-build.v1 manifest to import.")],
+    sensitivity: Annotated[
+        Sensitivity,
+        typer.Option("--sensitivity", case_sensitive=False),
+    ] = Sensitivity.INTERNAL,
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Import a bounded compiler-artifact bundle and register its pipeline."""
+    try:
+        result = KernelBuildImportService(_workspace(workspace)).import_manifest(
+            path,
+            sensitivity=sensitivity,
+            allow_external_path=True,
+        )
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@app.command("import-nvbench")
+def import_nvbench(
+    path: Annotated[Path, typer.Argument(help="NVBench --json output file to import.")],
+    sensitivity: Annotated[
+        Sensitivity,
+        typer.Option("--sensitivity", case_sensitive=False),
+    ] = Sensitivity.INTERNAL,
+    expected_sha256: Annotated[
+        str | None,
+        typer.Option("--expected-sha256", help="Declared SHA-256 digest of the JSON file."),
+    ] = None,
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Import an NVBench JSON and its provider-declared sidecars as one bundle."""
+    try:
+        result = NvbenchImportService(_workspace(workspace)).import_json(
+            path,
+            sensitivity=sensitivity,
+            allow_external_path=True,
+            expected_sha256=expected_sha256,
+        )
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@pipelines_app.command("register")
+def pipeline_register(
+    request_path: Annotated[
+        Path,
+        typer.Argument(help="JSON file containing a RegisterPipelineRequest."),
+    ],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Register a bounded pipeline over artifacts already attached to one run."""
+    try:
+        request = RegisterPipelineRequest.model_validate_json(request_path.read_text())
+        result = ArtifactPipelineService(_workspace(workspace)).register(request)
+    except ValidationError as error:
+        _fail(_validation_error(error), as_json=json_output)
+    except OSError as error:
+        _fail(
+            DomainError(
+                ErrorCode.ARTIFACT_PARSE_FAILED,
+                f"Pipeline request could not be read: {error}.",
+            ),
+            as_json=json_output,
+        )
+    except DomainError as error:
+        _fail(error, as_json=json_output)
+    _emit(result, as_json=json_output)
+
+
+@pipelines_app.command("compare")
+def pipeline_compare(
+    baseline_pipeline_id: Annotated[str, typer.Argument()],
+    candidate_pipeline_id: Annotated[str, typer.Argument()],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Compare two compatible ordered artifact pipelines."""
+    try:
+        result = ArtifactPipelineService(_workspace(workspace)).compare(
+            baseline_pipeline_id,
+            candidate_pipeline_id,
+        )
+    except DomainError as error:
+        _fail(error, as_json=json_output)
     _emit(result, as_json=json_output)
 
 
@@ -2273,6 +2375,23 @@ def extract_compute_sanitizer(
     """Extract bounded sanitizer findings through the isolated XML worker."""
     try:
         result = ComputeSanitizerExtractor(_workspace(workspace)).extract(run_id)
+    except DomainError as error:
+        _fail(error)
+    _emit(result, as_json=json_output)
+
+
+@extract_app.command("nvbench")
+def extract_nvbench(
+    run_id: Annotated[
+        str,
+        typer.Argument(help="Import run containing an NVBench JSON + jsonbin bundle."),
+    ],
+    workspace: WorkspaceOption = None,
+    json_output: JsonOption = False,
+) -> None:
+    """Extract NVBench sample times and frequencies from a preserved bundle."""
+    try:
+        result = NvbenchExtractor(_workspace(workspace)).extract(run_id)
     except DomainError as error:
         _fail(error)
     _emit(result, as_json=json_output)

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -103,6 +103,7 @@ class ArtifactKind(StrEnum):
     EXPERIMENT_CONFIGURATION = "experiment_configuration"
     INFERENCE_REQUEST_TRACE = "inference_request_trace"
     INFERENCE_RESULT = "inference_result"
+    KERNEL_BUILD = "kernel_build"
 
 
 class RunType(StrEnum):

--- a/src/flameox/mcp/resources.py
+++ b/src/flameox/mcp/resources.py
@@ -6,8 +6,10 @@ from typing import Literal, Protocol, cast
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 
+from flameox.adapters.kernel_build import kernel_build_json_schema
 from flameox.adapters.kernel_validation import kernel_validation_json_schema
 from flameox.application import (
+    ArtifactPipelineService,
     ArtifactService,
     EvidenceLookupService,
     ExperimentService,
@@ -30,14 +32,6 @@ def _workspace(ctx: Context) -> Workspace:
 
 def register_resources[T: WorkspaceContext](server: MCPServer[T]) -> None:  # noqa: C901
     """Register resource projections independently from the MCP tool transport."""
-
-    @server.resource(
-        "flameox://schemas/kernel-validation/v1",
-        mime_type="application/schema+json",
-        description="Published JSON Schema for flameox.kernel-validation.v1.",
-    )
-    async def kernel_validation_schema_resource() -> str:
-        return json.dumps(kernel_validation_json_schema(), indent=2, sort_keys=True)
 
     def error_payload(error: DomainError) -> str:
         return json.dumps({"ok": False, "error": error.to_detail()})
@@ -63,6 +57,38 @@ def register_resources[T: WorkspaceContext](server: MCPServer[T]) -> None:  # no
         try:
             workspace = _workspace(ctx)
             return ArtifactService(workspace).get(artifact_id).model_dump_json(indent=2)
+        except DomainError as error:
+            return error_payload(error)
+
+    @server.resource(
+        "flameox://schemas/kernel-validation/v1",
+        mime_type="application/schema+json",
+        description="Published JSON Schema for flameox.kernel-validation.v1.",
+    )
+    async def kernel_validation_schema_resource() -> str:
+        return json.dumps(kernel_validation_json_schema(), indent=2, sort_keys=True)
+
+    @server.resource(
+        "flameox://schemas/kernel-build/v1",
+        mime_type="application/schema+json",
+        description="Published JSON Schema for flameox.kernel-build.v1.",
+    )
+    async def kernel_build_schema_resource() -> str:
+        return json.dumps(kernel_build_json_schema(), indent=2, sort_keys=True)
+
+    @server.resource(
+        "flameox://pipelines/{pipeline_id}",
+        mime_type="application/json",
+        description="Immutable artifact-pipeline projection.",
+    )
+    async def pipeline_resource(pipeline_id: str, ctx: Context) -> str:
+        try:
+            workspace = _workspace(ctx)
+            return (
+                ArtifactPipelineService(workspace)
+                .pipelines.read(pipeline_id)
+                .model_dump_json(indent=2)
+            )
         except DomainError as error:
             return error_payload(error)
 

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -33,6 +33,8 @@ from flameox.adapters import (
     MemrayExtractor,
     NsightSystemsExtractionResult,
     NsightSystemsExtractor,
+    NvbenchExtractionResult,
+    NvbenchExtractor,
     ObservationExtractionResult,
     ObservationExtractor,
     PerfettoExtractionResult,
@@ -115,12 +117,16 @@ from flameox.application import (
     IntegrityService,
     InvestigationListResult,
     InvestigationService,
+    KernelBuildImportResult,
+    KernelBuildImportService,
     LifecycleEvidenceService,
     LifecycleQueryResult,
     MaterializeAnalysisRequest,
     MeasurementQueryResult,
     NativeViewerPlan,
     NativeViewerService,
+    NvbenchImportResult,
+    NvbenchImportService,
     OtlpExtractionResult,
     OtlpTraceService,
     PipelineComparison,
@@ -2152,6 +2158,108 @@ def create_server(
         except DomainError as error:
             return _failure(error)
 
+    @server.tool(name="import_kernel_build", annotations=ADDITIVE)
+    async def import_kernel_build_tool(
+        path: Annotated[
+            str,
+            Field(description="Kernel-build manifest path within the selected bounded root."),
+        ],
+        sensitivity: Sensitivity,
+        ctx: Context[AppContext],
+        source_root: Literal["project", "temp"] = "project",
+    ) -> Annotated[CallToolResult, ToolPayload[KernelBuildImportResult]]:
+        """Import declared native compiler files and register the existing pipeline model."""
+        try:
+            state = ctx.request_context.lifespan_context
+            result = await run_atomic_thread(
+                lambda: KernelBuildImportService(state.require_workspace()).import_manifest(
+                    _safe_import_path(state.project_root, path, source_root),
+                    sensitivity=sensitivity,
+                    allow_external_path=source_root == "temp",
+                )
+            )
+            return _success(
+                result,
+                f"Imported kernel-build pipeline {result.pipeline.pipeline_id}.",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Run {result.run.run_id}",
+                        uri=f"flameox://runs/{result.run.run_id}",
+                        description="Immutable kernel-build import run.",
+                        mime_type="application/json",
+                    ),
+                    ResourceLink(
+                        name=f"Pipeline {result.pipeline.pipeline_id}",
+                        uri=f"flameox://pipelines/{result.pipeline.pipeline_id}",
+                        description="Immutable compiler artifact pipeline.",
+                        mime_type="application/json",
+                    ),
+                ),
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="import_nvbench", annotations=ADDITIVE)
+    async def import_nvbench_tool(
+        path: Annotated[
+            str,
+            Field(description="NVBench --json output path within the selected bounded root."),
+        ],
+        sensitivity: Sensitivity,
+        ctx: Context[AppContext],
+        source_root: Literal["project", "temp"] = "project",
+        expected_sha256: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Declared SHA-256 digest of the JSON file (with or without sha256: prefix)."
+                ),
+                max_length=200,
+                pattern=r"^(?:sha256:)?[0-9a-fA-F]{64}$",
+            ),
+        ] = None,
+    ) -> Annotated[CallToolResult, ToolPayload[NvbenchImportResult]]:
+        """Import an NVBench JSON and its provider-declared sidecars as one atomic bundle.
+
+        Parses the primary JSON first to discover which sidecar files the
+        document references.  Only those files are imported — no arbitrary
+        sibling files are accepted.  Each sidecar's expected byte length is
+        bound to ``declared_size * 4`` (float32) and verified after import.
+        """
+        try:
+            state = ctx.request_context.lifespan_context
+            result = await run_atomic_thread(
+                lambda: NvbenchImportService(state.require_workspace()).import_json(
+                    _safe_import_path(state.project_root, path, source_root),
+                    sensitivity=sensitivity,
+                    allow_external_path=source_root == "temp",
+                    expected_sha256=expected_sha256,
+                )
+            )
+            run_uri = f"flameox://runs/{result.run.run_id}"
+            artifact_uri = f"flameox://artifacts/{result.primary_artifact_id}"
+            return _success(
+                result,
+                f"Imported NVBench bundle with {result.sidecar_count} sidecar(s) "
+                f"in run {result.run.run_id}.",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Run {result.run.run_id}",
+                        uri=run_uri,
+                        description="Immutable NVBench import run.",
+                        mime_type="application/json",
+                    ),
+                    ResourceLink(
+                        name=f"Artifact {result.primary_artifact_id}",
+                        uri=artifact_uri,
+                        description="Imported NVBench JSON artifact metadata.",
+                        mime_type="application/json",
+                    ),
+                ),
+            )
+        except DomainError as error:
+            return _failure(error)
+
     @server.tool(annotations=READ_ONLY)
     async def list_runs(
         limit: Annotated[StrictInt, Field(ge=1, le=1_000)],
@@ -2217,7 +2325,18 @@ def create_server(
             pipeline = ArtifactPipelineService(
                 ctx.request_context.lifespan_context.require_workspace()
             ).register(request)
-            return _success(pipeline, f"Registered artifact pipeline {pipeline.pipeline_id}.")
+            return _success(
+                pipeline,
+                f"Registered artifact pipeline {pipeline.pipeline_id}.",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Pipeline {pipeline.pipeline_id}",
+                        uri=f"flameox://pipelines/{pipeline.pipeline_id}",
+                        description="Immutable artifact-pipeline resource.",
+                        mime_type="application/json",
+                    ),
+                ),
+            )
         except DomainError as error:
             return _failure(error)
 
@@ -3235,6 +3354,46 @@ def create_server(
                         name=f"Artifact {result.artifact_id}",
                         uri=artifact_uri,
                         description="Authoritative Compute Sanitizer report metadata.",
+                        mime_type="application/json",
+                    ),
+                ),
+            )
+        except DomainError as error:
+            return _failure(error)
+
+    @server.tool(name="extract_nvbench", annotations=ADDITIVE)
+    async def extract_nvbench_tool(
+        run_id: Annotated[str, Field(min_length=1, max_length=200)],
+        ctx: Context[AppContext],
+    ) -> Annotated[CallToolResult, ToolPayload[NvbenchExtractionResult]]:
+        """Extract NVBench sample times and frequencies from a preserved bundle.
+
+        The run must contain exactly one primary NVBench JSON artifact and
+        zero or more sidecar artifacts declared by the JSON document.
+        """
+        try:
+            result = await run_atomic_thread(
+                lambda: NvbenchExtractor(
+                    ctx.request_context.lifespan_context.require_workspace()
+                ).extract(run_id)
+            )
+            run_uri = f"flameox://runs/{result.run_id}"
+            artifact_uri = f"flameox://artifacts/{result.artifact_id}"
+            return _success(
+                result,
+                f"Extracted {result.measurement_count} measurements from "
+                f"{result.benchmark_count} benchmark(s).",
+                resource_links=(
+                    ResourceLink(
+                        name=f"Run {result.run_id}",
+                        uri=run_uri,
+                        description="Authoritative NVBench import run.",
+                        mime_type="application/json",
+                    ),
+                    ResourceLink(
+                        name=f"Artifact {result.artifact_id}",
+                        uri=artifact_uri,
+                        description="Imported NVBench JSON artifact metadata.",
                         mime_type="application/json",
                     ),
                 ),

--- a/src/flameox/schemas/kernel-build-v1.schema.json
+++ b/src/flameox/schemas/kernel-build-v1.schema.json
@@ -1,0 +1,259 @@
+{
+  "$defs": {
+    "KernelBuildArtifact": {
+      "additionalProperties": false,
+      "properties": {
+        "byte_length": {
+          "minimum": 0,
+          "title": "Byte Length",
+          "type": "integer"
+        },
+        "media_type": {
+          "default": "application/octet-stream",
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Media Type",
+          "type": "string"
+        },
+        "path": {
+          "maxLength": 500,
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "role": {
+          "default": "compiler_stage",
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Role",
+          "type": "string"
+        },
+        "sha256": {
+          "pattern": "^[0-9a-f]{64}$",
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "byte_length",
+        "sha256"
+      ],
+      "title": "KernelBuildArtifact",
+      "type": "object"
+    },
+    "KernelBuildStage": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KernelBuildArtifact"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "elapsed_ns": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Elapsed Ns"
+        },
+        "format": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Format",
+          "type": "string"
+        },
+        "format_schema": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Format Schema",
+          "type": "string"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "maxLength": 500,
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 20,
+          "title": "Limitations",
+          "type": "array"
+        },
+        "name": {
+          "maxLength": 100,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "ordinal": {
+          "maximum": 99,
+          "minimum": 0,
+          "title": "Ordinal",
+          "type": "integer"
+        },
+        "predecessor": {
+          "anyOf": [
+            {
+              "maxLength": 100,
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Predecessor"
+        },
+        "status": {
+          "enum": [
+            "available",
+            "cached",
+            "skipped",
+            "unavailable",
+            "failed"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "ordinal",
+        "status",
+        "format",
+        "format_schema"
+      ],
+      "title": "KernelBuildStage",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "cache_status": {
+      "default": "unknown",
+      "enum": [
+        "hit",
+        "miss",
+        "mixed",
+        "unknown"
+      ],
+      "title": "Cache Status",
+      "type": "string"
+    },
+    "device_identity": {
+      "anyOf": [
+        {
+          "maxLength": 500,
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Device Identity"
+    },
+    "diagnostics": {
+      "default": [],
+      "items": {
+        "maxLength": 2000,
+        "minLength": 1,
+        "type": "string"
+      },
+      "maxItems": 50,
+      "title": "Diagnostics",
+      "type": "array"
+    },
+    "limitations": {
+      "default": [],
+      "items": {
+        "maxLength": 500,
+        "minLength": 1,
+        "type": "string"
+      },
+      "maxItems": 20,
+      "title": "Limitations",
+      "type": "array"
+    },
+    "outcome": {
+      "enum": [
+        "succeeded",
+        "failed",
+        "inconclusive"
+      ],
+      "title": "Outcome",
+      "type": "string"
+    },
+    "producer": {
+      "enum": [
+        "triton",
+        "cute"
+      ],
+      "title": "Producer",
+      "type": "string"
+    },
+    "producer_version": {
+      "maxLength": 100,
+      "minLength": 1,
+      "title": "Producer Version",
+      "type": "string"
+    },
+    "schema_version": {
+      "const": "flameox.kernel-build.v1",
+      "default": "flameox.kernel-build.v1",
+      "title": "Schema Version",
+      "type": "string"
+    },
+    "source_environment": {
+      "additionalProperties": {
+        "maxLength": 500,
+        "type": "string"
+      },
+      "propertyNames": {
+        "maxLength": 100,
+        "minLength": 1
+      },
+      "title": "Source Environment",
+      "type": "object"
+    },
+    "stages": {
+      "items": {
+        "$ref": "#/$defs/KernelBuildStage"
+      },
+      "maxItems": 100,
+      "minItems": 1,
+      "title": "Stages",
+      "type": "array"
+    },
+    "workload_identity": {
+      "maxLength": 200,
+      "minLength": 1,
+      "title": "Workload Identity",
+      "type": "string"
+    }
+  },
+  "required": [
+    "producer",
+    "producer_version",
+    "workload_identity",
+    "outcome",
+    "stages"
+  ],
+  "title": "KernelBuildManifestV1",
+  "type": "object"
+}

--- a/tests/adapters/test_cute_compiler_live.py
+++ b/tests/adapters/test_cute_compiler_live.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from flameox.application import CaptureService, ExecutionPolicy
+from flameox.domain import (
+    ArtifactKind,
+    CapabilityReport,
+    CapabilityStatus,
+    CaptureStatus,
+    ExecutionStatus,
+)
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+
+@pytest.mark.requires_cute
+@pytest.mark.anyio
+async def test_configured_cute_workload_emits_kernel_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workload = os.environ.get("FLAMEOX_CUTE_WORKLOAD")
+    assert workload is not None
+    workspace = Workspace.initialize(tmp_path)
+    disable_containment(workspace)
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.compile]
+argv = [{json.dumps(workload)}]
+timeout_seconds = 120
+"""
+    )
+    report = CapabilityReport(
+        adapter="cute.compiler",
+        status=CapabilityStatus.AVAILABLE,
+        version="configured-workload",
+        supported_modes=("compile",),
+        supported_formats=("kernel-build-manifest",),
+        permission_status="granted",
+        probe_kind="passive",
+    )
+    service = CaptureService(workspace)
+    monkeypatch.setattr(service.capabilities, "get", lambda _adapter: report)
+
+    async def probe(_adapter: str, *, refresh: bool = False) -> CapabilityReport:
+        assert refresh
+        return report
+
+    monkeypatch.setattr(service.capabilities, "probe", probe)
+
+    plan = await service.plan(
+        workload_name="compile",
+        adapter="cute.compiler",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    assert any(
+        registration.kind is ArtifactKind.KERNEL_BUILD
+        and registration.role.startswith("compiler_stage:")
+        for registration in result.run.artifacts
+    )

--- a/tests/adapters/test_kernel_build.py
+++ b/tests/adapters/test_kernel_build.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from flameox.adapters import KernelBuildManifestV1, kernel_build_json_schema
+from flameox.application import KernelBuildImportService, RegisteredPipelineStageDeclaration
+from flameox.domain import DomainError
+from flameox.storage import Workspace
+
+
+def _manifest(**updates: object) -> KernelBuildManifestV1:
+    payload: dict[str, object] = {
+        "producer": "triton",
+        "producer_version": "3.7.1",
+        "workload_identity": "vector-add",
+        "device_identity": "NVIDIA sm_86",
+        "outcome": "succeeded",
+        "cache_status": "miss",
+        "source_environment": {
+            "TRITON_DUMP_DIR": "compiler-dumps",
+            "TRITON_KERNEL_DUMP": "1",
+        },
+        "stages": [
+            {
+                "name": "ttir",
+                "ordinal": 0,
+                "status": "available",
+                "format": "mlir",
+                "format_schema": "triton-ttir",
+                "artifact": {
+                    "path": "kernel/vector_add.ttir",
+                    "byte_length": 4,
+                    "sha256": "a" * 64,
+                    "media_type": "text/plain",
+                },
+            },
+            {
+                "name": "ptx",
+                "ordinal": 1,
+                "predecessor": "ttir",
+                "status": "cached",
+                "format": "ptx",
+                "format_schema": "nvidia-ptx",
+                "artifact": {
+                    "path": "kernel/vector_add.ptx",
+                    "byte_length": 4,
+                    "sha256": "b" * 64,
+                    "media_type": "text/plain",
+                },
+            },
+        ],
+    }
+    payload.update(updates)
+    return KernelBuildManifestV1.model_validate(payload)
+
+
+def test_kernel_build_translates_to_existing_pipeline_contract() -> None:
+    manifest = _manifest(diagnostics=["diagnostic text remains native manifest data"])
+
+    request = manifest.pipeline_request(
+        run_id="run-1",
+        registration_ids_by_path={
+            "kernel/vector_add.ttir": "registration-ttir",
+            "kernel/vector_add.ptx": "registration-ptx",
+        },
+    )
+
+    assert request.pipeline_name == "triton.compiler"
+    assert request.pipeline_schema == "flameox.kernel-build.v1"
+    assert all(isinstance(stage, RegisteredPipelineStageDeclaration) for stage in request.stages)
+    assert request.stages[1].status == "cached"
+    assert "diagnostics are preserved" in request.limitations[0]
+
+
+def test_kernel_build_returns_only_declared_bundle_paths(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+
+    assert _manifest().bundle_paths(manifest_path) == (
+        tmp_path / "kernel/vector_add.ttir",
+        tmp_path / "kernel/vector_add.ptx",
+    )
+
+
+@pytest.mark.parametrize("path", ["../secret", "/absolute", "kernel/../secret", "."])
+def test_kernel_build_rejects_uncontained_artifact_paths(path: str) -> None:
+    stages = _manifest().model_dump(mode="json")["stages"]
+    stages[0]["artifact"]["path"] = path
+
+    with pytest.raises(ValidationError, match=r"contained relative|normalized"):
+        _manifest(stages=stages)
+
+
+def test_kernel_build_rejects_duplicate_artifacts_and_out_of_order_stages() -> None:
+    stages = _manifest().model_dump(mode="json")["stages"]
+    stages[1]["artifact"]["path"] = stages[0]["artifact"]["path"]
+    stages[1]["ordinal"] = 0
+
+    with pytest.raises(ValidationError, match="unique"):
+        _manifest(stages=stages)
+
+
+def test_failed_build_requires_failed_stage_and_success_rejects_missing_output() -> None:
+    stages = _manifest().model_dump(mode="json")["stages"]
+    stages[1]["status"] = "unavailable"
+    stages[1]["artifact"] = None
+
+    with pytest.raises(ValidationError, match="successful build"):
+        _manifest(stages=stages)
+    with pytest.raises(ValidationError, match="requires a failed stage"):
+        _manifest(outcome="failed")
+
+
+def test_kernel_build_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs"):
+        _manifest(unverified_hint=True)
+
+
+def test_kernel_build_generated_schema_does_not_drift() -> None:
+    schema_path = (
+        Path(__file__).resolve().parents[2] / "src/flameox/schemas/kernel-build-v1.schema.json"
+    )
+
+    assert json.loads(schema_path.read_text(encoding="utf-8")) == kernel_build_json_schema()
+
+
+def test_kernel_build_bundle_import_registers_existing_pipeline(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    artifact_path = tmp_path / "kernel.ttir"
+    artifact_path.write_text("ttir", encoding="utf-8")
+    manifest = _manifest(
+        stages=[
+            {
+                "name": "ttir",
+                "ordinal": 0,
+                "status": "available",
+                "format": "mlir",
+                "format_schema": "triton-ttir",
+                "artifact": {
+                    "path": artifact_path.name,
+                    "byte_length": 4,
+                    "sha256": hashlib.sha256(b"ttir").hexdigest(),
+                    "media_type": "text/plain",
+                },
+            }
+        ]
+    )
+    manifest_path = tmp_path / "kernel-build.json"
+    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+
+    result = KernelBuildImportService(workspace).import_manifest(manifest_path)
+
+    assert result.run.artifacts[0].role == "kernel_build_manifest"
+    assert result.run.artifacts[1].role == "compiler_stage:ttir"
+    assert result.pipeline.run_id == result.run.run_id
+    assert result.pipeline.stages[0].artifact_id == result.run.artifacts[1].artifact_id
+
+
+def test_kernel_build_bundle_rejects_digest_mismatch_before_registration(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    (tmp_path / "kernel.ttir").write_text("changed", encoding="utf-8")
+    manifest = _manifest(
+        stages=[
+            {
+                "name": "ttir",
+                "ordinal": 0,
+                "status": "available",
+                "format": "mlir",
+                "format_schema": "triton-ttir",
+                "artifact": {
+                    "path": "kernel.ttir",
+                    "byte_length": 4,
+                    "sha256": hashlib.sha256(b"ttir").hexdigest(),
+                },
+            }
+        ]
+    )
+    manifest_path = tmp_path / "kernel-build.json"
+    manifest_path.write_text(manifest.model_dump_json(), encoding="utf-8")
+
+    with pytest.raises(DomainError, match="byte length mismatch"):
+        KernelBuildImportService(workspace).import_manifest(manifest_path)
+
+
+def test_kernel_build_import_preserves_distinct_paths_with_same_basename(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    stages: list[dict[str, object]] = []
+    for ordinal, directory in enumerate(("kernel-a", "kernel-b")):
+        artifact_path = tmp_path / directory / "kernel.ptx"
+        artifact_path.parent.mkdir()
+        payload = f"ptx-{ordinal}".encode()
+        artifact_path.write_bytes(payload)
+        stages.append(
+            {
+                "name": f"ptx-{ordinal}",
+                "ordinal": ordinal,
+                "status": "available",
+                "format": "ptx",
+                "format_schema": "nvidia-ptx",
+                "artifact": {
+                    "path": f"{directory}/kernel.ptx",
+                    "byte_length": len(payload),
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                    "media_type": "text/plain",
+                },
+            }
+        )
+    manifest_path = tmp_path / "kernel-build.json"
+    manifest_path.write_text(_manifest(stages=stages).model_dump_json())
+
+    result = KernelBuildImportService(workspace).import_manifest(manifest_path)
+
+    assert [item.display_name for item in result.run.artifacts[1:]] == [
+        "kernel-a/kernel.ptx",
+        "kernel-b/kernel.ptx",
+    ]

--- a/tests/adapters/test_kernel_build_capture.py
+++ b/tests/adapters/test_kernel_build_capture.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters.builtins import build_capture_invocation
+from flameox.adapters.options import bind_adapter_options
+from flameox.application import (
+    ArtifactPipelineService,
+    CaptureService,
+    ExecutionPolicy,
+    KernelBuildCaptureCollector,
+)
+from flameox.domain import ArtifactKind, CaptureStatus, DomainError, ErrorCode, ExecutionStatus
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+
+def _write_workload(
+    project: Path,
+    *,
+    script: str,
+    environment: dict[str, str] | None = None,
+) -> None:
+    env_section = ""
+    if environment:
+        env_lines = "\n".join(f'  {key} = "{value}"' for key, value in environment.items())
+        env_section = f"\n[workloads.compile.environment]\n{env_lines}"
+    (project / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+
+[workloads.compile]
+argv = ["python", "{script}"]
+cwd = "."
+timeout_seconds = 30{env_section}
+"""
+    )
+
+
+def _dump_script(path: Path, dump_dir: Path, *, exit_code: int = 0) -> None:
+    """A fake compiler that writes IR files to TRITON_DUMP_DIR and exits."""
+    path.write_text(
+        f"""
+import os, sys, pathlib
+dump = pathlib.Path(os.environ["TRITON_DUMP_DIR"])
+dump.mkdir(parents=True, exist_ok=True)
+(dump / "kernel.ttir").write_text("ttir content")
+(dump / "kernel.ptx").write_text("ptx content")
+(dump / "kernel.cubin").write_bytes(b"\\x00\\x01\\x02\\x03")
+sys.exit({exit_code})
+"""
+    )
+
+
+def test_triton_compiler_capture_invocation_sets_env_vars(tmp_path: Path) -> None:
+    invocation = build_capture_invocation(
+        "triton.compiler",
+        ("python", "compile.py"),
+        tmp_path / "output",
+        executable=None,
+        options={"dump_subdir": "triton-dumps", "kernel_dump": True},
+    )
+    assert invocation.argv == ("python", "compile.py")
+    assert invocation.environment["TRITON_KERNEL_DUMP"] == "1"
+    assert "triton-dumps" in invocation.environment["TRITON_DUMP_DIR"]
+    assert "TRITON_REPRODUCER_PATH" not in invocation.environment
+
+
+def test_triton_compiler_reproducer_option_sets_env_var(tmp_path: Path) -> None:
+    invocation = build_capture_invocation(
+        "triton.compiler",
+        ("python", "compile.py"),
+        tmp_path / "output",
+        executable=None,
+        options={"reproducer_filename": "triton-reproducer.mlir"},
+    )
+    assert "TRITON_REPRODUCER_PATH" in invocation.environment
+    assert invocation.environment["TRITON_REPRODUCER_PATH"].endswith("triton-reproducer.mlir")
+
+
+def test_cute_compiler_capture_invocation_sets_env_vars(tmp_path: Path) -> None:
+    invocation = build_capture_invocation(
+        "cute.compiler",
+        ("python", "compile.py"),
+        tmp_path / "output",
+        executable=None,
+        options={"keep_allowlist": ("ir", "ptx")},
+    )
+    assert invocation.argv == ("python", "compile.py")
+    assert "CUTE_DSL_DUMP_DIR" in invocation.environment
+    assert invocation.environment["CUTE_DSL_KEEP"] == "ir,ptx"
+
+
+def test_cute_compiler_rejects_all_mixed_with_other_tokens(tmp_path: Path) -> None:
+    with pytest.raises(DomainError) as error:
+        bind_adapter_options(
+            "cute.compiler",
+            {"keep_allowlist": ["all", "ptx"]},
+            project_root=tmp_path,
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_cute_compiler_rejects_duplicate_keep_allowlist(tmp_path: Path) -> None:
+    with pytest.raises(DomainError) as error:
+        bind_adapter_options(
+            "cute.compiler",
+            {"keep_allowlist": ["ptx", "ptx"]},
+            project_root=tmp_path,
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_triton_compiler_rejects_invalid_dump_subdir(tmp_path: Path) -> None:
+    with pytest.raises(DomainError) as error:
+        bind_adapter_options(
+            "triton.compiler",
+            {"dump_subdir": "../escape"},
+            project_root=tmp_path,
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+@pytest.mark.anyio
+async def test_env_conflict_rejected_unless_identical(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    script = tmp_path / "compile.py"
+    _dump_script(script, tmp_path / "triton-dumps")
+    _write_workload(
+        tmp_path,
+        script=str(script),
+        environment={"TRITON_DUMP_DIR": "/elsewhere"},
+    )
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    with pytest.raises(DomainError) as error:
+        await service._adapter_command(
+            "triton.compiler",
+            service.workloads.resolve("compile").command,
+            tmp_path / "staging",
+            options=bind_adapter_options(
+                "triton.compiler",
+                {},
+                project_root=tmp_path,
+            ),
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+    assert "conflict" in error.value.message.lower()
+
+
+@pytest.mark.anyio
+async def test_env_conflict_identical_value_accepted(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    staging = tmp_path / "staging"
+    invocation = build_capture_invocation(
+        "triton.compiler",
+        ("python", "compile.py"),
+        staging,
+        executable=None,
+        options={},
+    )
+    dump_dir = invocation.environment["TRITON_DUMP_DIR"]
+    script = tmp_path / "compile.py"
+    _dump_script(script, Path(dump_dir))
+    _write_workload(
+        tmp_path,
+        script=str(script),
+        environment={"TRITON_DUMP_DIR": dump_dir},
+    )
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    binding = await service._adapter_command(
+        "triton.compiler",
+        service.workloads.resolve("compile").command,
+        staging,
+        options=bind_adapter_options(
+            "triton.compiler",
+            {},
+            project_root=tmp_path,
+        ),
+    )
+    assert binding.environment["TRITON_DUMP_DIR"] == dump_dir
+
+
+@pytest.mark.anyio
+async def test_triton_compiler_capture_emits_manifest_with_native_artifacts(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    script = tmp_path / "compile.py"
+    _dump_script(script, tmp_path / "triton-dumps")
+    _write_workload(tmp_path, script=str(script))
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="compile",
+        adapter="triton.compiler",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    manifest_reg = next(reg for reg in result.run.artifacts if reg.role == "kernel_build_manifest")
+    assert manifest_reg.kind is ArtifactKind.KERNEL_BUILD
+    native_regs = [reg for reg in result.run.artifacts if reg.role.startswith("compiler_stage:")]
+    assert len(native_regs) == 3
+    extensions = {reg.display_name.rsplit(".", 1)[1] for reg in native_regs}
+    assert extensions == {"ttir", "ptx", "cubin"}
+    pipelines = ArtifactPipelineService(workspace).pipelines.list()
+    assert len(pipelines) == 1
+    assert pipelines[0].run_id == result.run.run_id
+    assert {stage.artifact_id for stage in pipelines[0].stages} == {
+        registration.artifact_id for registration in native_regs
+    }
+
+
+@pytest.mark.anyio
+async def test_triton_compiler_capture_preserves_manifest_on_nonzero_exit(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    script = tmp_path / "compile.py"
+    _dump_script(script, tmp_path / "triton-dumps", exit_code=1)
+    _write_workload(tmp_path, script=str(script))
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="compile",
+        adapter="triton.compiler",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+    assert result.run.execution_status is ExecutionStatus.FAILED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    manifest_regs = [reg for reg in result.run.artifacts if reg.role == "kernel_build_manifest"]
+    assert len(manifest_regs) == 1
+    native_regs = [reg for reg in result.run.artifacts if reg.role.startswith("compiler_stage:")]
+    assert len(native_regs) == 3
+
+
+@pytest.mark.anyio
+async def test_cute_compiler_capture_emits_manifest(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    script = tmp_path / "compile.py"
+    script.write_text(
+        """
+import os, sys, pathlib
+dump = pathlib.Path(os.environ["CUTE_DSL_DUMP_DIR"])
+dump.mkdir(parents=True, exist_ok=True)
+(dump / ("cute_dsl_" + "long_kernel_identity_" * 6 + ".mlir")).write_text("cute ir")
+(dump / "kernel.ptx").write_text("ptx")
+sys.exit(0)
+"""
+    )
+    _write_workload(tmp_path, script=str(script))
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="compile",
+        adapter="cute.compiler",
+        adapter_options={"keep_allowlist": ["ir", "ptx"]},
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    native_regs = [reg for reg in result.run.artifacts if reg.role.startswith("compiler_stage:")]
+    assert len(native_regs) == 2
+    assert all(len(reg.role) <= 100 for reg in native_regs)
+    assert any("long_kernel_identity" in reg.display_name for reg in native_regs)
+    pipelines = ArtifactPipelineService(workspace).pipelines.list()
+    assert len(pipelines) == 1
+    assert {stage.artifact_id for stage in pipelines[0].stages} == {
+        registration.artifact_id for registration in native_regs
+    }
+
+
+@pytest.mark.anyio
+async def test_kernel_build_manifest_content_matches_artifacts(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    script = tmp_path / "compile.py"
+    _dump_script(script, tmp_path / "triton-dumps")
+    _write_workload(tmp_path, script=str(script))
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="compile",
+        adapter="triton.compiler",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+    from flameox.storage import ArtifactStore
+
+    manifest_reg = next(reg for reg in result.run.artifacts if reg.role == "kernel_build_manifest")
+    artifact = ArtifactStore(workspace).get(manifest_reg.artifact_id)
+    manifest = json.loads(artifact.payload_path.read_text())
+    assert manifest["schema_version"] == "flameox.kernel-build.v1"
+    assert manifest["producer"] == "triton"
+    assert manifest["workload_identity"] == "compile"
+    assert manifest["outcome"] == "succeeded"
+    assert len(manifest["stages"]) == 3
+    for stage in manifest["stages"]:
+        assert stage["artifact"] is not None
+        assert len(stage["artifact"]["sha256"]) == 64
+    ttir_stage = next(s for s in manifest["stages"] if s["name"] == "ttir")
+    assert ttir_stage["format"] == "ttir"
+    assert ttir_stage["format_schema"] == "triton-ttir"
+    ptx_stage = next(s for s in manifest["stages"] if s["name"] == "ptx")
+    assert ptx_stage["predecessor"] is None
+    assert any("predecessor lineage" in item for item in manifest["limitations"])
+
+
+def test_collector_rejects_symlink_in_dump_dir(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    target = tmp_path / "real.ttir"
+    target.write_text("real")
+    link = dump_dir / "link.ttir"
+    link.symlink_to(target)
+    collector = KernelBuildCaptureCollector(workspace)
+    _, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    assert native_paths == ()
+
+
+def test_collector_ignores_non_allowlisted_extensions(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    (dump_dir / "kernel.ttir").write_text("ttir")
+    (dump_dir / "readme.txt").write_text("ignore me")
+    (dump_dir / "data.bin").write_bytes(b"binary")
+    collector = KernelBuildCaptureCollector(workspace)
+    _, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    assert len(native_paths) == 1
+    assert native_paths[0].suffix == ".ttir"
+
+
+def test_collector_emits_inconclusive_when_no_artifacts(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    collector = KernelBuildCaptureCollector(workspace)
+    manifest, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    assert manifest.outcome == "inconclusive"
+    assert native_paths == ()
+    assert any("no allowlisted" in lim.lower() for lim in manifest.limitations)
+
+
+def test_collector_emits_failed_when_nonzero_and_no_artifacts(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    collector = KernelBuildCaptureCollector(workspace)
+    manifest, _, _ = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=1,
+        producer_version="1",
+        source_environment={},
+    )
+    assert manifest.outcome == "failed"
+
+
+def test_collector_handles_missing_dump_dir(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    collector = KernelBuildCaptureCollector(workspace)
+    manifest, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=tmp_path / "nonexistent",
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    assert manifest.outcome == "inconclusive"
+    assert native_paths == ()
+
+
+def test_collector_cute_keep_allowlist_filters_extensions(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "cute-dumps"
+    dump_dir.mkdir()
+    (dump_dir / "kernel.mlir").write_text("ir")
+    (dump_dir / "kernel.ptx").write_text("ptx")
+    (dump_dir / "kernel.cubin").write_bytes(b"cubin")
+    collector = KernelBuildCaptureCollector(workspace)
+    _, _, native_paths = collector.collect(
+        adapter="cute.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+        cute_keep_allowlist=("ptx",),
+    )
+    assert len(native_paths) == 1
+    assert native_paths[0].suffix == ".ptx"
+
+
+def test_collector_recognizes_cute_multi_suffix_debug_ir(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "cute-dumps"
+    dump_dir.mkdir()
+    debug_ir = dump_dir / "kernel.mlir"
+    debug_ir.write_text("debug ir")
+
+    manifest, _, native_paths = KernelBuildCaptureCollector(workspace).collect(
+        adapter="cute.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={"CUTE_DSL_DUMP_DIR": str(dump_dir)},
+        cute_keep_allowlist=("ir-debug",),
+    )
+
+    assert native_paths == (debug_ir,)
+    assert manifest.stages[0].format == "cute_dsl_ir"
+    assert manifest.source_environment["CUTE_DSL_DUMP_DIR"] == "<staging>/cute-dumps"
+
+
+def test_collector_hardlinks_rejected(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    original = tmp_path / "original.ttir"
+    original.write_text("content")
+    hardlink = dump_dir / "link.ttir"
+    os.link(original, hardlink)
+    collector = KernelBuildCaptureCollector(workspace)
+    _, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    if hardlink.lstat().st_nlink > 1:
+        assert native_paths == ()
+    else:
+        assert len(native_paths) == 1
+
+
+def test_collector_inventories_amdgcn_and_hsaco_extensions(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    (dump_dir / "kernel.amdgcn").write_text("amdgcn source")
+    (dump_dir / "kernel.hsaco").write_bytes(b"hsaco binary")
+    collector = KernelBuildCaptureCollector(workspace)
+    manifest, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    assert len(native_paths) == 2
+    extensions = {p.suffix for p in native_paths}
+    assert extensions == {".amdgcn", ".hsaco"}
+    formats = {s.format for s in manifest.stages if s.artifact is not None}
+    assert "amdgcn" in formats
+    assert "hsaco" in formats
+
+
+def test_collector_inventories_reproducer_file_outside_dump_dir(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    dump_dir.mkdir()
+    (dump_dir / "kernel.ttir").write_text("ttir")
+    reproducer = tmp_path / "triton-reproducer.mlir"
+    reproducer.write_text("reproducer content")
+    collector = KernelBuildCaptureCollector(workspace)
+    manifest, _, native_paths = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+        reproducer_path=reproducer,
+    )
+    assert len(native_paths) == 2
+    assert reproducer in native_paths
+    reproducer_stage = next(s for s in manifest.stages if s.format == "reproducer")
+    assert reproducer_stage.artifact is not None
+    assert reproducer_stage.artifact.path == "triton-reproducer.mlir"
+
+
+def test_collector_does_not_infer_predecessor_lineage_from_paths(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    dump_dir = tmp_path / "triton-dumps"
+    kernel_a = dump_dir / "kernel_a"
+    kernel_b = dump_dir / "kernel_b"
+    kernel_a.mkdir(parents=True)
+    kernel_b.mkdir(parents=True)
+    (kernel_a / "a.ttir").write_text("a ttir")
+    (kernel_a / "a.ptx").write_text("a ptx")
+    (kernel_b / "b.ttir").write_text("b ttir")
+    (kernel_b / "b.ptx").write_text("b ptx")
+    collector = KernelBuildCaptureCollector(workspace)
+    manifest, _, _ = collector.collect(
+        adapter="triton.compiler",
+        dump_dir=dump_dir,
+        output_root=tmp_path,
+        workload_name="compile",
+        exit_code=0,
+        producer_version="1",
+        source_environment={},
+    )
+    available = [stage for stage in manifest.stages if stage.artifact is not None]
+    assert [stage.format for stage in available] == ["ttir", "ttir", "ptx", "ptx"]
+    assert all(stage.predecessor is None for stage in available)
+    assert any("predecessor lineage" in item for item in manifest.limitations)

--- a/tests/adapters/test_nvbench.py
+++ b/tests/adapters/test_nvbench.py
@@ -1,0 +1,1084 @@
+"""Tests for NVBench JSON + jsonbin bundle import and extraction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from flameox.adapters.builtins import build_capture_invocation
+from flameox.adapters.nvbench import NvbenchExtractor
+from flameox.adapters.options import bind_adapter_options
+from flameox.application import ImportService, NvbenchImportService
+from flameox.application.imports import BundleMember, ImportBundleRequest
+from flameox.catalog import Catalog
+from flameox.domain import ArtifactKind, DomainError, ErrorCode
+from flameox.storage import GenerationManifest, RunStore, Workspace
+
+
+def _float32_bytes(values: list[float]) -> bytes:
+    return struct.pack(f"<{len(values)}f", *values)
+
+
+def _nvbench_json(
+    *,
+    sidecar_filename: str = "out.json-bin/0.bin",
+    sample_count: int = 3,
+    benchmark_name: str = "cub.bench.scan",
+    state_name: str = "[T=I32 Elements=2^16]",
+    device_id: int = 0,
+    json_version: tuple[int, int, int] = (1, 0, 0),
+    nvbench_version: tuple[int, int, int] = (0, 1, 0),
+) -> str:
+    return json.dumps(
+        {
+            "meta": {
+                "argv": ["bench", "-d", "0", "--jsonbin", "out.json"],
+                "version": {
+                    "json": {
+                        "major": json_version[0],
+                        "minor": json_version[1],
+                        "patch": json_version[2],
+                        "string": ".".join(str(v) for v in json_version),
+                    },
+                    "nvbench": {
+                        "major": nvbench_version[0],
+                        "minor": nvbench_version[1],
+                        "patch": nvbench_version[2],
+                        "string": ".".join(str(v) for v in nvbench_version),
+                    },
+                },
+            },
+            "devices": [
+                {"id": device_id, "name": "NVIDIA GeForce RTX 4090"},
+            ],
+            "benchmarks": [
+                {
+                    "name": benchmark_name,
+                    "index": 0,
+                    "axes": [],
+                    "states": [
+                        {
+                            "name": state_name,
+                            "device": device_id,
+                            "type_config_index": 0,
+                            "is_skipped": False,
+                            "summaries": [
+                                {
+                                    "tag": "nv/json/bin:sample_times",
+                                    "name": "Sample Times File",
+                                    "description": (
+                                        "Binary file containing sample times "
+                                        "as little-endian float32."
+                                    ),
+                                    "hint": "file/sample_times",
+                                    "hide": "Not needed in table.",
+                                    "data": [
+                                        {
+                                            "name": "filename",
+                                            "type": "string",
+                                            "value": sidecar_filename,
+                                        },
+                                        {
+                                            "name": "size",
+                                            "type": "int64",
+                                            # NVBench json_printer.cu serializes
+                                            # int64 values as decimal strings.
+                                            "value": str(sample_count),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+
+
+def _import_bundle(
+    workspace: Workspace,
+    json_path: Path,
+    sidecar_path: Path,
+    *,
+    sidecar_filename: str = "out.json-bin/0.bin",
+) -> str:
+    result = ImportService(workspace)._import_provider_bundle(
+        ImportBundleRequest(
+            primary=BundleMember(
+                path=json_path,
+                role="primary",
+                media_type="application/json",
+            ),
+            sidecars=(
+                BundleMember(
+                    path=sidecar_path,
+                    role="nvbench_sidecar",
+                    media_type="application/octet-stream",
+                    display_name=sidecar_filename,
+                ),
+            ),
+            kind=ArtifactKind.BENCHMARK_SAMPLES,
+            producer="nvbench",
+            producer_version="0.1.0",
+        )
+    )
+    return result.run.run_id
+
+
+def test_nvbench_extracts_float32_sample_times_without_lossy_conversion(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    samples = [0.004571, 0.004580, 0.004562]
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=len(samples)))
+    sidecar_path.write_bytes(_float32_bytes(samples))
+
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    result = NvbenchExtractor(workspace).extract(run_id)
+    repeated = NvbenchExtractor(workspace).extract(run_id)
+
+    assert result.measurement_count == 3
+    assert result.benchmark_count == 1
+    assert result.producer_version == "0.1.0"
+    assert result.limitations == ()
+    assert repeated.corpus_commit_id == result.corpus_commit_id
+    run = RunStore(workspace).read(run_id)
+    expected_input_ids = {
+        registration.artifact_id
+        for registration in run.artifacts
+        if registration.role in {"primary", "nvbench_sidecar"}
+    }
+    head = workspace.corpus.read_head()
+    generations = [
+        GenerationManifest.model_validate_json(
+            (workspace.paths.root / relative_path).read_text(encoding="utf-8")
+        )
+        for relative_path in head.generation_manifests
+    ]
+    generation = next(
+        manifest for manifest in generations if manifest.publisher == NvbenchExtractor.name
+    )
+    assert set(generation.input_artifact_ids) == expected_input_ids
+    with Catalog(workspace).open_snapshot() as snapshot:
+        rows = snapshot.execute(
+            "SELECT name, value_int, value_float, unit, is_warmup, "
+            "dimensions FROM measurements WHERE run_id = ? "
+            "ORDER BY value_index",
+            (run_id,),
+        ).fetchall()
+    assert len(rows) == 3
+    for row in rows:
+        name, value_int, value_float, unit, is_warmup, dimensions = row
+        assert name == "nvbench.cub.bench.scan.sample_times"
+        assert value_int is None
+        assert value_float is not None
+        assert unit == "seconds"
+        assert is_warmup is False
+        assert dimensions["nvbench_benchmark"] == "cub.bench.scan"
+    assert rows[0][2] == pytest.approx(0.004571, abs=1e-6)
+
+
+def test_nvbench_rejects_nonfinite_binary_samples(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    sidecar_path.write_bytes(_float32_bytes([float("nan")]))
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    with pytest.raises(DomainError, match="non-finite"):
+        NvbenchExtractor(workspace).extract(run_id)
+
+
+def test_nvbench_measurement_identity_includes_consumed_sidecar(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "out.json-bin" / "0.bin"
+    sidecar_path.parent.mkdir()
+    json_path.write_text(_nvbench_json(sample_count=1))
+    sidecar_path.write_bytes(_float32_bytes([0.001]))
+    first_run = NvbenchImportService(workspace).import_json(json_path).run.run_id
+    first = NvbenchExtractor(workspace).extract(first_run)
+
+    sidecar_path.write_bytes(_float32_bytes([0.002]))
+    second_run = NvbenchImportService(workspace).import_json(json_path).run.run_id
+    second = NvbenchExtractor(workspace).extract(second_run)
+
+    with Catalog(workspace).open_snapshot() as snapshot:
+        measurement_ids = snapshot.execute(
+            "SELECT run_id, measurement_id FROM measurements "
+            "WHERE run_id IN (?, ?) ORDER BY run_id",
+            (first_run, second_run),
+        ).fetchall()
+    assert first.corpus_commit_id != second.corpus_commit_id
+    assert len({measurement_id for _, measurement_id in measurement_ids}) == 2
+
+
+def test_nvbench_extracts_real_upstream_shape_with_nested_relative_paths(
+    tmp_path: Path,
+) -> None:
+    """Reflect real NVBench output: string-serialized size and nested
+    relative sidecar paths like ``out.json-bin/0.bin``.
+
+    NVBench's json_printer.cu writes int64 summary values as decimal
+    strings and stores sidecar filenames as paths relative to the JSON
+    file's directory (e.g. ``out.json-bin/0.bin``).  The bundle import
+    must preserve that relative path in ``display_name`` so the extractor
+    can match it exactly.
+    """
+    workspace = Workspace.initialize(tmp_path)
+    samples = [0.003120, 0.003145, 0.003108, 0.003129]
+    json_path = tmp_path / "out.json"
+    # Real NVBench writes sidecars into a sibling directory:
+    #   out.json-bin/0.bin
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    json_path.write_text(
+        _nvbench_json(
+            sidecar_filename="out.json-bin/0.bin",
+            sample_count=len(samples),
+        )
+    )
+    sidecar_path.write_bytes(_float32_bytes(samples))
+
+    run_id = _import_bundle(
+        workspace,
+        json_path,
+        sidecar_path,
+        sidecar_filename="out.json-bin/0.bin",
+    )
+
+    result = NvbenchExtractor(workspace).extract(run_id)
+    assert result.measurement_count == 4
+    assert result.benchmark_count == 1
+    with Catalog(workspace).open_snapshot() as snapshot:
+        rows = snapshot.execute(
+            "SELECT value_float, unit FROM measurements WHERE run_id = ? ORDER BY value_index",
+            (run_id,),
+        ).fetchall()
+    assert len(rows) == 4
+    for row in rows:
+        value_float, unit = row
+        assert unit == "seconds"
+        assert value_float is not None
+    assert rows[0][0] == pytest.approx(0.003120, abs=1e-6)
+
+
+def test_nvbench_rejects_non_decimal_string_size(tmp_path: Path) -> None:
+    """NVBench serializes size as a decimal string; non-decimal values
+    must be rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    doc = json.loads(_nvbench_json(sample_count=3))
+    doc["benchmarks"][0]["states"][0]["summaries"][0]["data"][1]["value"] = "-5"
+    json_path.write_text(json.dumps(doc))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02, 0.03]))
+
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    with pytest.raises(DomainError) as error:
+        NvbenchExtractor(workspace).extract(run_id)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_rejects_numeric_sidecar_size_in_current_schema(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    doc = json.loads(_nvbench_json(sample_count=3))
+    doc["benchmarks"][0]["states"][0]["summaries"][0]["data"][1]["value"] = 3
+    json_path.write_text(json.dumps(doc))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_handles_skipped_states(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    doc = json.loads(_nvbench_json(sample_count=2))
+    doc["benchmarks"][0]["states"].append(
+        {
+            "name": "[T=F32 Elements=2^20]",
+            "device": 0,
+            "is_skipped": True,
+            "skip_reason": "No CUDA device",
+            "summaries": [],
+        }
+    )
+    json_path.write_text(json.dumps(doc))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02]))
+
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    result = NvbenchExtractor(workspace).extract(run_id)
+    assert result.measurement_count == 2
+
+
+def test_nvbench_rejects_missing_sidecar(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    other_path = tmp_path / "wrong.bin"
+    json_path.write_text(_nvbench_json(sidecar_filename="0.bin", sample_count=2))
+    other_path.write_bytes(_float32_bytes([0.01, 0.02]))
+
+    run_id = _import_bundle(
+        workspace,
+        json_path,
+        other_path,
+        sidecar_filename="wrong.bin",
+    )
+
+    with pytest.raises(DomainError) as error:
+        NvbenchExtractor(workspace).extract(run_id)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_rejects_sidecar_size_mismatch(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=3))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02]))
+
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    with pytest.raises(DomainError) as error:
+        NvbenchExtractor(workspace).extract(run_id)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_rejects_declared_samples_over_row_budget_before_decoding(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    document = json.loads(_nvbench_json(sample_count=2))
+    summaries = document["benchmarks"][0]["states"][0]["summaries"]
+    summaries.append(
+        {**summaries[0], "tag": "nv/json/bin:sample_freqs", "hint": "file/sample_freqs"}
+    )
+    json_path.write_text(json.dumps(document))
+    # This payload is deliberately malformed for the declared sample count. A
+    # decoder-first implementation reports a size mismatch instead of rejecting
+    # the declared allocation against the generation budget.
+    sidecar_path.write_bytes(b"not-float32-data")
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+    config = workspace.config.model_copy(
+        update={
+            "storage": workspace.config.storage.model_copy(update={"max_rows_per_generation": 3})
+        }
+    )
+    workspace.paths.config.write_text(config.to_toml())
+
+    with pytest.raises(DomainError) as error:
+        NvbenchExtractor(workspace).extract(run_id)
+
+    assert error.value.code is ErrorCode.QUERY_BUDGET_EXCEEDED
+    assert error.value.details == {"rows": 4, "max_rows": 3}
+
+
+def test_nvbench_rejects_malformed_json(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text("{not valid json")
+    sidecar_path.write_bytes(_float32_bytes([0.01]))
+
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    with pytest.raises(DomainError) as error:
+        NvbenchExtractor(workspace).extract(run_id)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_extracts_zero_measurements_from_empty_document(
+    tmp_path: Path,
+) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text('{"meta": {}, "benchmarks": []}')
+    sidecar_path.write_bytes(_float32_bytes([0.01]))
+
+    run_id = _import_bundle(workspace, json_path, sidecar_path)
+
+    result = NvbenchExtractor(workspace).extract(run_id)
+    assert result.measurement_count == 0
+    assert result.benchmark_count == 0
+
+
+def test_nvbench_rejects_run_without_primary(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    sidecar_path.write_bytes(_float32_bytes([0.01]))
+
+    result = ImportService(workspace)._import_provider_bundle(
+        ImportBundleRequest(
+            primary=BundleMember(
+                path=json_path,
+                role="secondary",
+                media_type="application/json",
+            ),
+            sidecars=(
+                BundleMember(
+                    path=sidecar_path,
+                    role="nvbench_sidecar",
+                    media_type="application/octet-stream",
+                ),
+            ),
+            kind=ArtifactKind.BENCHMARK_SAMPLES,
+            producer="nvbench",
+        )
+    )
+
+    with pytest.raises(DomainError) as error:
+        NvbenchExtractor(workspace).extract(result.run.run_id)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_bundle_import_rejects_excess_members(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    sidecar_files: list[BundleMember] = []
+    for i in range(100):
+        sidecar = tmp_path / f"{i}.bin"
+        sidecar.write_bytes(_float32_bytes([float(i)]))
+        sidecar_files.append(BundleMember(path=sidecar, role="nvbench_sidecar"))
+
+    with pytest.raises(ValidationError):
+        ImportService(workspace)._import_provider_bundle(
+            ImportBundleRequest(
+                primary=BundleMember(path=json_path),
+                sidecars=tuple(sidecar_files),
+                kind=ArtifactKind.BENCHMARK_SAMPLES,
+                producer="nvbench",
+            )
+        )
+
+
+def test_bundle_import_rejects_duplicate_sidecar(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    sidecar_path.write_bytes(_float32_bytes([0.01]))
+
+    with pytest.raises(DomainError) as error:
+        ImportService(workspace)._import_provider_bundle(
+            ImportBundleRequest(
+                primary=BundleMember(path=json_path),
+                sidecars=(
+                    BundleMember(path=sidecar_path, role="nvbench_sidecar"),
+                    BundleMember(path=sidecar_path, role="nvbench_sidecar"),
+                ),
+                kind=ArtifactKind.BENCHMARK_SAMPLES,
+                producer="nvbench",
+            )
+        )
+    assert error.value.code is ErrorCode.EXECUTION_REFUSED
+
+
+def test_bundle_import_allows_distinct_members_with_identical_content(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_a = tmp_path / "a.bin"
+    sidecar_b = tmp_path / "b.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    payload = _float32_bytes([0.01])
+    sidecar_a.write_bytes(payload)
+    sidecar_b.write_bytes(payload)
+
+    result = ImportService(workspace)._import_provider_bundle(
+        ImportBundleRequest(
+            primary=BundleMember(path=json_path),
+            sidecars=(
+                BundleMember(path=sidecar_a, role="nvbench_sidecar"),
+                BundleMember(path=sidecar_b, role="nvbench_sidecar"),
+            ),
+            kind=ArtifactKind.BENCHMARK_SAMPLES,
+            producer="nvbench",
+        )
+    )
+
+    assert result.sidecar_artifact_ids[0] == result.sidecar_artifact_ids[1]
+
+
+def test_bundle_import_verifies_declared_byte_length(tmp_path: Path) -> None:
+    """A source that changes size between manifest and import is rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    payload = _float32_bytes([0.01])
+    sidecar_path.write_bytes(payload)
+
+    # Declare a wrong byte length to simulate a raced source
+    with pytest.raises(DomainError) as error:
+        ImportService(workspace)._import_provider_bundle(
+            ImportBundleRequest(
+                primary=BundleMember(path=json_path),
+                sidecars=(
+                    BundleMember(
+                        path=sidecar_path,
+                        role="nvbench_sidecar",
+                        display_name="out.json-bin/0.bin",
+                        expected_byte_length=len(payload) + 1,
+                    ),
+                ),
+                kind=ArtifactKind.BENCHMARK_SAMPLES,
+                producer="nvbench",
+            )
+        )
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+    assert "byte length mismatch" in error.value.message
+
+
+def test_bundle_import_verifies_declared_sha256(tmp_path: Path) -> None:
+    """A source whose digest differs from the manifest is rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    payload = _float32_bytes([0.01])
+    sidecar_path.write_bytes(payload)
+
+    wrong_sha = "sha256:" + "0" * 64
+    with pytest.raises(DomainError) as error:
+        ImportService(workspace)._import_provider_bundle(
+            ImportBundleRequest(
+                primary=BundleMember(path=json_path),
+                sidecars=(
+                    BundleMember(
+                        path=sidecar_path,
+                        role="nvbench_sidecar",
+                        display_name="out.json-bin/0.bin",
+                        expected_sha256=wrong_sha,
+                    ),
+                ),
+                kind=ArtifactKind.BENCHMARK_SAMPLES,
+                producer="nvbench",
+            )
+        )
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+    assert "sha256 mismatch" in error.value.message
+
+
+def test_bundle_import_accepts_correct_declared_integrity(tmp_path: Path) -> None:
+    """Correct declared byte length and sha256 pass verification."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "nvbench.json"
+    sidecar_path = tmp_path / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=1))
+    payload = _float32_bytes([0.01])
+    sidecar_path.write_bytes(payload)
+    actual_sha = "sha256:" + hashlib.sha256(payload).hexdigest()
+
+    result = ImportService(workspace)._import_provider_bundle(
+        ImportBundleRequest(
+            primary=BundleMember(path=json_path),
+            sidecars=(
+                BundleMember(
+                    path=sidecar_path,
+                    role="nvbench_sidecar",
+                    display_name="out.json-bin/0.bin",
+                    expected_byte_length=len(payload),
+                    expected_sha256=actual_sha,
+                ),
+            ),
+            kind=ArtifactKind.BENCHMARK_SAMPLES,
+            producer="nvbench",
+        )
+    )
+    assert result.primary_artifact_id
+
+
+# ---------------------------------------------------------------------------
+# NvbenchImportService: provider-defined selection boundary
+# ---------------------------------------------------------------------------
+
+
+def test_nvbench_import_service_imports_only_declared_sidecars(tmp_path: Path) -> None:
+    """Only sidecars referenced by the JSON are imported, not arbitrary siblings."""
+    workspace = Workspace.initialize(tmp_path)
+    samples = [0.01, 0.02, 0.03]
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    # An undeclared sibling that must NOT be imported
+    undeclared_path = sidecar_dir / "1.bin"
+    json_path.write_text(_nvbench_json(sample_count=len(samples)))
+    sidecar_path.write_bytes(_float32_bytes(samples))
+    undeclared_path.write_bytes(_float32_bytes([0.99, 0.88]))
+
+    result = NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+
+    assert result.sidecar_count == 1
+    assert len(result.sidecar_artifact_ids) == 1
+    # The undeclared file must not appear in the run
+    with Catalog(workspace).open_snapshot() as snapshot:
+        rows = snapshot.execute(
+            "SELECT display_name FROM artifact_registrations "
+            "WHERE run_id = ? ORDER BY display_name",
+            (result.run.run_id,),
+        ).fetchall()
+    display_names = [row[0] for row in rows]
+    assert "out.json-bin/0.bin" in display_names
+    assert "out.json-bin/1.bin" not in display_names
+
+
+def test_nvbench_import_service_binds_expected_byte_length(tmp_path: Path) -> None:
+    """Sidecar expected_byte_length = count * 4 is verified after import."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    # JSON declares 3 samples (12 bytes) but we write 4 samples (16 bytes)
+    json_path.write_text(_nvbench_json(sample_count=3))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02, 0.03, 0.04]))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+    assert "byte length mismatch" in error.value.message
+
+
+def test_nvbench_import_service_round_trip_extract(tmp_path: Path) -> None:
+    """import_json followed by NvbenchExtractor.extract produces correct measurements."""
+    workspace = Workspace.initialize(tmp_path)
+    samples = [0.003120, 0.003145, 0.003108, 0.003129]
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=len(samples)))
+    sidecar_path.write_bytes(_float32_bytes(samples))
+
+    result = NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    extracted = NvbenchExtractor(workspace).extract(result.run.run_id)
+    assert extracted.measurement_count == 4
+    assert extracted.benchmark_count == 1
+
+
+def test_nvbench_import_service_rejects_malformed_json(tmp_path: Path) -> None:
+    """A non-JSON file is rejected at parse time before any import."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    json_path.write_text("{not valid json")
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_import_service_rejects_conflicting_sidecar_sizes(
+    tmp_path: Path,
+) -> None:
+    """Duplicate sidecar filenames with different sizes are rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    # Build a document with two summaries referencing the same sidecar
+    # filename but declaring different sizes.  Both use the documented
+    # file/sample_freqs hint.
+    doc = json.loads(_nvbench_json(sample_count=3))
+    state = doc["benchmarks"][0]["states"][0]
+    state["summaries"].append(
+        {
+            "tag": "sample_freqs",
+            "hint": "file/sample_freqs",
+            "data": [
+                {"name": "filename", "type": "string", "value": "out.json-bin/0.bin"},
+                {"name": "size", "type": "int64", "value": "5"},
+            ],
+        }
+    )
+    json_path.write_text(json.dumps(doc))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02, 0.03]))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+    assert "conflicting sizes" in error.value.message
+
+
+def test_nvbench_import_service_collapses_duplicate_sidecar_same_size(
+    tmp_path: Path,
+) -> None:
+    """Duplicate sidecar filenames with identical sizes are collapsed."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    # Build a document with two summaries referencing the same sidecar
+    # filename and the same size.  The second summary repeats the same
+    # file/sample_times hint (NVBench may emit duplicate references).
+    doc = json.loads(_nvbench_json(sample_count=3))
+    state = doc["benchmarks"][0]["states"][0]
+    state["summaries"].append(
+        {
+            "tag": "sample_times_dup",
+            "hint": "file/sample_times",
+            "data": [
+                {"name": "filename", "type": "string", "value": "out.json-bin/0.bin"},
+                {"name": "size", "type": "int64", "value": "3"},
+            ],
+        }
+    )
+    json_path.write_text(json.dumps(doc))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02, 0.03]))
+
+    result = NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert result.sidecar_count == 1
+
+
+def test_nvbench_import_service_rejects_unknown_file_hint(
+    tmp_path: Path,
+) -> None:
+    """An unknown file/ hint must be rejected, not silently ignored."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    doc = json.loads(_nvbench_json(sample_count=3))
+    state = doc["benchmarks"][0]["states"][0]
+    state["summaries"].append(
+        {
+            "tag": "unknown_encoding",
+            "hint": "file/unknown",
+            "data": [
+                {"name": "filename", "type": "string", "value": "out.json-bin/0.bin"},
+                {"name": "size", "type": "int64", "value": "3"},
+            ],
+        }
+    )
+    json_path.write_text(json.dumps(doc))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02, 0.03]))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+    assert "Unknown NVBench file hint" in error.value.message
+
+
+def test_nvbench_import_service_rejects_known_hint_missing_filename(
+    tmp_path: Path,
+) -> None:
+    """A known file hint missing the filename datum must be rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    doc = json.loads(_nvbench_json(sample_count=3))
+    state = doc["benchmarks"][0]["states"][0]
+    state["summaries"].append(
+        {
+            "tag": "sample_freqs_no_filename",
+            "hint": "file/sample_freqs",
+            "data": [
+                {"name": "size", "type": "int64", "value": "3"},
+            ],
+        }
+    )
+    json_path.write_text(json.dumps(doc))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+    assert "missing" in error.value.message
+    assert "filename" in error.value.message
+
+
+def test_nvbench_import_service_rejects_known_hint_missing_size(
+    tmp_path: Path,
+) -> None:
+    """A known file hint missing the size datum must be rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    doc = json.loads(_nvbench_json(sample_count=3))
+    state = doc["benchmarks"][0]["states"][0]
+    state["summaries"].append(
+        {
+            "tag": "sample_times_no_size",
+            "hint": "file/sample_times",
+            "data": [
+                {"name": "filename", "type": "string", "value": "out.json-bin/0.bin"},
+            ],
+        }
+    )
+    json_path.write_text(json.dumps(doc))
+    sidecar_path.write_bytes(_float32_bytes([0.01, 0.02, 0.03]))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+    assert "missing" in error.value.message
+    assert "size" in error.value.message
+
+
+def test_nvbench_import_service_rejects_missing_sidecar(tmp_path: Path) -> None:
+    """A declared sidecar that does not exist on disk is rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    json_path.write_text(_nvbench_json(sample_count=3))
+    # No sidecar directory or file created
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+    # The missing sidecar triggers either EXECUTION_REFUSED (preflight)
+    # or ARTIFACT_INTEGRITY_FAILED (import), both are acceptable
+    assert error.value.code in {
+        ErrorCode.EXECUTION_REFUSED,
+        ErrorCode.ARTIFACT_INTEGRITY_FAILED,
+    }
+
+
+def test_nvbench_import_service_rejects_sidecar_traversal(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    json_path.write_text(_nvbench_json(sidecar_filename="../outside.bin", sample_count=1))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
+def test_nvbench_import_service_rejects_symlinked_sidecar(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    target = tmp_path / "target.bin"
+    target.write_bytes(_float32_bytes([0.01]))
+    (sidecar_dir / "0.bin").symlink_to(target)
+    json_path.write_text(_nvbench_json(sample_count=1))
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(json_path, allow_external_path=True)
+
+    assert error.value.code is ErrorCode.EXECUTION_REFUSED
+
+
+def test_nvbench_import_service_verifies_primary_sha256(tmp_path: Path) -> None:
+    """An expected_sha256 mismatch on the primary JSON is rejected."""
+    workspace = Workspace.initialize(tmp_path)
+    samples = [0.01, 0.02]
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    json_path.write_text(_nvbench_json(sample_count=len(samples)))
+    sidecar_path.write_bytes(_float32_bytes(samples))
+    wrong_sha = "sha256:" + "0" * 64
+
+    with pytest.raises(DomainError) as error:
+        NvbenchImportService(workspace).import_json(
+            json_path, allow_external_path=True, expected_sha256=wrong_sha
+        )
+    assert error.value.code is ErrorCode.ARTIFACT_INTEGRITY_FAILED
+    assert "sha256 mismatch" in error.value.message
+
+
+def test_nvbench_import_service_accepts_correct_primary_sha256(
+    tmp_path: Path,
+) -> None:
+    """A correct expected_sha256 on the primary JSON passes verification."""
+    workspace = Workspace.initialize(tmp_path)
+    samples = [0.01, 0.02]
+    json_path = tmp_path / "out.json"
+    sidecar_dir = tmp_path / "out.json-bin"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "0.bin"
+    json_content = _nvbench_json(sample_count=len(samples))
+    json_path.write_text(json_content)
+    sidecar_path.write_bytes(_float32_bytes(samples))
+    correct_sha = "sha256:" + hashlib.sha256(json_content.encode()).hexdigest()
+
+    result = NvbenchImportService(workspace).import_json(
+        json_path, allow_external_path=True, expected_sha256=correct_sha
+    )
+    assert result.primary_artifact_id
+
+
+def test_nvbench_capture_invocation_uses_jsonbin_by_default(tmp_path: Path) -> None:
+    bound = bind_adapter_options("nvbench", None, project_root=tmp_path)
+    invocation = build_capture_invocation(
+        "nvbench",
+        ("./bench", "-a", "T=I32"),
+        tmp_path / "output",
+        executable=None,
+        options=cast(dict[str, object], bound),
+    )
+    argv = invocation.argv
+    # argv[0] is the benchmark executable, not a wrapper
+    assert argv[0] == "./bench"
+    # --jsonbin is the default; --json must NOT be present (alternative modes)
+    assert "--jsonbin" in argv
+    assert "--json" not in argv
+    # No "--" separator — flags are injected into the benchmark argv
+    assert "--" not in argv
+    # Workload's own args appear after injected flags
+    assert argv[-2:] == ("-a", "T=I32")
+
+
+def test_nvbench_capture_invocation_falls_back_to_json_without_jsonbin(
+    tmp_path: Path,
+) -> None:
+    bound = bind_adapter_options(
+        "nvbench",
+        {"enable_jsonbin": False},
+        project_root=tmp_path,
+    )
+    invocation = build_capture_invocation(
+        "nvbench",
+        ("./bench",),
+        tmp_path / "output",
+        executable=None,
+        options=cast(dict[str, object], bound),
+    )
+    argv = invocation.argv
+    assert "--json" in argv
+    assert "--jsonbin" not in argv
+    assert argv[0] == "./bench"
+
+
+def test_nvbench_capture_invocation_passes_optional_flags(tmp_path: Path) -> None:
+    bound = bind_adapter_options(
+        "nvbench",
+        {
+            "enable_jsonbin": True,
+            "stopping_criterion": "entropy",
+            "min_samples": 10,
+            "timeout": 30.0,
+            "devices": "0",
+        },
+        project_root=tmp_path,
+    )
+    invocation = build_capture_invocation(
+        "nvbench",
+        ("./bench",),
+        tmp_path / "output",
+        executable=None,
+        options=cast(dict[str, object], bound),
+    )
+    argv = invocation.argv
+    # Only --jsonbin, not --json
+    assert "--jsonbin" in argv
+    assert "--json" not in argv
+    assert "--stopping-criterion" in argv
+    assert "entropy" in argv
+    assert "--min-samples" in argv
+    assert "10" in argv
+    assert "--timeout" in argv
+    assert "30.0" in argv
+    assert "-d" in argv
+    assert "0" in argv
+
+
+def test_nvbench_capture_invocation_rejects_conflicting_json_flag(
+    tmp_path: Path,
+) -> None:
+    bound = bind_adapter_options("nvbench", None, project_root=tmp_path)
+    with pytest.raises(DomainError) as error:
+        build_capture_invocation(
+            "nvbench",
+            ("./bench", "--json", "other.json"),
+            tmp_path / "output",
+            executable=None,
+            options=cast(dict[str, object], bound),
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_nvbench_capture_invocation_rejects_conflicting_jsonbin_flag(
+    tmp_path: Path,
+) -> None:
+    bound = bind_adapter_options("nvbench", None, project_root=tmp_path)
+    with pytest.raises(DomainError) as error:
+        build_capture_invocation(
+            "nvbench",
+            ("./bench", "--jsonbin", "other.json"),
+            tmp_path / "output",
+            executable=None,
+            options=cast(dict[str, object], bound),
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_nvbench_capture_invocation_rejects_equals_form_json(
+    tmp_path: Path,
+) -> None:
+    bound = bind_adapter_options("nvbench", None, project_root=tmp_path)
+    with pytest.raises(DomainError) as error:
+        build_capture_invocation(
+            "nvbench",
+            ("./bench", "--json=other.json"),
+            tmp_path / "output",
+            executable=None,
+            options=cast(dict[str, object], bound),
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_nvbench_capture_invocation_rejects_equals_form_jsonbin(
+    tmp_path: Path,
+) -> None:
+    bound = bind_adapter_options("nvbench", None, project_root=tmp_path)
+    with pytest.raises(DomainError) as error:
+        build_capture_invocation(
+            "nvbench",
+            ("./bench", "--jsonbin=other.json"),
+            tmp_path / "output",
+            executable=None,
+            options=cast(dict[str, object], bound),
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_nvbench_capture_invocation_rejects_empty_workload(tmp_path: Path) -> None:
+    bound = bind_adapter_options("nvbench", None, project_root=tmp_path)
+    with pytest.raises(DomainError) as error:
+        build_capture_invocation(
+            "nvbench",
+            (),
+            tmp_path / "output",
+            executable=None,
+            options=cast(dict[str, object], bound),
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_nvbench_options_reject_unknown_keys(tmp_path: Path) -> None:
+    with pytest.raises(DomainError) as error:
+        bind_adapter_options(
+            "nvbench",
+            {"arbitrary_flag": "--destroy"},
+            project_root=tmp_path,
+        )
+    assert error.value.code is ErrorCode.INVALID_CAPTURE_PLAN

--- a/tests/adapters/test_nvbench_live.py
+++ b/tests/adapters/test_nvbench_live.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from flameox.adapters.nvbench import NvbenchExtractor
+from flameox.application import CaptureService, ExecutionPolicy
+from flameox.domain import ArtifactKind, CaptureStatus, ExecutionStatus
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+
+@pytest.mark.requires_nvbench
+@pytest.mark.anyio
+async def test_configured_nvbench_executable_emits_native_output(tmp_path: Path) -> None:
+    executable = os.environ.get("FLAMEOX_NVBENCH_EXECUTABLE")
+    assert executable is not None
+    workspace = Workspace.initialize(tmp_path)
+    disable_containment(workspace)
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.bench]
+argv = [{json.dumps(executable)}]
+timeout_seconds = 120
+"""
+    )
+
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="bench",
+        adapter="nvbench",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    assert any(
+        registration.kind is ArtifactKind.BENCHMARK_SAMPLES and registration.role == "primary"
+        for registration in result.run.artifacts
+    )
+    sidecars = [
+        registration
+        for registration in result.run.artifacts
+        if registration.kind is ArtifactKind.BENCHMARK_SAMPLES
+        and registration.role == "nvbench_sidecar"
+    ]
+    assert sidecars
+
+    extracted = NvbenchExtractor(workspace).extract(result.run.run_id)
+    repeated = NvbenchExtractor(workspace).extract(result.run.run_id)
+    assert extracted.benchmark_count > 0
+    assert extracted.measurement_count > 0
+    assert repeated.corpus_commit_id == extracted.corpus_commit_id

--- a/tests/adapters/test_triton_compiler_live.py
+++ b/tests/adapters/test_triton_compiler_live.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from flameox.application import CaptureService, ExecutionPolicy
+from flameox.domain import ArtifactKind, CaptureStatus, ExecutionStatus
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+
+def _write_triton_workload(project: Path, *, python: str, script: str) -> None:
+    (project / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+
+[workloads.compile]
+argv = ["{python}", "{script}"]
+cwd = "."
+timeout_seconds = 60
+
+[workloads.compile.environment]
+TRITON_CACHE_DIR = "{project / "triton-cache"}"
+"""
+    )
+
+
+def _triton_kernel_script(path: Path) -> None:
+    path.write_text(
+        """
+import os
+import triton
+import triton.language as tl
+
+@triton.jit
+def add_kernel(x_ptr, y_ptr, out_ptr, n, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < n
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x + y, mask=mask)
+
+import torch
+x = torch.randn(128, device="cuda")
+y = torch.randn(128, device="cuda")
+out = torch.empty_like(x)
+add_kernel[(1,)](x, y, out, 128, BLOCK=128)
+print(out.sum().item())
+"""
+    )
+
+
+@pytest.mark.requires_triton
+@pytest.mark.anyio
+async def test_triton_compiler_live_capture_emits_manifest_with_ir(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    python = os.environ.get("FLAMEOX_TRITON_PYTHON", sys.executable)
+    script = tmp_path / "triton_kernel.py"
+    _triton_kernel_script(script)
+    _write_triton_workload(tmp_path, python=python, script=str(script))
+    disable_containment(workspace)
+    service = CaptureService(workspace)
+    plan = await service.plan(
+        workload_name="compile",
+        adapter="triton.compiler",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    result = await service.execute(plan.plan_id)
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    manifest_regs = [reg for reg in result.run.artifacts if reg.role == "kernel_build_manifest"]
+    assert len(manifest_regs) == 1
+    assert manifest_regs[0].kind is ArtifactKind.KERNEL_BUILD
+    native_regs = [reg for reg in result.run.artifacts if reg.role.startswith("compiler_stage:")]
+    assert len(native_regs) >= 1
+    extensions = {reg.display_name.rsplit(".", 1)[1] for reg in native_regs}
+    assert "ttir" in extensions or "ptx" in extensions or "cubin" in extensions

--- a/tests/application/test_capture_nvbench_provider.py
+++ b/tests/application/test_capture_nvbench_provider.py
@@ -1,0 +1,279 @@
+"""Process-level NVBench capture tests using a fake benchmark executable."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from flameox.application import CaptureResult, CaptureService, ExecutionPolicy
+from flameox.domain import (
+    ArtifactKind,
+    ArtifactRegistration,
+    CapabilityReport,
+    CapabilityStatus,
+    CaptureStatus,
+    ExecutionStatus,
+)
+from flameox.storage import Workspace
+from tests.support.capture import disable_containment
+
+
+def _fake_nvbench_bench(path: Path) -> None:
+    """Write a fake NVBench benchmark executable.
+
+    The script reads ``--jsonbin <path>`` from argv, writes a JSON document
+    to ``<path>``, and writes ``sample_count`` float32 values to
+    ``<path>-bin/0.bin``.  An undeclared sibling ``<path>-bin/1.bin`` is
+    also written to verify it is NOT registered.
+
+    Modes:
+    - ``mode=ok``: exit 0, write valid JSON + sidecar + undeclared sibling.
+    - ``mode=malformed``: exit 0, write invalid JSON (no sidecars).
+    - ``mode=missing_sidecar``: exit 0, write valid JSON but no sidecar dir.
+    - ``mode=nonzero``: exit 7, write valid JSON + sidecar + undeclared sibling.
+    - ``mode=nonzero_malformed``: exit 7, write invalid JSON.
+    """
+    path.write_text(
+        """#!/usr/bin/env python3
+import json as _json
+import pathlib
+import struct
+import sys
+
+argv = sys.argv
+jsonbin_idx = argv.index("--jsonbin")
+output = pathlib.Path(argv[jsonbin_idx + 1])
+mode = "ok"
+for arg in argv:
+    if arg.startswith("mode="):
+        mode = arg[len("mode="):]
+
+samples = [0.003120, 0.003145, 0.003108]
+sample_count = len(samples)
+
+if mode == "malformed" or mode == "nonzero_malformed":
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("{not valid json")
+else:
+    doc = {
+        "meta": {
+            "argv": ["bench", "--jsonbin", str(output)],
+            "version": {
+                "json": {"major": 1, "minor": 0, "patch": 0, "string": "1.0.0"},
+                "nvbench": {"major": 0, "minor": 1, "patch": 0, "string": "0.1.0"},
+            },
+        },
+        "devices": [{"id": 0, "name": "NVIDIA GeForce RTX 4090"}],
+        "benchmarks": [
+            {
+                "name": "cub.bench.scan",
+                "index": 0,
+                "axes": [],
+                "states": [
+                    {
+                        "name": "[T=I32 Elements=2^16]",
+                        "device": 0,
+                        "type_config_index": 0,
+                        "is_skipped": False,
+                        "summaries": [
+                            {
+                                "tag": "nv/json/bin:sample_times",
+                                "name": "Sample Times File",
+                                "description": "Binary file.",
+                                "hint": "file/sample_times",
+                                "hide": "Not needed in table.",
+                                "data": [
+                                    {
+                                        "name": "filename",
+                                        "type": "string",
+                                        "value": str(output.name) + "-bin/0.bin",
+                                    },
+                                    {
+                                        "name": "size",
+                                        "type": "int64",
+                                        "value": str(sample_count),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(_json.dumps(doc))
+    if mode != "missing_sidecar":
+        sidecar_dir = output.parent / (output.name + "-bin")
+        sidecar_dir.mkdir(parents=True, exist_ok=True)
+        (sidecar_dir / "0.bin").write_bytes(
+            struct.pack(f"<{sample_count}f", *samples)
+        )
+        # Undeclared sibling that must NOT be registered
+        (sidecar_dir / "1.bin").write_bytes(
+            struct.pack("<2f", 0.99, 0.88)
+        )
+
+if mode.startswith("nonzero"):
+    raise SystemExit(7)
+"""
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _make_service(
+    workspace: Workspace,
+    bench: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> CaptureService:
+    report = CapabilityReport(
+        adapter="nvbench",
+        status=CapabilityStatus.AVAILABLE,
+        executable=str(bench),
+        version="fake-nvbench",
+        supported_modes=("benchmark",),
+        supported_formats=("nvbench-json", "nvbench-jsonbin"),
+        permission_status="granted",
+        probe_kind="active",
+    )
+    service = CaptureService(workspace)
+    monkeypatch.setattr(service.capabilities, "get", lambda _adapter: report)
+
+    async def probe(_adapter: str, *, refresh: bool = False) -> CapabilityReport:
+        assert refresh
+        return report
+
+    monkeypatch.setattr(service.capabilities, "probe", probe)
+    return service
+
+
+async def _capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    mode: str,
+) -> tuple[CaptureService, CaptureResult]:
+    workspace = Workspace.initialize(tmp_path)
+    disable_containment(workspace)
+    bench = tmp_path / "fake-bench"
+    _fake_nvbench_bench(bench)
+    (tmp_path / "flameox.toml").write_text(
+        f"""
+schema_version = 1
+[workloads.bench]
+argv = ["./fake-bench", "mode={mode}"]
+timeout_seconds = 10
+"""
+    )
+    service = _make_service(workspace, bench, monkeypatch)
+    plan = await service.plan(
+        workload_name="bench",
+        adapter="nvbench",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    return service, await service.execute(plan.plan_id)
+
+
+def _benchmark_registrations(result: CaptureResult) -> list[ArtifactRegistration]:
+    return [item for item in result.run.artifacts if item.kind is ArtifactKind.BENCHMARK_SAMPLES]
+
+
+@pytest.mark.anyio
+async def test_nvbench_successful_capture_registers_declared_sidecars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, result = await _capture(tmp_path, monkeypatch, mode="ok")
+
+    assert result.run.execution_status is ExecutionStatus.SUCCEEDED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    benchmark_regs = _benchmark_registrations(result)
+    roles = {item.role for item in benchmark_regs}
+    assert "primary" in roles
+    assert "nvbench_sidecar" in roles
+    sidecar_regs = [item for item in benchmark_regs if item.role == "nvbench_sidecar"]
+    assert len(sidecar_regs) == 1
+    # display_name must match the declared relative path
+    assert sidecar_regs[0].display_name == "nvbench.json-bin/0.bin"
+    # The undeclared sibling (1.bin) must not be registered
+    display_names = {item.display_name for item in benchmark_regs}
+    assert "nvbench.json-bin/1.bin" not in display_names
+
+
+@pytest.mark.anyio
+async def test_nvbench_successful_malformed_json_is_preserved_as_failed_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, result = await _capture(tmp_path, monkeypatch, mode="malformed")
+
+    assert result.run.execution_status is ExecutionStatus.FAILED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    assert [item.role for item in _benchmark_registrations(result)] == ["primary"]
+    assert not list(service.workspace.paths.quarantine.glob("*/manifest.json"))
+    assert any(detail.code == "expected_output_invalid" for detail in result.run.limitation_details)
+
+
+@pytest.mark.anyio
+async def test_nvbench_successful_missing_sidecar_is_preserved_as_failed_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, result = await _capture(tmp_path, monkeypatch, mode="missing_sidecar")
+
+    assert result.run.execution_status is ExecutionStatus.FAILED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    assert [item.role for item in _benchmark_registrations(result)] == ["primary"]
+    assert not list(service.workspace.paths.quarantine.glob("*/manifest.json"))
+
+
+@pytest.mark.anyio
+async def test_nvbench_nonzero_preserves_partial_sidecars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, result = await _capture(tmp_path, monkeypatch, mode="nonzero")
+
+    assert result.run.execution_status is ExecutionStatus.FAILED
+    # Partial artifacts are preserved (not quarantined)
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    benchmark_regs = _benchmark_registrations(result)
+    roles = {item.role for item in benchmark_regs}
+    assert "primary" in roles
+    assert "nvbench_sidecar" in roles
+    sidecar_regs = [item for item in benchmark_regs if item.role == "nvbench_sidecar"]
+    assert len(sidecar_regs) == 1
+    assert sidecar_regs[0].display_name == "nvbench.json-bin/0.bin"
+    # Undeclared sibling must not be registered
+    display_names = {item.display_name for item in benchmark_regs}
+    assert "nvbench.json-bin/1.bin" not in display_names
+    # Must have nonzero limitation; valid output has no expected_output_invalid
+    limitation_codes = {detail.code for detail in result.run.limitation_details}
+    assert "nonzero_exit" in limitation_codes
+    # Must NOT be quarantined
+    manifests = list(service.workspace.paths.quarantine.glob("*/manifest.json"))
+    assert not manifests
+
+
+@pytest.mark.anyio
+async def test_nvbench_nonzero_malformed_preserves_json_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service, result = await _capture(tmp_path, monkeypatch, mode="nonzero_malformed")
+
+    assert result.run.execution_status is ExecutionStatus.FAILED
+    assert result.run.capture_status is CaptureStatus.REGISTERED
+    benchmark_regs = _benchmark_registrations(result)
+    # The partial JSON is preserved as primary, but no sidecars
+    roles = {item.role for item in benchmark_regs}
+    assert "primary" in roles
+    assert "nvbench_sidecar" not in roles
+    # Must NOT be quarantined (partial preservation on nonzero)
+    manifests = list(service.workspace.paths.quarantine.glob("*/manifest.json"))
+    assert not manifests
+    limitation_codes = {detail.code for detail in result.run.limitation_details}
+    assert "nonzero_exit" in limitation_codes
+    assert "expected_output_invalid" in limitation_codes

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 923
+expected_test_count = 1015
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -40,7 +40,13 @@ expected_test_count = 923
 'tests/adapters/test_benchmark_samples.py' = { count = 8, digest = '71e398543a29c75f059be8b1ba659ee80952b9407ef0295b7fa9bfe736ad05d3' }
 'tests/adapters/test_compute_sanitizer.py' = { count = 17, digest = '0a44b26ba1816dee25ceb541819e23c8f64fc5f833efdd4d53a40750e4de14e6' }
 'tests/adapters/test_compute_sanitizer_live.py' = { count = 2, digest = 'ed25601a0ea6a107634c87cde1bf6c7ead550feeb1dc9dfa74c7852966e691cc' }
+'tests/adapters/test_cute_compiler_live.py' = { count = 1, digest = 'c06df142e528133b2fc9ce9045f37d96bf4155740f85928b5d7452ce1d9075f2' }
+'tests/adapters/test_kernel_build.py' = { count = 13, digest = 'b6c8efe8c729909e6f3554c1b83554e62f5cf289728588e2c6b4a3877d59637a' }
+'tests/adapters/test_kernel_build_capture.py' = { count = 23, digest = 'ba3671771c7bffa170869d7fca5e86a2e098603d461788bccc7e931eb6e7431a' }
 'tests/adapters/test_kernel_validation.py' = { count = 12, digest = '86a12a5fb7f6a3cf94a68be67fd68cb1ea34736f5be7a68a7bee2b9145bf0f37' }
+'tests/adapters/test_nvbench.py' = { count = 42, digest = '74e6d6e9e6cb31e5a018ac0ed4c0d11b0d0077b6f6dbc56124accce2b0c230d0' }
+'tests/adapters/test_nvbench_live.py' = { count = 1, digest = '95b6165af0c766dac662211d5065d9f3854aa99a038fba53c28cba1a8f5b5bf9' }
+'tests/adapters/test_triton_compiler_live.py' = { count = 1, digest = '0dfa64a2bfaaf94a441d80fac025d703bc267101e9ab748c31d25c8ee9ebfd5e' }
 'tests/adapters/test_inference_artifacts.py' = { count = 86, digest = '9a9ccc9c7cfa6204fa5dc02a04b1b23c4899b5b719ed98ce846608d80a43d739' }
 'tests/adapters/test_coverage.py' = { count = 3, digest = 'a9aa85687b6f34101ebcf2d6b69c22c866f9279436bdb9cbaff2793dba714891' }
 'tests/adapters/test_memray.py' = { count = 3, digest = '929b943d44dd1e64914730a760870fb7f87154c0a036e7d6ef355ce42d858c66' }
@@ -64,6 +70,7 @@ expected_test_count = 923
 'tests/application/test_async_work.py' = { count = 1, digest = '5c21ab9d048e8676c0b086ff6859e87b28da82ab793c2b70de975f592355067e' }
 'tests/application/test_capabilities.py' = { count = 20, digest = '15279d4414beca5438e376ff2f787b3e9fe916d8242de0b35d3580de4cc24069' }
 'tests/application/test_capture_native_outputs.py' = { count = 5, digest = '73ffb01416e94a3044feeecb6f11f1fb452f0b1595ecc8b3ac3ef4f749918f77' }
+'tests/application/test_capture_nvbench_provider.py' = { count = 5, digest = '60dc3c898ac55fef04dea85abe5d2236be4d72ca549641d44d48d34b22cace71' }
 'tests/application/test_comparison_samples.py' = { count = 5, digest = 'e8f94545da22cc09a8868477a4ad48b9c7a88dcecd03de4d00a0d9199ca293dc' }
 'tests/application/test_detached.py' = { count = 9, digest = '4e14dd7f799b1dcbc3eddf8d6ab45af470f9287e769ee03346698aeb78477365' }
 'tests/application/test_discovery.py' = { count = 2, digest = '154e2545ae8110e6e72d19cd62a1734779f7bf2f6b14180f57ea2852365e8fd2' }
@@ -119,5 +126,5 @@ expected_test_count = 923
 'tests/test_cli_smoke.py' = { count = 8, digest = 'fe24d29a2d116f21d4505ff8013b15a436e0999de1c970a28d53e57ffbd0fd6c' }
 'tests/test_release_metadata.py' = { count = 3, digest = '83591570ba43893617d18cef840660f50d8c9420e4ca86cec97a16170f00bd23' }
 'tests/test_setup_ui.py' = { count = 2, digest = '9b80453c3b4df6c3744f2d8e750d794bf6f0dc1d568ca987a39739a124a48e45' }
-'tests/test_test_runner.py' = { count = 21, digest = 'b84b9c8b9ebc089aea51ffafb9e000fe98def14160519380c2f2c4d6287bc23a' }
+'tests/test_test_runner.py' = { count = 27, digest = '79382b27fc93672fac342d6b456cea308652b3725a2d6a49825a9ecd088f3bbf' }
 'tests/golden/test_semantic_matrix.py' = { count = 1, digest = 'ad3ee0c218bcfa4a2badc24faed4b456b281234589cb6f05721ef14f8c4acee3' }

--- a/tests/ownership.toml
+++ b/tests/ownership.toml
@@ -25,7 +25,9 @@ lane = "adapters"
 paths = [
     "tests/adapters/test_benchmark_samples.py",
     "tests/adapters/test_compute_sanitizer.py",
+    "tests/adapters/test_kernel_build.py",
     "tests/adapters/test_kernel_validation.py",
+    "tests/adapters/test_nvbench.py",
     "tests/adapters/test_pyperf.py",
   "tests/adapters/test_python_startup.py",
 ]
@@ -531,6 +533,12 @@ paths = ["tests/application/test_capture_torch_provider.py"]
 markers = ["integration", "optional", "process", "serial", "requires_torch"]
 
 [[ownership]]
+owner = "capture-nvbench-provider"
+lane = "process"
+paths = ["tests/application/test_capture_nvbench_provider.py"]
+markers = ["integration", "process", "serial"]
+
+[[ownership]]
 owner = "torch-launcher"
 lane = "process"
 paths = ["tests/collectors/test_torch_launcher.py"]
@@ -631,6 +639,30 @@ owner = "nsight-systems-adapter"
 lane = "process"
 paths = ["tests/adapters/test_nsight_systems.py"]
 markers = ["integration", "process", "serial"]
+
+[[ownership]]
+owner = "kernel-build-capture"
+lane = "adapters"
+paths = ["tests/adapters/test_kernel_build_capture.py"]
+markers = ["integration", "process"]
+
+[[ownership]]
+owner = "triton-compiler-live"
+lane = "adapters"
+paths = ["tests/adapters/test_triton_compiler_live.py"]
+markers = ["integration", "optional", "process", "serial", "requires_triton"]
+
+[[ownership]]
+owner = "nvbench-live"
+lane = "adapters"
+paths = ["tests/adapters/test_nvbench_live.py"]
+markers = ["integration", "optional", "process", "serial", "requires_nvbench"]
+
+[[ownership]]
+owner = "cute-compiler-live"
+lane = "adapters"
+paths = ["tests/adapters/test_cute_compiler_live.py"]
+markers = ["integration", "optional", "process", "serial", "requires_cute"]
 
 [[ownership]]
 owner = "perfetto-phase-normalization"

--- a/tests/support/providers.py
+++ b/tests/support/providers.py
@@ -11,6 +11,10 @@ PACKAGE_PROVIDERS = {
     "requires_coverage": "coverage",
     "requires_memray": "memray",
     "requires_torch": "torch",
+    "requires_triton": "triton",
+}
+CONFIGURED_EXECUTABLE_PROVIDERS = {
+    "requires_nvbench": "FLAMEOX_NVBENCH_EXECUTABLE",
 }
 EXECUTABLE_PROVIDERS = {
     "requires_bwrap": "bwrap",
@@ -23,7 +27,9 @@ EXECUTABLE_PROVIDERS = {
 PROVIDER_MARKERS = frozenset(
     {
         *PACKAGE_PROVIDERS,
+        *CONFIGURED_EXECUTABLE_PROVIDERS,
         *EXECUTABLE_PROVIDERS,
+        "requires_cute",
         "requires_perfetto",
         "requires_toxiproxy",
     }
@@ -84,6 +90,18 @@ def provider_available(marker: str) -> bool:
         return bool(configured and Path(configured).is_file())
     if marker == "requires_systemd":
         return systemd_user_scope_available()
+    if marker == "requires_triton":
+        configured = os.environ.get("FLAMEOX_TRITON_PYTHON")
+        if configured:
+            return Path(configured).expanduser().is_file()
+        return importlib.util.find_spec("triton") is not None
+    if marker == "requires_cute":
+        configured = os.environ.get("FLAMEOX_CUTE_WORKLOAD")
+        return bool(configured and Path(configured).expanduser().is_file())
+    configured_variable = CONFIGURED_EXECUTABLE_PROVIDERS.get(marker)
+    if configured_variable is not None:
+        configured = os.environ.get(configured_variable)
+        return bool(configured and Path(configured).expanduser().is_file())
     package = PACKAGE_PROVIDERS.get(marker)
     if package is not None:
         return importlib.util.find_spec(package) is not None
@@ -98,7 +116,9 @@ def provider_inventory() -> tuple[tuple[str, bool], ...]:
         (marker, provider_available(marker))
         for marker in (
             *PACKAGE_PROVIDERS,
+            *CONFIGURED_EXECUTABLE_PROVIDERS,
             *EXECUTABLE_PROVIDERS,
+            "requires_cute",
             "requires_perfetto",
             "requires_toxiproxy",
         )

--- a/tests/test_test_runner.py
+++ b/tests/test_test_runner.py
@@ -40,6 +40,7 @@ def test_list_reports_lanes_and_metadata_commands() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "  golden" in result.stdout
+    assert "  optional-nvbench" in result.stdout
     assert "Metadata commands:" in result.stdout
     assert "  capabilities validate managed setup metadata against extras" in result.stdout
 
@@ -110,6 +111,33 @@ def test_performance_marked_test_selects_performance_lane_on_pull_request(
     assert plan["run_performance"] is True
     assert any(item["lane"] == "performance" for item in plan["selected_lanes"])
     assert all(item["lane"] != "performance" for item in plan["unselected_lanes"])
+
+
+@pytest.mark.parametrize(
+    "event", ["pull_request", "merge_group", "push", "schedule", "workflow_dispatch"]
+)
+def test_gpu_provider_lanes_are_local_only_and_never_emitted_to_hosted_plans(
+    monkeypatch: pytest.MonkeyPatch,
+    event: str,
+) -> None:
+    plan = _plan(monkeypatch, {"tests/adapters/test_nvbench_live.py"}, event=event)
+
+    emitted = {
+        *plan["optional_lanes"],
+        *(item["lane"] for item in plan["selected_lanes"]),
+        *(item["lane"] for item in plan["unselected_lanes"]),
+        *(item["lane"] for item in plan["matrix"]["optional_lanes"]),
+    }
+    assert emitted.isdisjoint(runner.GPU_PROVIDER_LANES)
+    assert runner.validate_affected_plan(plan, RECORDS) == plan
+
+
+def test_hosted_optional_provider_lane_remains_schedulable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan(monkeypatch, {"tests/adapters/test_coverage.py"}, event="pull_request")
+
+    assert "optional-coverage" in plan["optional_lanes"]
 
 
 @pytest.mark.parametrize(

--- a/tools/generate_contract_schemas.py
+++ b/tools/generate_contract_schemas.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from flameox.adapters.kernel_build import kernel_build_json_schema
 from flameox.adapters.kernel_validation import kernel_validation_json_schema
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -11,7 +12,10 @@ SCHEMA_ROOT = PROJECT_ROOT / "src" / "flameox" / "schemas"
 
 def main() -> None:
     SCHEMA_ROOT.mkdir(parents=True, exist_ok=True)
-    schemas = {"kernel-validation-v1.schema.json": kernel_validation_json_schema()}
+    schemas = {
+        "kernel-build-v1.schema.json": kernel_build_json_schema(),
+        "kernel-validation-v1.schema.json": kernel_validation_json_schema(),
+    }
     for filename, schema in schemas.items():
         path = SCHEMA_ROOT / filename
         path.write_text(

--- a/tools/test.py
+++ b/tools/test.py
@@ -65,21 +65,34 @@ PLAN_KEYS = {
     "run_performance",
 }
 PROVIDER_LANES = {
-    "optional-compute-sanitizer": "optional and requires_compute_sanitizer",
     "optional-coverage": "optional and requires_coverage",
+    "optional-compute-sanitizer": "optional and requires_compute_sanitizer",
+    "optional-cute": "optional and requires_cute",
+    "optional-nvbench": "optional and requires_nvbench",
+    "optional-triton": "optional and requires_triton",
     "optional-memray": "optional and requires_memray",
     "optional-perfetto": "optional and requires_perfetto",
     "optional-pyspy": "optional and requires_pyspy",
     "optional-torch": "optional and requires_torch",
     "optional-host": (
-        "optional and not requires_compute_sanitizer and not requires_coverage "
+        "optional and not requires_compute_sanitizer and not requires_cute "
+        "and not requires_nvbench and not requires_triton "
+        "and not requires_coverage "
         "and not requires_memray "
         "and not requires_perfetto and not requires_pyspy and not requires_torch"
     ),
 }
-GPU_PROVIDER_LANES = frozenset({"optional-compute-sanitizer"})
-# GitHub-hosted runners do not provide CUDA GPUs. Keep the live lane available
-# as an explicit local command without emitting a job that can only skip.
+GPU_PROVIDER_LANES = frozenset(
+    {
+        "optional-compute-sanitizer",
+        "optional-cute",
+        "optional-nvbench",
+        "optional-triton",
+    }
+)
+# The affected plan is consumed by GitHub-hosted ubuntu-latest runners. Keep
+# GPU lanes as explicit local commands, but never emit them into that hosted
+# matrix where their hardware requirements would turn the job into a skip.
 CI_PROVIDER_LANES = {
     lane: expression
     for lane, expression in PROVIDER_LANES.items()
@@ -712,8 +725,11 @@ def affected_plan(  # noqa: C901
                 coverage = True
                 _reason_map_add(lane_reasons, record.lane, f"owned test path: {path}")
             provider_markers = (
-                ("requires_compute_sanitizer", "optional-compute-sanitizer"),
                 ("requires_coverage", "optional-coverage"),
+                ("requires_compute_sanitizer", "optional-compute-sanitizer"),
+                ("requires_cute", "optional-cute"),
+                ("requires_nvbench", "optional-nvbench"),
+                ("requires_triton", "optional-triton"),
                 ("requires_memray", "optional-memray"),
                 ("requires_perfetto", "optional-perfetto"),
                 ("requires_pyspy", "optional-pyspy"),


### PR DESCRIPTION
## Description

Flameox previously required project-specific conversion for NVBench output and could register compiler files only as unrelated artifacts. That loses raw sample sidecar relationships and the attributable build structure needed for pipeline comparison.

This stacked PR adds bounded NVBench import/capture and manifest-driven Triton/CuTe compiler artifacts. It is based on #137; after that PR merges, this branch can be retargeted to `main`.

Relates to #132.
Relates to #134.

## Approach

- Import NVBench JSON and every declared float32 binary sidecar as one bounded provider bundle, with containment, link, duplicate, count, size, and digest checks before atomic registration.
- Preserve the native files unchanged and publish raw timing/frequency samples through the existing benchmark measurement model.
- Preflight aggregate declared sample counts before reading sidecars so an oversized document fails without allocating an unbounded row list.
- Add managed NVBench capture using the official `--json`/`--jsonbin` interface, rejecting conflicting output arguments and preserving partial outputs.
- Define `flameox.kernel-build.v1`, inventory native Triton and CuTe dump artifacts without parsing or rewriting them, and translate the manifest into the existing `ArtifactPipeline` model.
- Use only documented Triton and CuTe environment controls. Provider output order is preserved, but predecessor lineage is left unavailable unless the producer declares it.

Suggested review order:

1. `src/flameox/application/nvbench_imports.py` and the bounded provider importer
2. `src/flameox/adapters/nvbench.py`
3. `src/flameox/adapters/kernel_build.py` and `application/kernel_builds.py`
4. managed capture wiring, interfaces, tests, and compatibility notes

## Commands run

```console
# Focused NVBench, kernel-build, capture, and MCP tests: 92 passed
uv run python tools/test.py optional-nvbench
# 1 passed on the local NVIDIA host, including sidecars and extraction
uv run python tools/test.py optional-triton
# 1 passed on the local NVIDIA host
uv run python tools/test.py optional-cute
# 1 passed against the pinned official CuTe example

uv run ruff check src tests tools
uv run ruff format --check src tests tools
uv run mypy src tests tools
uv run lint-imports
uv run python tools/test.py ownership
uv run python tools/test.py collection
```

The stacked collection receipt covers 1,015 node IDs across 91 files. Both import-boundary contracts pass, and generated-schema regeneration leaves no diff.

## Compatibility

Imports do not require CUDA, NVBench, Triton, or CuTe. Managed capture requires the corresponding official executable or Python toolchain and a compatible GPU.

Live evidence used NVBench commit `c18488992e313240166f588b9ee4da3e0de76004` and CUTLASS/CuTe v4.6.2 (`6c65a175668952f09bcbf66cb97a8de1b734b4a0`). The NVBench build used CUDA 13.3 with GCC 15, outside the upstream published GCC 7–14 range, so that result is recorded as observed local evidence rather than a supported toolchain claim. GitHub-hosted CI requires deterministic fixture and simulated-process coverage and does not schedule GPU-only jobs that could silently skip.
