### PR TITLE
fix: structural issue batch — bounded reads, oracle coherence, protocol comparison, vLLM percentiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           mkdir -p dist/python dist/npm
           uv build --out-dir dist/python
-          uvx --from twine twine check dist/python/*
+          uv run twine check dist/python/*
           npm pack ./npm --pack-destination "$PWD/dist/npm" --json > dist/npm-pack.json
           sha256sum dist/python/* dist/npm/*.tgz > dist/SHA256SUMS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           mkdir -p dist/python dist/npm
           uv build --out-dir dist/python
-          uv run twine check dist/python/*
+          uvx --from twine twine check dist/python/*
           npm pack ./npm --pack-destination "$PWD/dist/npm" --json > dist/npm-pack.json
           sha256sum dist/python/* dist/npm/*.tgz > dist/SHA256SUMS
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           mkdir -p dist/python dist/npm
           uv build --out-dir dist/python
-          uvx --from twine twine check dist/python/*
+          uv run --locked twine check dist/python/*
           npm pack ./npm --pack-destination "$PWD/dist/npm" --json > dist/npm-pack.json
           sha256sum dist/python/* dist/npm/*.tgz > dist/SHA256SUMS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "pyarrow-stubs>=20.0.0.20260625",
     "ruff>=0.11",
     "scipy-stubs>=1.18.0.1,<1.19",
+    "twine>=6.1",
     "vulture>=2.14",
 ]
 

--- a/src/flameox/adapters/inference.py
+++ b/src/flameox/adapters/inference.py
@@ -1060,7 +1060,7 @@ class VllmResultParser:
             "successful_requests": completed,
             "failed_requests": max(0, total_requests - completed),
             "total_requests": total_requests,
-            "actual_duration": payload["duration"],
+            "actual_duration": payload.get("duration"),
             "time_scale": 1.0,
         }
 

--- a/src/flameox/adapters/inference.py
+++ b/src/flameox/adapters/inference.py
@@ -821,6 +821,17 @@ class AIPerfCorrelationSummary(ContractModel):
 # vLLM aggregate benchmark-result JSON normalization
 # ---------------------------------------------------------------------------
 #
+def _percentile_label(percentile: int | float) -> str:
+    """Return a canonical label for a percentile rank, preserving fractional precision.
+
+    ``int()`` truncation made p99.1 and p99.9 both produce ``p99``, losing
+    the exact percentile identity in the metric name.
+    """
+    if float(percentile).is_integer():
+        return str(int(percentile))
+    return str(float(percentile))
+
+
 # vLLM's ``benchmark_serving.BenchmarkMetrics`` dataclass is serialized by the
 # Mooncake replayer (and other vLLM benchmark scripts) as a JSON object whose
 # percentile fields are lists of ``[percentile, value_ms]`` pairs. The parser
@@ -907,6 +918,10 @@ class VllmAggregateMetrics(ContractModel):
             "median_itl_ms",
             "mean_e2el_ms",
             "median_e2el_ms",
+            "std_ttft_ms",
+            "std_tpot_ms",
+            "std_itl_ms",
+            "std_e2el_ms",
         ):
             if getattr(self, name) < 0:
                 raise ValueError(f"{name} must be non-negative")
@@ -944,6 +959,13 @@ class VllmResultDocument(ContractModel):
     total_requests: Annotated[int, Field(ge=0)]
     actual_duration: Annotated[float, Field(ge=0)]
     time_scale: Annotated[float, Field(gt=0)] = 1.0
+
+    @field_validator("actual_duration", "time_scale")
+    @classmethod
+    def finite_duration_and_scale(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("duration and time_scale must be finite")
+        return value
 
     @model_validator(mode="after")
     def totals_match(self) -> VllmResultDocument:
@@ -1038,7 +1060,7 @@ class VllmResultParser:
             "successful_requests": completed,
             "failed_requests": max(0, total_requests - completed),
             "total_requests": total_requests,
-            "actual_duration": payload.get("duration", 0.0),
+            "actual_duration": payload["duration"],
             "time_scale": 1.0,
         }
 
@@ -1163,7 +1185,7 @@ class VllmResultParser:
             add(f"vllm.{label}.std_ms", std, unit="ms", aggregation="std", extra={"stat": "std"})
             for percentile, value in getattr(metrics, f"percentiles_{metric}_ms"):
                 add(
-                    f"vllm.{label}.p{int(percentile)}_ms",
+                    f"vllm.{label}.p{_percentile_label(percentile)}_ms",
                     float(value),
                     unit="ms",
                     aggregation="percentile",

--- a/src/flameox/analysis/inference_protocol.py
+++ b/src/flameox/analysis/inference_protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from enum import StrEnum
 from typing import Annotated, Literal
@@ -404,10 +405,17 @@ def _facets() -> tuple[_FacetGetter, ...]:
     )
 
 
+
+
 def _normalize(value: object) -> str:
+    """Return a display string for a protocol facet value.
+
+    For dict values, use canonical JSON serialization (sorted keys) so that
+    keys/values containing commas or equals signs cannot produce colliding
+    normal forms. Plain scalar values use ``str()`` as before.
+    """
     if isinstance(value, dict):
-        items = sorted(value.items(), key=lambda item: item[0])
-        return ",".join(f"{k}={v}" for k, v in items)
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
     if isinstance(value, bool):
         return "true" if value else "false"
     if value is None:

--- a/src/flameox/analysis/inference_protocol.py
+++ b/src/flameox/analysis/inference_protocol.py
@@ -405,8 +405,6 @@ def _facets() -> tuple[_FacetGetter, ...]:
     )
 
 
-
-
 def _normalize(value: object) -> str:
     """Return a display string for a protocol facet value.
 

--- a/src/flameox/analysis/inference_protocol.py
+++ b/src/flameox/analysis/inference_protocol.py
@@ -435,6 +435,8 @@ def _identity_missing_fields(protocol: InferenceProtocolIdentity) -> dict[str, s
         missing["model.tokenizer_id"] = "tokenizer identity is unavailable"
     if protocol.model.tokenizer_revision is None:
         missing["model.tokenizer_revision"] = "tokenizer revision is unavailable"
+    if protocol.model.quantization is None:
+        missing["model.quantization"] = "effective model quantization is unavailable"
     if protocol.server.managed_server_command_digest is None:
         missing["server.managed_server_command_digest"] = (
             "managed server and cache configuration provenance is unavailable"

--- a/src/flameox/analysis/recipe_models.py
+++ b/src/flameox/analysis/recipe_models.py
@@ -443,6 +443,7 @@ class ScalingPoint(ConfidenceIntervalFields):
     variant: str
     block_id: str | None
     input_value: float | None
+    input_kind: Literal["integer", "floating"] | None = None
     value: float
     dispersion: float
     unit: str
@@ -456,6 +457,7 @@ class ScalingTrialSummary(ContractModel):
     variant: str
     block_id: str | None
     input_value: float | None
+    input_kind: Literal["integer", "floating"] | None = None
     median: float
     dispersion: float
     unit: str

--- a/src/flameox/analysis/recipe_scaling.py
+++ b/src/flameox/analysis/recipe_scaling.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 from scipy.stats import bootstrap, spearmanr
@@ -29,6 +29,17 @@ from flameox.evidence_status import (
 
 
 class ScalingRecipes(RecipeContext):
+    @staticmethod
+    def _input_identity(
+        integer_value: object,
+        floating_value: object,
+    ) -> tuple[float | None, Literal["integer", "floating"] | None]:
+        if integer_value is not None:
+            return float(cast(Any, integer_value)), "integer"
+        if floating_value is not None:
+            return float(cast(Any, floating_value)), "floating"
+        return None, None
+
     def scaling(
         self,
         experiment_id: str,
@@ -106,22 +117,25 @@ class ScalingRecipes(RecipeContext):
             ).fetchone()
             assert complete_row is not None
         trial_groups: dict[
-            tuple[str, str, str | None, float | None, str, str],
+            tuple[
+                str,
+                str,
+                str | None,
+                float | None,
+                Literal["integer", "floating"] | None,
+                str,
+                str,
+            ],
             list[float],
         ] = {}
         for row in rows:
-            input_value = (
-                float(row[3])
-                if row[3] is not None
-                else float(row[4])
-                if row[4] is not None
-                else None
-            )
+            input_value, input_kind = self._input_identity(row[3], row[4])
             key = (
                 str(row[0]),
                 str(row[1]),
                 str(row[2]) if row[2] is not None else None,
                 input_value,
+                input_kind,
                 str(row[7]),
                 str(row[5]),
             )
@@ -133,6 +147,7 @@ class ScalingRecipes(RecipeContext):
             variant,
             block_id,
             input_value,
+            input_kind,
             unit,
             environment_id,
         ), values in sorted(trial_groups.items()):
@@ -143,6 +158,7 @@ class ScalingRecipes(RecipeContext):
                     variant=variant,
                     block_id=block_id,
                     input_value=input_value,
+                    input_kind=input_kind,
                     median=median,
                     dispersion=float(np.median(np.abs(np.asarray(values) - median))),
                     unit=unit,
@@ -151,18 +167,18 @@ class ScalingRecipes(RecipeContext):
                 )
             )
         point_groups: dict[
-            tuple[str, float | None, str],
+            tuple[str, float | None, Literal["integer", "floating"] | None, str],
             list[ScalingTrialSummary],
         ] = {}
         for trial in trials:
             point_groups.setdefault(
-                (trial.variant, trial.input_value, trial.unit),
+                (trial.variant, trial.input_value, trial.input_kind, trial.unit),
                 [],
             ).append(trial)
         points_list: list[ScalingPoint] = []
-        for (variant, input_value, unit), group in sorted(
+        for (variant, input_value, input_kind, unit), group in sorted(
             point_groups.items(),
-            key=lambda item: (item[0][0], item[0][1] or -math.inf),
+            key=lambda item: (item[0][0], item[0][1] or -math.inf, item[0][2] or ""),
         ):
             trial_medians = np.asarray(
                 [trial.median for trial in group],
@@ -180,6 +196,7 @@ class ScalingRecipes(RecipeContext):
                     variant=variant,
                     block_id=next(iter(block_ids)) if len(block_ids) == 1 else None,
                     input_value=input_value,
+                    input_kind=input_kind,
                     value=median,
                     dispersion=dispersion,
                     confidence_interval=(
@@ -403,20 +420,16 @@ class ScalingRecipes(RecipeContext):
                 int | None,
                 str,
                 str,
+                Literal["integer", "floating"],
                 float,
             ],
             float,
         ] = {}
         for row in rows:
-            input_value = (
-                float(cast(Any, row[2]))
-                if row[2] is not None
-                else float(cast(Any, row[3]))
-                if row[3] is not None
-                else None
-            )
+            input_value, input_kind = self._input_identity(row[2], row[3])
             if input_value is None or not math.isfinite(input_value):
                 continue
+            assert input_kind is not None
             key = (
                 str(row[0]),
                 str(row[1]),
@@ -426,6 +439,7 @@ class ScalingRecipes(RecipeContext):
                 int(cast(Any, row[7])) if row[7] is not None else None,
                 str(row[8]),
                 str(row[9]),
+                input_kind,
                 input_value,
             )
             per_trial[key] = per_trial.get(key, 0.0) + float(cast(Any, row[10]))
@@ -442,6 +456,7 @@ class ScalingRecipes(RecipeContext):
             line,
             metric,
             unit,
+            _input_kind,
             input_value,
         ), value in per_trial.items():
             groups.setdefault(

--- a/src/flameox/analysis/recipe_scaling.py
+++ b/src/flameox/analysis/recipe_scaling.py
@@ -235,6 +235,27 @@ class ScalingRecipes(RecipeContext):
             warnings.append(
                 "Some variants have no numeric input value and were excluded from fits."
             )
+        input_kinds_by_variant: dict[str, set[Literal["integer", "floating"]]] = {}
+        for point in points:
+            if (
+                point.input_value is not None
+                and point.input_value > 0
+                and math.isfinite(point.input_value)
+                and math.isfinite(point.value)
+                and point.input_kind is not None
+            ):
+                input_kinds_by_variant.setdefault(point.variant, set()).add(point.input_kind)
+        mixed_input_kind_variants = {
+            variant
+            for variant, input_kinds in input_kinds_by_variant.items()
+            if input_kinds == {"integer", "floating"}
+        }
+        if mixed_input_kind_variants:
+            warnings.append(
+                "Fits were excluded for variants with mixed integer and floating scaling inputs: "
+                + ", ".join(sorted(mixed_input_kind_variants))
+                + "."
+            )
         environment_stable = all(point.environment_count == 1 for point in points)
         if not environment_stable:
             warnings.append("Environment identity varies within at least one scaling point.")
@@ -310,6 +331,8 @@ class ScalingRecipes(RecipeContext):
                 and math.isfinite(point.value)
             ]
             if len(numeric) < 3 or len({point.input_value for point in numeric}) < 2:
+                continue
+            if {point.input_kind for point in numeric} == {"integer", "floating"}:
                 continue
             x = np.asarray([point.input_value for point in numeric], dtype=float)
             y = np.asarray([point.value for point in numeric], dtype=float)

--- a/src/flameox/application/__init__.py
+++ b/src/flameox/application/__init__.py
@@ -363,6 +363,11 @@ __all__ = [
     "parse_inference_tool_discovery",
     "probe_existing_vllm_server",
     "render_evidence_summary_markdown",
+    "scalar_contains",
+    "scalar_equal",
+    "scalar_identity",
+    "scalar_identity_set",
+    "scalar_subset",
     "workspace_status",
 ]
 

--- a/src/flameox/application/experiments.py
+++ b/src/flameox/application/experiments.py
@@ -143,6 +143,7 @@ class ExperimentPlan(ContractModel):
     execution_policy: ExecutionPolicy
     variant_parameter: str
     variants: tuple[str, ...]
+    baseline_variant: str | None = None
     factors: dict[str, tuple[JsonValue, ...]] = Field(default_factory=dict)
     parameter_overrides: dict[str, JsonValue]
     blocks: tuple[ExperimentBlock, ...]
@@ -664,6 +665,11 @@ class ExperimentService:
             execution_policy=execution_policy,
             variant_parameter=variant_parameter,
             variants=variants,
+            baseline_variant=(
+                self._factor_label(config.baseline_value)
+                if isinstance(config, _FactorExperimentConfig) and config.baseline_value is not None
+                else None
+            ),
             factors={
                 name: tuple(cast(JsonValue, value) for value in values)
                 for name, values in factors.items()
@@ -907,12 +913,26 @@ class ExperimentService:
                 "Automatic experiment comparison currently requires pyperf measurements."
             )
         else:
+            comparison_run_sets: tuple[RunSet, ...] = run_sets
+            if not plan.baseline_variant:
+                limitations.append(
+                    "Baseline was determined by list position, not an explicit "
+                    "baseline_value. Reordering the treatment list reverses the "
+                    "comparison direction."
+                )
+            else:
+                comparison_run_sets = tuple(
+                    sorted(
+                        run_sets,
+                        key=lambda run_set: run_set.selection["variant"] != plan.baseline_variant,
+                    )
+                )
             comparison = await run_atomic_thread(
                 lambda: ComparisonService(self.workspace).record(
                     parse_compare_run_sets_request(
                         {
-                            "baseline_run_set_id": run_sets[0].run_set_id,
-                            "candidate_run_set_id": run_sets[1].run_set_id,
+                            "baseline_run_set_id": comparison_run_sets[0].run_set_id,
+                            "candidate_run_set_id": comparison_run_sets[1].run_set_id,
                             "experiment_id": plan.experiment.experiment_id,
                             "metric": plan.experiment.primary_metric,
                             "unit": (
@@ -1220,9 +1240,13 @@ class ExperimentService:
             disposition = ExperimentOutcomeDisposition.INSUFFICIENT_EVIDENCE
         elif not failures:
             disposition = ExperimentOutcomeDisposition.ALL_CLEAN
-        elif len(plan.variants) == 2 and failed_treatments == {plan.variants[0]}:
+        elif len(plan.variants) == 2 and failed_treatments == {
+            plan.baseline_variant or plan.variants[0]
+        }:
             disposition = ExperimentOutcomeDisposition.BASE_ONLY_FAILURE
-        elif len(plan.variants) == 2 and failed_treatments == {plan.variants[1]}:
+        elif len(plan.variants) == 2 and failed_treatments == {
+            v for v in plan.variants if v != (plan.baseline_variant or plan.variants[0])
+        }:
             disposition = ExperimentOutcomeDisposition.CANDIDATE_ONLY_FAILURE
         else:
             disposition = ExperimentOutcomeDisposition.MIXED

--- a/src/flameox/application/experiments.py
+++ b/src/flameox/application/experiments.py
@@ -913,42 +913,55 @@ class ExperimentService:
                 "Automatic experiment comparison currently requires pyperf measurements."
             )
         else:
-            comparison_run_sets: tuple[RunSet, ...] = run_sets
-            if not plan.baseline_variant:
+            comparison_run_sets: tuple[RunSet, RunSet] | None = run_sets
+            if plan.baseline_variant is None:
                 limitations.append(
                     "Baseline was determined by list position, not an explicit "
                     "baseline_value. Reordering the treatment list reverses the "
                     "comparison direction."
                 )
             else:
-                comparison_run_sets = tuple(
-                    sorted(
-                        run_sets,
-                        key=lambda run_set: run_set.selection["variant"] != plan.baseline_variant,
+                baseline_run_sets = tuple(
+                    run_set
+                    for run_set in run_sets
+                    if run_set.selection["variant"] == plan.baseline_variant
+                )
+                candidate_run_sets = tuple(
+                    run_set
+                    for run_set in run_sets
+                    if run_set.selection["variant"] != plan.baseline_variant
+                )
+                if len(baseline_run_sets) != 1 or len(candidate_run_sets) != 1:
+                    limitations.append(
+                        "Automatic paired comparison requires the declared baseline and exactly "
+                        "one candidate treatment."
+                    )
+                    comparison_run_sets = None
+                else:
+                    comparison_run_sets = (baseline_run_sets[0], candidate_run_sets[0])
+            if comparison_run_sets is not None:
+                comparison = await run_atomic_thread(
+                    lambda: ComparisonService(self.workspace).record(
+                        parse_compare_run_sets_request(
+                            {
+                                "baseline_run_set_id": comparison_run_sets[0].run_set_id,
+                                "candidate_run_set_id": comparison_run_sets[1].run_set_id,
+                                "experiment_id": plan.experiment.experiment_id,
+                                "metric": plan.experiment.primary_metric,
+                                "unit": (
+                                    "bytes"
+                                    if plan.metric_source is MetricSource.RUNTIME_RESOURCE
+                                    else "ns"
+                                ),
+                                "metric_source": plan.metric_source,
+                                "polarity": plan.experiment.polarity,
+                                "practical_threshold": plan.experiment.practical_threshold,
+                                "confidence_level": plan.experiment.confidence_level,
+                                "random_seed": plan.experiment.random_seed,
+                            }
+                        )
                     )
                 )
-            comparison = await run_atomic_thread(
-                lambda: ComparisonService(self.workspace).record(
-                    parse_compare_run_sets_request(
-                        {
-                            "baseline_run_set_id": comparison_run_sets[0].run_set_id,
-                            "candidate_run_set_id": comparison_run_sets[1].run_set_id,
-                            "experiment_id": plan.experiment.experiment_id,
-                            "metric": plan.experiment.primary_metric,
-                            "unit": (
-                                "bytes"
-                                if plan.metric_source is MetricSource.RUNTIME_RESOURCE
-                                else "ns"
-                            ),
-                            "metric_source": plan.metric_source,
-                            "polarity": plan.experiment.polarity,
-                            "practical_threshold": plan.experiment.practical_threshold,
-                            "confidence_level": plan.experiment.confidence_level,
-                            "random_seed": plan.experiment.random_seed,
-                        }
-                    )
-                )
-            )
         result_commit_id = published.commit.commit_id
         if comparison is not None:
             result_commit_id = comparison.materialized_commit_id or comparison.corpus_commit_id
@@ -1231,6 +1244,9 @@ class ExperimentService:
             trial.failure_class in {"oracle_inconclusive", "oracle_receipt_error", "unattempted"}
             for trial in trials
         )
+        baseline_variant = plan.baseline_variant
+        if baseline_variant is None and plan.variants:
+            baseline_variant = plan.variants[0]
         if counts and all(
             item.unsupported + item.oracle_unsupported == item.attempted and item.attempted > 0
             for item in counts
@@ -1240,13 +1256,17 @@ class ExperimentService:
             disposition = ExperimentOutcomeDisposition.INSUFFICIENT_EVIDENCE
         elif not failures:
             disposition = ExperimentOutcomeDisposition.ALL_CLEAN
-        elif len(plan.variants) == 2 and failed_treatments == {
-            plan.baseline_variant or plan.variants[0]
-        }:
+        elif (
+            len(plan.variants) == 2
+            and baseline_variant is not None
+            and failed_treatments == {baseline_variant}
+        ):
             disposition = ExperimentOutcomeDisposition.BASE_ONLY_FAILURE
-        elif len(plan.variants) == 2 and failed_treatments == {
-            v for v in plan.variants if v != (plan.baseline_variant or plan.variants[0])
-        }:
+        elif (
+            len(plan.variants) == 2
+            and baseline_variant is not None
+            and failed_treatments == {v for v in plan.variants if v != baseline_variant}
+        ):
             disposition = ExperimentOutcomeDisposition.CANDIDATE_ONLY_FAILURE
         else:
             disposition = ExperimentOutcomeDisposition.MIXED

--- a/src/flameox/application/experiments.py
+++ b/src/flameox/application/experiments.py
@@ -35,6 +35,10 @@ from flameox.application.workloads import (
     _FactorExperimentConfig,
     _OutcomeExperimentConfig,
     _ScaledLegacyExperimentConfig,
+    scalar_contains,
+    scalar_equal,
+    scalar_identity_set,
+    scalar_subset,
 )
 from flameox.catalog import Catalog
 from flameox.domain import (
@@ -988,7 +992,7 @@ class ExperimentService:
             matches = [
                 name
                 for name, choices in workload_parameters.items()
-                if set(config.variants).issubset(set(choices))
+                if scalar_subset(list(config.variants), list(choices))
             ]
             if not matches:
                 raise DomainError(
@@ -1018,7 +1022,9 @@ class ExperimentService:
                     ErrorCode.WORKSPACE_INVALID,
                     f"Experiment factor {name!r} is not a workload parameter.",
                 )
-            if len(set(values)) != len(values) or not set(values).issubset(set(allowed)):
+            if len(scalar_identity_set(list(values))) != len(values) or not scalar_subset(
+                list(values), list(allowed)
+            ):
                 raise DomainError(
                     ErrorCode.WORKSPACE_INVALID,
                     f"Experiment factor {name!r} contains duplicate or undeclared values.",
@@ -1040,7 +1046,7 @@ class ExperimentService:
                     ErrorCode.WORKSPACE_INVALID,
                     "Explicit combinations must contain every declared factor exactly once.",
                 )
-            if any(combination[name] not in factors[name] for name in factor_names):
+            if any(not scalar_contains(combination[name], factors[name]) for name in factor_names):
                 raise DomainError(
                     ErrorCode.WORKSPACE_INVALID,
                     "Explicit combination contains an undeclared factor value.",
@@ -1060,7 +1066,7 @@ class ExperimentService:
                     ErrorCode.WORKSPACE_INVALID,
                     "Every exclusion must name at least one declared factor.",
                 )
-            if any(value not in factors[name] for name, value in rule.items()):
+            if any(not scalar_contains(value, factors[name]) for name, value in rule.items()):
                 raise DomainError(
                     ErrorCode.WORKSPACE_INVALID,
                     "Exclusion contains an undeclared factor value.",
@@ -1069,7 +1075,7 @@ class ExperimentService:
             combination
             for combination in combinations
             if not any(
-                all(combination[name] == value for name, value in rule.items())
+                all(scalar_equal(combination[name], value) for name, value in rule.items())
                 for rule in config.exclude
             )
         )
@@ -1102,7 +1108,10 @@ class ExperimentService:
             selected = [
                 trial
                 for trial in trials
-                if trial.factors.get(plan.variant_parameter) == treatment_value
+                if scalar_equal(
+                    cast(Scalar, trial.factors.get(plan.variant_parameter)),
+                    cast(Scalar, treatment_value),
+                )
             ]
             attempted = sum(trial.outcome is not TrialOutcome.UNATTEMPTED for trial in selected)
             eligible = sum(

--- a/src/flameox/application/faults.py
+++ b/src/flameox/application/faults.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import shutil
 import socket
 from collections.abc import Awaitable, Callable
@@ -250,6 +251,9 @@ class FaultExperimentService:
         )
         blocks: list[ExperimentBlock] = []
         for block_number in range(1, config.blocks * config.repetitions + 1):
+            cell_treatments = list(treatments)
+            generator = random.Random(f"{config.random_seed}:{block_number}")
+            generator.shuffle(cell_treatments)
             cells = tuple(
                 ExperimentCell(
                     trial_id=digest_model(
@@ -260,12 +264,12 @@ class FaultExperimentService:
                     factors={"scenario": treatment},
                     parameters={},
                 )
-                for treatment in treatments
+                for treatment in cell_treatments
             )
             blocks.append(
                 ExperimentBlock(
                     block_id=f"fault-block-{block_number:04d}",
-                    order=treatments,
+                    order=tuple(cell_treatments),
                     cells=cells,
                 )
             )

--- a/src/flameox/application/faults.py
+++ b/src/flameox/application/faults.py
@@ -106,12 +106,13 @@ class FaultExperimentPlan(ContractModel):
 
 
 class FaultExperimentResult(ContractModel):
-    schema_version: Literal[1] = 1
+    schema_version: Literal[1, 2] = 2
     result_id: str
     plan_id: str
     experiment: Experiment
     trials: tuple[Trial, ...]
-    treatment_order: tuple[str, ...]
+    treatment_order: tuple[str, ...] | None = None
+    block_treatment_orders: tuple[tuple[str, ...], ...] = ()
     trial_artifacts: dict[str, tuple[str, ...]] = Field(default_factory=dict)
     corpus_commit_id: str
     limitations: tuple[str, ...] = ()
@@ -515,7 +516,7 @@ class FaultExperimentService:
             plan_id=plan.plan_id,
             experiment=plan.experiment_plan.experiment,
             trials=tuple(trials),
-            treatment_order=plan.experiment_plan.variants,
+            block_treatment_orders=tuple(block.order for block in plan.experiment_plan.blocks),
             trial_artifacts={name: tuple(values) for name, values in artifact_ids.items()},
             corpus_commit_id=self.workspace.corpus.read_head().commit_id,
             limitations=(

--- a/src/flameox/application/inference.py
+++ b/src/flameox/application/inference.py
@@ -1556,7 +1556,7 @@ class InferenceReplayService:
                 model_revision=plan.model_revision,
                 tokenizer_id=plan.tokenizer or plan.model,
                 tokenizer_revision=plan.tokenizer_revision or plan.model_revision,
-                quantization=plan.quantization or "none",
+                quantization=plan.quantization,
             ),
             server=ServerConfigIdentity(
                 backend=plan.server_provider.value,

--- a/src/flameox/application/summaries.py
+++ b/src/flameox/application/summaries.py
@@ -28,6 +28,23 @@ from flameox.domain import (
 from flameox.models import ContractModel
 from flameox.storage import ArtifactStore, JsonRecordStore, RunStore, Workspace
 
+_DISCARD_CHUNK_SIZE = 4096
+
+
+def _discard_rest_of_line(stream) -> None:
+    """Discard the remainder of an overlong line without materializing it.
+
+    Instead of calling unbounded ``stream.readline()`` which loads the
+    entire remaining line into memory, read fixed-size chunks until a
+    newline or EOF is encountered.  Peak memory is bounded by
+    ``_DISCARD_CHUNK_SIZE``, not by the physical line length.
+    """
+    while True:
+        chunk = stream.readline(_DISCARD_CHUNK_SIZE)
+        if not chunk or chunk.endswith("\n"):
+            break
+
+
 _ANSI_ESCAPE = re.compile(r"\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))")
 _CONTROL = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
@@ -566,7 +583,7 @@ class EvidenceSummaryService:
                     break
                 if len(line) == 201 and not line.endswith("\n"):
                     truncated = True
-                    stream.readline()
+                    _discard_rest_of_line(stream)
                 selected.append(_CONTROL.sub("", _ANSI_ESCAPE.sub("", line.rstrip("\r\n"))))
             if stream.readline(1):
                 truncated = True

--- a/src/flameox/application/summaries.py
+++ b/src/flameox/application/summaries.py
@@ -4,7 +4,7 @@ import html
 import json
 import re
 from enum import StrEnum
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal, TextIO, cast
 
 from pydantic import Field, JsonValue, model_validator
 
@@ -31,7 +31,7 @@ from flameox.storage import ArtifactStore, JsonRecordStore, RunStore, Workspace
 _DISCARD_CHUNK_SIZE = 4096
 
 
-def _discard_rest_of_line(stream) -> None:
+def _discard_rest_of_line(stream: TextIO) -> None:
     """Discard the remainder of an overlong line without materializing it.
 
     Instead of calling unbounded ``stream.readline()`` which loads the

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -265,6 +265,7 @@ class _FactorExperimentConfig(_CommonExperimentConfig):
     )
     exclude: Annotated[tuple[dict[str, Scalar], ...], Field(max_length=1_000)] = ()
     treatment_factor: str
+    baseline_value: Scalar | None = None
     scaling_parameter: Literal[None] = None
     scaling_values: Annotated[tuple[Scalar, ...], Field(max_length=0)] = ()
 
@@ -272,6 +273,12 @@ class _FactorExperimentConfig(_CommonExperimentConfig):
     def treatment_is_declared(self) -> _FactorExperimentConfig:
         if self.treatment_factor not in self.factors:
             raise ValueError("factor experiments require a declared treatment_factor")
+        if self.baseline_value is not None:
+            allowed = self.factors[self.treatment_factor]
+            if not scalar_contains(self.baseline_value, allowed):
+                raise ValueError(
+                    "baseline_value must be one of the declared treatment_factor values"
+                )
         return self
 
 

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -103,9 +103,7 @@ def scalar_identity_set(
 def scalar_subset(subset_values: list[Scalar], superset_values: list[Scalar]) -> bool:
     """Return True only when every identity in ``subset_values`` is in ``superset_values``."""
     superset = scalar_identity_set(superset_values)
-    return all(
-        identity in superset for identity in (scalar_identity(v) for v in subset_values)
-    )
+    return all(identity in superset for identity in (scalar_identity(v) for v in subset_values))
 
 
 RUNTIME_RESOURCE_METRICS = frozenset(

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -62,6 +62,52 @@ from flameox.storage import Workspace
 
 Scalar = str | int | float | bool
 
+
+def scalar_identity(value: Scalar) -> tuple[str, object]:
+    """Return a typed identity key distinguishing bool/int/float/str by exact JSON type.
+
+    Python's numeric tower treats ``True == 1`` and ``1 == 1.0`` as equal, and
+    ``hash(True) == hash(1)``. Configuration and evidence protocols must not
+    treat those as the same scalar. This helper returns a ``(type_tag, value)``
+    tuple where the type tag distinguishes the four scalar JSON kinds so that
+    ``scalar_identity(True) != scalar_identity(1)`` and
+    ``scalar_identity(1) != scalar_identity(1.0)``.
+    """
+    if type(value) is bool:
+        return ("bool", value)
+    if type(value) is int:
+        return ("int", value)
+    if type(value) is float:
+        return ("float", value)
+    return ("string", value)
+
+
+def scalar_equal(left: Scalar, right: Scalar) -> bool:
+    """Return True only when both scalars share the exact JSON type and value."""
+    return scalar_identity(left) == scalar_identity(right)
+
+
+def scalar_contains(value: Scalar, choices: tuple[Scalar, ...] | list[Scalar]) -> bool:
+    """Return True only when ``value`` is present in ``choices`` by exact scalar identity."""
+    identity = scalar_identity(value)
+    return any(scalar_identity(choice) == identity for choice in choices)
+
+
+def scalar_identity_set(
+    values: tuple[Scalar, ...] | list[Scalar],
+) -> set[tuple[str, object]]:
+    """Return the set of scalar identities for ``values`` without Python-equality collisions."""
+    return {scalar_identity(value) for value in values}
+
+
+def scalar_subset(subset_values: list[Scalar], superset_values: list[Scalar]) -> bool:
+    """Return True only when every identity in ``subset_values`` is in ``superset_values``."""
+    superset = scalar_identity_set(superset_values)
+    return all(
+        identity in superset for identity in (scalar_identity(v) for v in subset_values)
+    )
+
+
 RUNTIME_RESOURCE_METRICS = frozenset(
     {
         "runtime_resource.peak_rss_bytes",
@@ -1887,7 +1933,7 @@ class WorkloadService:
                     f"Dynamic workload parameter {name!r} must be supplied.",
                 )
             value = overrides.get(name, choices[0])
-            if name not in dynamic_parameters and value not in choices:
+            if name not in dynamic_parameters and not scalar_contains(value, choices):
                 raise DomainError(
                     ErrorCode.INVALID_CAPTURE_PLAN,
                     f"Value for {name!r} is outside the declared choices.",

--- a/src/flameox/application/workloads.py
+++ b/src/flameox/application/workloads.py
@@ -320,7 +320,7 @@ class _ScaledLegacyExperimentConfig(_LegacyExperimentConfig):
     @field_validator("scaling_values")
     @classmethod
     def scaling_values_are_unique(cls, value: tuple[Scalar, ...]) -> tuple[Scalar, ...]:
-        if len(set(value)) != len(value):
+        if len(scalar_identity_set(list(value))) != len(value):
             raise ValueError("experiment scaling values must be unique")
         return value
 

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -312,35 +312,6 @@ class OracleReceiptV1(ContractModel):
         return value
 
 
-    @model_validator(mode="after")
-    def status_must_be_coherent_with_evidence(self) -> OracleReceiptV1:
-        """Reject receipts where categorical status contradicts quantitative evidence.
-
-        When both ``absolute_error`` and ``tolerance.absolute`` are present,
-        a ``status='pass'`` receipt with error exceeding tolerance is rejected,
-        and a ``status='fail'`` receipt with error within tolerance is rejected.
-
-        Receipts without quantitative evidence (no error/tolerance) are
-        accepted with any status since there is nothing to contradict.
-        """
-        if self.absolute_error is not None and self.tolerance is not None:
-            abs_tol = self.tolerance.absolute
-            if abs_tol is not None:
-                if self.status == "pass" and self.absolute_error > abs_tol:
-                    raise ValueError(
-                        f"Receipt status='pass' contradicts evidence: "
-                        f"absolute_error={self.absolute_error} exceeds "
-                        f"tolerance.absolute={abs_tol}"
-                    )
-                if self.status == "fail" and self.absolute_error <= abs_tol:
-                    raise ValueError(
-                        f"Receipt status='fail' contradicts evidence: "
-                        f"absolute_error={self.absolute_error} is within "
-                        f"tolerance.absolute={abs_tol}"
-                    )
-        return self
-
-
 class OracleReceiptRecord(ContractModel):
     receipt: OracleReceiptV1
     receipt_artifact_id: Digest

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -1341,7 +1341,7 @@ class Variant(ContractModel):
     schema_version: Literal[1] = 1
     variant_id: Identifier
     experiment_id: Identifier
-    name: Identifier
+    name: str
     source_state_id: Digest | None = None
     workload_instance_id: Digest | None = None
     environment_requirements: dict[str, JsonValue] = Field(default_factory=dict)

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -22,6 +22,7 @@ from flameox.domain.scalars import NumericValue
 from flameox.models import ContractModel
 
 Identifier = Annotated[str, StringConstraints(min_length=1, max_length=200)]
+VariantName = Annotated[str, StringConstraints(max_length=200)]
 Digest = Annotated[str, StringConstraints(pattern=r"^sha256:[0-9a-f]{64}$")]
 ShortText = Annotated[str, StringConstraints(min_length=1, max_length=500)]
 
@@ -1341,7 +1342,7 @@ class Variant(ContractModel):
     schema_version: Literal[1] = 1
     variant_id: Identifier
     experiment_id: Identifier
-    name: str
+    name: VariantName
     source_state_id: Digest | None = None
     workload_instance_id: Digest | None = None
     environment_requirements: dict[str, JsonValue] = Field(default_factory=dict)

--- a/src/flameox/domain/models.py
+++ b/src/flameox/domain/models.py
@@ -312,6 +312,35 @@ class OracleReceiptV1(ContractModel):
         return value
 
 
+    @model_validator(mode="after")
+    def status_must_be_coherent_with_evidence(self) -> OracleReceiptV1:
+        """Reject receipts where categorical status contradicts quantitative evidence.
+
+        When both ``absolute_error`` and ``tolerance.absolute`` are present,
+        a ``status='pass'`` receipt with error exceeding tolerance is rejected,
+        and a ``status='fail'`` receipt with error within tolerance is rejected.
+
+        Receipts without quantitative evidence (no error/tolerance) are
+        accepted with any status since there is nothing to contradict.
+        """
+        if self.absolute_error is not None and self.tolerance is not None:
+            abs_tol = self.tolerance.absolute
+            if abs_tol is not None:
+                if self.status == "pass" and self.absolute_error > abs_tol:
+                    raise ValueError(
+                        f"Receipt status='pass' contradicts evidence: "
+                        f"absolute_error={self.absolute_error} exceeds "
+                        f"tolerance.absolute={abs_tol}"
+                    )
+                if self.status == "fail" and self.absolute_error <= abs_tol:
+                    raise ValueError(
+                        f"Receipt status='fail' contradicts evidence: "
+                        f"absolute_error={self.absolute_error} is within "
+                        f"tolerance.absolute={abs_tol}"
+                    )
+        return self
+
+
 class OracleReceiptRecord(ContractModel):
     receipt: OracleReceiptV1
     receipt_artifact_id: Digest

--- a/tests/adapters/test_inference_artifacts.py
+++ b/tests/adapters/test_inference_artifacts.py
@@ -1307,6 +1307,16 @@ def test_vllm_parse_rejects_boolean_native_request_counts() -> None:
     assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
 
 
+def test_vllm_parse_rejects_native_result_without_duration() -> None:
+    metrics = _vllm_metrics()
+    metrics["num_prompts"] = 313
+
+    with pytest.raises(DomainError) as error:
+        VllmResultParser().parse_payload(metrics)
+
+    assert error.value.code is ErrorCode.ARTIFACT_PARSE_FAILED
+
+
 def test_mooncake_extractor_publishes_bounded_request_evidence(tmp_path: Path) -> None:
     workspace = Workspace.initialize(tmp_path)
     trace = tmp_path / "trace.jsonl"

--- a/tests/analysis/test_inference_protocol.py
+++ b/tests/analysis/test_inference_protocol.py
@@ -45,6 +45,7 @@ def _protocol(**overrides: object) -> InferenceProtocolIdentity:
             "tokenizer_revision": "main",
             "trust_remote_code": False,
             "dtype": "auto",
+            "quantization": "none",
         },
         "server": {
             "backend": "vllm",
@@ -131,6 +132,16 @@ def test_missing_semantic_oracle_results_are_exploratory() -> None:
 
     assert result.validity is ComparisonValidity.EXPLORATORY
     assert any(reason.field == "oracle_result.status" for reason in result.exploratory_reasons)
+
+
+def test_missing_effective_quantization_is_exploratory() -> None:
+    baseline = _apply(_protocol(), "model.quantization", None)
+    candidate = _apply(_protocol(), "model.quantization", None)
+
+    result = compare_inference_protocols(baseline, candidate)
+
+    assert result.validity is ComparisonValidity.EXPLORATORY
+    assert any(reason.field == "model.quantization" for reason in result.exploratory_reasons)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/analysis/test_inference_protocol.py
+++ b/tests/analysis/test_inference_protocol.py
@@ -366,3 +366,23 @@ def test_server_rejects_out_of_range_gpu_utilization() -> None:
 def test_oracle_result_rejects_empty_reason() -> None:
     with pytest.raises(ValueError):
         OracleResult(status=OracleStatus.PASS, reason="")
+
+
+def test_kv_transfer_config_with_delimiter_chars_does_not_collide() -> None:
+    """Distinct KV-transfer configs with commas/equals in keys/values must not collide.
+
+    Regression for #288: the old ``_normalize()`` used unescaped
+    ``",".join(f"{k}={v}")`` which could make distinct dicts produce the
+    same normalized string. The fix uses canonical JSON serialization.
+    """
+    from flameox.analysis.inference_protocol import _normalize
+
+    config_a = {"a=b,c": "d"}
+    config_b = {"a": "b=c,d"}
+
+    norm_a = _normalize(config_a)
+    norm_b = _normalize(config_b)
+    assert norm_a != norm_b, (
+        f"Distinct configs must not collide: {config_a!r} vs {config_b!r} "
+        f"both normalized to {norm_a!r}"
+    )

--- a/tests/analysis/test_scaling_recipes.py
+++ b/tests/analysis/test_scaling_recipes.py
@@ -20,7 +20,7 @@ def test_scaling_reports_dispersion_models_and_supported_range(
 ) -> None:
     workspace = Workspace.initialize(tmp_path)
     now = FIXTURE_CREATED_AT
-    variants = (32_768, 65_536, 131_072)
+    variants = (32_768, 32_768.0, 65_536, 131_072)
     run_rows = []
     trial_rows = []
     measurement_rows: list[dict[str, object]] = []
@@ -37,6 +37,7 @@ def test_scaling_reports_dispersion_models_and_supported_range(
         }
     ]
     for input_value in variants:
+        is_integer = type(input_value) is int
         variant_id = "variant-baseline"
         for block in range(3):
             run_id = f"run-{input_value}-{block}"
@@ -57,7 +58,7 @@ def test_scaling_reports_dispersion_models_and_supported_range(
                     "collector": "pyperf",
                     "collector_version": "1",
                     "exit_code": 0,
-                    "wall_time_ns": input_value * 2,
+                    "wall_time_ns": int(input_value * 2),
                     "manifest_path": f"runs/{run_id}/manifest.json",
                 }
             )
@@ -74,8 +75,8 @@ def test_scaling_reports_dispersion_models_and_supported_range(
                     "block_id": f"block-{input_value}-{block}",
                     "order_in_block": block,
                     "parameter_name": "length",
-                    "parameter_value_int": input_value,
-                    "parameter_value_float": None,
+                    "parameter_value_int": input_value if is_integer else None,
+                    "parameter_value_float": None if is_integer else input_value,
                     "attempt": 1,
                     "outcome": "succeeded",
                     "exclusion_reason": None,
@@ -89,8 +90,8 @@ def test_scaling_reports_dispersion_models_and_supported_range(
                     "run_id": run_id,
                     "artifact_id": None,
                     "name": "scan.time",
-                    "value_int": input_value * 2 + block,
-                    "value_float": None,
+                    "value_int": int(input_value * 2 + block) if is_integer else None,
+                    "value_float": None if is_integer else input_value * 2 + block,
                     "unit": "ns",
                     "aggregation": "single",
                     "scope": "process",
@@ -179,14 +180,20 @@ def test_scaling_reports_dispersion_models_and_supported_range(
 
     result = RecipeService(workspace).scaling("scaling-experiment")
 
-    assert result.attempted_trials == 9
-    assert result.complete_blocks == 9
+    assert result.attempted_trials == 12
+    assert result.complete_blocks == 12
     assert result.environment_stable
     assert any(fit.model == "linear" for fit in result.fits)
     assert {fit.variant for fit in result.fits} == {"baseline"}
     assert {fit.supported_min for fit in result.fits} == {32_768}
     assert {fit.supported_max for fit in result.fits} == {131_072}
-    assert len(result.trials) == 9
+    assert len(result.trials) == 12
+    assert {(point.input_value, point.input_kind) for point in result.points} == {
+        (32_768.0, "integer"),
+        (32_768.0, "floating"),
+        (65_536.0, "integer"),
+        (131_072.0, "integer"),
+    }
     assert all(point.confidence_low is not None for point in result.points)
     assert result.correlated_hotspots[0].function == "reverse_scan"
     assert result.correlated_hotspots[0].spearman_rho > 0.9

--- a/tests/analysis/test_scaling_recipes.py
+++ b/tests/analysis/test_scaling_recipes.py
@@ -183,10 +183,11 @@ def test_scaling_reports_dispersion_models_and_supported_range(
     assert result.attempted_trials == 12
     assert result.complete_blocks == 12
     assert result.environment_stable
-    assert any(fit.model == "linear" for fit in result.fits)
-    assert {fit.variant for fit in result.fits} == {"baseline"}
-    assert {fit.supported_min for fit in result.fits} == {32_768}
-    assert {fit.supported_max for fit in result.fits} == {131_072}
+    assert result.fits == ()
+    assert (
+        "Fits were excluded for variants with mixed integer and floating scaling inputs: baseline."
+        in result.warnings
+    )
     assert len(result.trials) == 12
     assert {(point.input_value, point.input_kind) for point in result.points} == {
         (32_768.0, "integer"),

--- a/tests/application/test_experiments.py
+++ b/tests/application/test_experiments.py
@@ -98,7 +98,7 @@ async def test_randomized_experiment_records_trials_and_compares_run_sets(
     workspace = Workspace.initialize(tmp_path)
     (tmp_path / "bench.py").write_text(
         "import sys\n"
-        "count = 6000 if sys.argv[1] == 'baseline' else 1500\n"
+        "count = 6000 if sys.argv[1] == 'implementation=' else 1500\n"
         "assert sum(range(count)) >= 0\n"
     )
     (tmp_path / "flameox.toml").write_text(
@@ -106,12 +106,12 @@ async def test_randomized_experiment_records_trials_and_compares_run_sets(
 schema_version = 1
 
 [workloads.scan]
-argv = ["python", "bench.py", "{implementation}"]
+argv = ["python", "bench.py", "implementation={implementation}"]
 cwd = "."
 timeout_seconds = 30
 
 [workloads.scan.parameters]
-implementation = ["baseline", "candidate"]
+implementation = ["", "candidate"]
 
 [workloads.scan.oracle]
 strength = "cross_treatment_equivalence"
@@ -120,7 +120,7 @@ argv = ["python", "-c", "print('same-output')"]
 [experiments.scan_comparison]
 workload = "scan"
 treatment_factor = "implementation"
-baseline_value = "baseline"
+baseline_value = ""
 design = "randomized_complete_blocks"
 blocks = 1
 primary_metric = "pyperf.workload"
@@ -130,7 +130,7 @@ practical_threshold = 0.01
 confidence_level = 0.95
 random_seed = 1984
 [experiments.scan_comparison.factors]
-implementation = ["candidate", "baseline"]
+implementation = ["candidate", ""]
 """
     )
     config = workspace.config.validated_copy(
@@ -177,8 +177,8 @@ implementation = ["candidate", "baseline"]
     result = await service.run(plan.plan_id, progress=record_progress)
 
     assert len(plan.blocks) == 1
-    assert set(plan.blocks[0].order) == {"baseline", "candidate"}
-    assert plan.baseline_variant == "baseline"
+    assert set(plan.blocks[0].order) == {"", "candidate"}
+    assert plan.baseline_variant == ""
     assert len(result.trials) == 2
     assert all(trial.outcome is TrialOutcome.SUCCEEDED for trial in result.trials)
     assert len(result.run_sets) == 2
@@ -186,7 +186,7 @@ implementation = ["candidate", "baseline"]
     assert result.comparison.comparison.experiment_id == result.experiment.experiment_id
     assert result.comparison.comparison.validity is ComparisonValidity.EXPLORATORY
     assert result.comparison.comparison.complete_pair_n == 1
-    assert result.comparison.baseline_run_set.selection["variant"] == "baseline"
+    assert result.comparison.baseline_run_set.selection["variant"] == ""
     assert result.comparison.candidate_run_set.selection["variant"] == "candidate"
     assert result.limitations == ()
     assert service.experiments.read(result.experiment.experiment_id) == result.experiment
@@ -194,7 +194,7 @@ implementation = ["candidate", "baseline"]
     assert scaling.attempted_trials == 2
     assert scaling.complete_blocks == 1
     assert {point.variant for point in scaling.points} == {
-        "baseline",
+        "",
         "candidate",
     }
     assert [item[0] for item in progress] == list(range(7))
@@ -254,6 +254,66 @@ implementation = ["baseline", "candidate"]
 
     assert result.comparison is not None
     assert result.comparison.comparison.metric == "runtime_resource.peak_rss_bytes"
+
+
+@pytest.mark.anyio
+async def test_explicit_factor_comparison_requires_the_declared_baseline(tmp_path: Path) -> None:
+    workspace = Workspace.initialize(tmp_path)
+    (tmp_path / "bench.py").write_text("assert sum(range(1000)) >= 0\n")
+    (tmp_path / "flameox.toml").write_text(
+        """
+schema_version = 1
+[workloads.scan]
+argv = ["python", "bench.py"]
+cwd = "."
+[workloads.scan.parameters]
+implementation = ["baseline", "candidate", "other"]
+[workloads.scan.oracle]
+strength = "cross_treatment_equivalence"
+argv = ["python", "-c", "print('same-output')"]
+[experiments.partial]
+workload = "scan"
+treatment_factor = "implementation"
+baseline_value = "baseline"
+combination_policy = "explicit"
+combinations = [{implementation = "candidate"}, {implementation = "other"}]
+blocks = 1
+primary_metric = "runtime_resource.peak_rss_bytes"
+polarity = "lower_is_better"
+[experiments.partial.factors]
+implementation = ["baseline", "candidate", "other"]
+"""
+    )
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "add", "bench.py", "flameox.toml")
+    _git(
+        tmp_path,
+        "-c",
+        "user.name=flameox Test",
+        "-c",
+        "user.email=flameox@example.invalid",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+    investigation = InvestigationService(workspace).create(
+        CreateInvestigationRequest(question="Does the partial matrix affect resource use?")
+    )
+    service = ExperimentService(workspace)
+    plan = await service.plan(
+        experiment_name="partial",
+        investigation_id=investigation.investigation_id,
+        adapter="command",
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    result = await service.run(plan.plan_id)
+
+    assert result.comparison is None
+    assert (
+        "Automatic paired comparison requires the declared baseline and exactly one candidate "
+        "treatment." in (result.limitations)
+    )
 
 
 @pytest.mark.anyio
@@ -614,14 +674,14 @@ schema_version = 1
 [workloads.semantic]
 argv = ["python", "-c", "print('{mode}', '{case}')"]
 [workloads.semantic.parameters]
-mode = ["base", "candidate"]
+mode = ["", "candidate"]
 case = ["bad", "clean"]
 [workloads.semantic.oracle]
 strength = "contract_check"
 argv = [
   "python", "-c",
-  "import sys; raise SystemExit(1 if sys.argv[1:] == ['base', 'bad'] else 0)",
-  "{mode}", "{case}",
+  "import sys; raise SystemExit(1 if sys.argv[1:] == ['mode=', 'bad'] else 0)",
+  "mode={mode}", "{case}",
 ]
 
 [experiments.semantic]
@@ -629,13 +689,13 @@ workload = "semantic"
 design = "fixed_order"
 blocks = 1
 treatment_factor = "mode"
-baseline_value = "base"
+baseline_value = ""
 analysis = "outcome"
 outcome_goal = "equivalence"
 minimum_attempts = 1
 maximum_attempts = 1
 [experiments.semantic.factors]
-mode = ["candidate", "base"]
+mode = ["candidate", ""]
 case = ["bad", "clean"]
 """
     )
@@ -665,10 +725,11 @@ case = ["bad", "clean"]
     assert result.outcome.disposition == "base_only_failure"
     assert result.outcome.complete_pairs == 2
     assert result.outcome.unmatched_cells == 0
-    assert result.outcome.first_failure_factors == {"mode": "base", "case": "bad"}
+    assert plan.baseline_variant == ""
+    assert result.outcome.first_failure_factors == {"mode": "", "case": "bad"}
     counts = {item.treatment: item for item in result.outcome.counts}
-    assert counts["base"].oracle_failed == 1
-    assert counts["base"].failure_rate == 0.5
+    assert counts[""].oracle_failed == 1
+    assert counts[""].failure_rate == 0.5
     assert counts["candidate"].pass_rate == 1
     with Catalog(workspace).open_snapshot() as snapshot:
         row = snapshot.execute(

--- a/tests/application/test_experiments.py
+++ b/tests/application/test_experiments.py
@@ -120,6 +120,7 @@ argv = ["python", "-c", "print('same-output')"]
 [experiments.scan_comparison]
 workload = "scan"
 treatment_factor = "implementation"
+baseline_value = "baseline"
 design = "randomized_complete_blocks"
 blocks = 1
 primary_metric = "pyperf.workload"
@@ -129,7 +130,7 @@ practical_threshold = 0.01
 confidence_level = 0.95
 random_seed = 1984
 [experiments.scan_comparison.factors]
-implementation = ["baseline", "candidate"]
+implementation = ["candidate", "baseline"]
 """
     )
     config = workspace.config.validated_copy(
@@ -177,6 +178,7 @@ implementation = ["baseline", "candidate"]
 
     assert len(plan.blocks) == 1
     assert set(plan.blocks[0].order) == {"baseline", "candidate"}
+    assert plan.baseline_variant == "baseline"
     assert len(result.trials) == 2
     assert all(trial.outcome is TrialOutcome.SUCCEEDED for trial in result.trials)
     assert len(result.run_sets) == 2
@@ -184,6 +186,8 @@ implementation = ["baseline", "candidate"]
     assert result.comparison.comparison.experiment_id == result.experiment.experiment_id
     assert result.comparison.comparison.validity is ComparisonValidity.EXPLORATORY
     assert result.comparison.comparison.complete_pair_n == 1
+    assert result.comparison.baseline_run_set.selection["variant"] == "baseline"
+    assert result.comparison.candidate_run_set.selection["variant"] == "candidate"
     assert result.limitations == ()
     assert service.experiments.read(result.experiment.experiment_id) == result.experiment
     scaling = RecipeService(workspace).scaling(result.experiment.experiment_id)
@@ -625,12 +629,13 @@ workload = "semantic"
 design = "fixed_order"
 blocks = 1
 treatment_factor = "mode"
+baseline_value = "base"
 analysis = "outcome"
 outcome_goal = "equivalence"
 minimum_attempts = 1
 maximum_attempts = 1
 [experiments.semantic.factors]
-mode = ["base", "candidate"]
+mode = ["candidate", "base"]
 case = ["bad", "clean"]
 """
     )

--- a/tests/application/test_faults.py
+++ b/tests/application/test_faults.py
@@ -322,6 +322,10 @@ latency_ms = 10
     assert len(result.trials) == 2
     assert all(trial.run_id is not None for trial in result.trials)
     assert len(leases) == 2
+    assert result.treatment_order is None
+    assert result.block_treatment_orders == tuple(
+        block.order for block in plan.experiment_plan.blocks
+    )
     # Baseline must have no toxics; the latency treatment must have one.
     baseline_lease = next(lease for lease in leases if lease.treatments == [])
     treatment_lease = next(

--- a/tests/application/test_faults.py
+++ b/tests/application/test_faults.py
@@ -322,8 +322,12 @@ latency_ms = 10
     assert len(result.trials) == 2
     assert all(trial.run_id is not None for trial in result.trials)
     assert len(leases) == 2
-    assert leases[0].treatments == []
-    assert leases[1].treatments[0]["toxic_type"] == "latency"
+    # Baseline must have no toxics; the latency treatment must have one.
+    baseline_lease = next(lease for lease in leases if lease.treatments == [])
+    treatment_lease = next(
+        lease for lease in leases if lease.treatments and lease is not baseline_lease
+    )
+    assert treatment_lease.treatments[0]["toxic_type"] == "latency"
     assert all(trial.trial_id in result.trial_artifacts for trial in result.trials)
 
     treatment_run = next(
@@ -342,7 +346,7 @@ latency_ms = 10
     )
     assert config_payload["tool"]["version"] == "2.12.0"
     assert config_payload["tool"]["sha256"] == "a" * 64
-    assert config_payload["observed"]["admin_port"] == 48002
+    assert config_payload["observed"]["admin_port"] in (48001, 48002)
     assert config_payload["observed"]["proxy_upstream"] == f"127.0.0.1:{upstream.server_port}"
     assert config_payload["observed"]["oracle"]["validation_status"] == "not_requested"
     endpoint = f"http://127.0.0.1:{upstream.server_port}"
@@ -363,3 +367,92 @@ latency_ms = 10
         not set(item).intersection({"cmdline", "environment", "cwd", "exe", "connections"})
         for item in snapshot_payload
     )
+
+
+@pytest.mark.anyio
+async def test_fault_plan_randomizes_treatment_order_across_blocks(
+    tmp_path: Path,
+) -> None:
+    """Regression: random_seed must permute the schedule so baseline is not always first.
+
+    Issue #286: Fault experiments always ran baseline first, confounding
+    treatment with execution order. The seed must now produce a different
+    schedule than the fixed declaration order.
+    """
+    workspace = Workspace.initialize(tmp_path)
+    (tmp_path / "flameox.toml").write_text(
+        """
+schema_version = 1
+
+[workloads.client]
+argv = ["python", "-c", "print(1)", "{endpoint}"]
+cwd = "."
+
+[workloads.client.parameters]
+endpoint = ["unused"]
+
+[fault_experiments.transport]
+workload = "client"
+endpoint_parameter = "endpoint"
+upstream_host = "127.0.0.1"
+upstream_port = 8080
+endpoint_template = "http://{host}:{port}"
+blocks = 2
+repetitions = 1
+random_seed = 42
+
+[fault_experiments.transport.scenarios.delay]
+type = "latency"
+latency_ms = 10
+
+[fault_experiments.transport.scenarios.timeout]
+type = "timeout"
+timeout_ms = 50
+"""
+    )
+    investigation = InvestigationService(workspace).create(
+        CreateInvestigationRequest(question="does transport latency change the outcome?")
+    )
+    tool_manager = _ToolManager(Path("/bin/true"))
+    plan = await FaultExperimentService(workspace, tool_manager=tool_manager).plan(
+        experiment_name="transport",
+        investigation_id=investigation.investigation_id,
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+
+    # Baseline must not be first in every block (the old confounding bug).
+    first_treatments = [block.order[0] for block in plan.experiment_plan.blocks]
+    assert not all(t == "baseline" for t in first_treatments), (
+        "Baseline is always first — treatment is confounded with execution order."
+    )
+
+    # All declared treatments appear in each block (no drop).
+    for block in plan.experiment_plan.blocks:
+        assert set(block.order) == {"baseline", "delay", "timeout"}
+
+    # Reproducibility: same seed + same block gives the same order.
+    plan2 = await FaultExperimentService(
+        workspace, tool_manager=_ToolManager(Path("/bin/true"))
+    ).plan(
+        experiment_name="transport",
+        investigation_id=investigation.investigation_id,
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    assert [b.order for b in plan.experiment_plan.blocks] == [
+        b.order for b in plan2.experiment_plan.blocks
+    ]
+
+    # Different seed gives a different schedule.
+    (tmp_path / "flameox.toml").write_text(
+        (tmp_path / "flameox.toml").read_text().replace("random_seed = 42", "random_seed = 999")
+    )
+    plan_diff = await FaultExperimentService(
+        workspace, tool_manager=_ToolManager(Path("/bin/true"))
+    ).plan(
+        experiment_name="transport",
+        investigation_id=investigation.investigation_id,
+        execution_policy=ExecutionPolicy.TRUSTED_LOCAL,
+    )
+    assert [b.order for b in plan_diff.experiment_plan.blocks] != [
+        b.order for b in plan.experiment_plan.blocks
+    ]

--- a/tests/application/test_inference_comparison.py
+++ b/tests/application/test_inference_comparison.py
@@ -85,6 +85,7 @@ def _complete_protocol_identity() -> InferenceProtocolIdentity:
             model_revision="revision-1",
             tokenizer_id="test-tokenizer",
             tokenizer_revision="revision-1",
+            quantization="none",
         ),
         server=ServerConfigIdentity(
             backend="vllm",

--- a/tests/application/test_summaries.py
+++ b/tests/application/test_summaries.py
@@ -182,3 +182,26 @@ def test_trial_failure_class_fallback_for_null_column_value() -> None:
 
     fallback = TrialFailureClass(str(None) if None is not None else TrialFailureClass.NONE)
     assert fallback is TrialFailureClass.NONE
+
+
+def test_excerpt_discards_overlong_line_in_bounded_chunks() -> None:
+    """Overlong lines must not be materialized during excerpt extraction.
+
+    Regression for #291: ``_excerpt()`` called unbounded ``stream.readline()``
+    to discard the remainder of a line longer than 200 characters, materializing
+    a multi-gigabyte string in memory. The fix uses bounded ``_DISCARD_CHUNK_SIZE``
+    chunks instead.
+    """
+    import io
+
+    from flameox.application.summaries import _discard_rest_of_line
+
+    long_line = "X" * 10_000
+    content = f"{long_line}\nshort line\n"
+    stream = io.StringIO(content)
+    line = stream.readline(201)
+    assert len(line) == 201
+    assert not line.endswith("\n")
+    _discard_rest_of_line(stream)
+    next_line = stream.readline()
+    assert next_line == "short line\n"

--- a/tests/application/test_workloads.py
+++ b/tests/application/test_workloads.py
@@ -425,6 +425,28 @@ def test_experiment_requires_explicit_treatment_factor_and_factors() -> None:
     assert config.factors["length"] == (128, 256)
 
 
+def test_factor_experiment_baseline_value_uses_exact_scalar_identity() -> None:
+    config = parse_experiment_config(
+        {
+            "workload": "probe",
+            "treatment_factor": "mode",
+            "baseline_value": 1.0,
+            "factors": {"mode": (1, 1.0)},
+        }
+    )
+
+    assert config.model_dump(mode="python")["baseline_value"] == 1.0
+    with pytest.raises(ValueError, match="baseline_value must be one of"):
+        parse_experiment_config(
+            {
+                "workload": "probe",
+                "treatment_factor": "mode",
+                "baseline_value": True,
+                "factors": {"mode": (1, 1.0)},
+            }
+        )
+
+
 def test_scalar_identity_distinguishes_exact_json_types() -> None:
     """Scalar identity distinguishes bool/int/float even when Python equality treats them equal."""
     from flameox.application import (

--- a/tests/application/test_workloads.py
+++ b/tests/application/test_workloads.py
@@ -187,6 +187,30 @@ def test_schema_one_legacy_experiment_fields_remain_loadable() -> None:
     assert experiment.scaling_values == (1, 2)
 
 
+def test_legacy_scaled_experiment_accepts_distinct_typed_scaling_values() -> None:
+    project = ProjectConfig.model_validate(
+        {
+            "schema_version": 1,
+            "workloads": {
+                "scan": {
+                    "argv": ["python", "-c", "print('{length}')"],
+                    "parameters": {"length": [1, 1.0]},
+                }
+            },
+            "experiments": {
+                "scan": {
+                    "workload": "scan",
+                    "variants": ["baseline", "candidate"],
+                    "scaling_parameter": "length",
+                    "scaling_values": [1, 1.0],
+                }
+            },
+        }
+    )
+
+    assert project.experiments["scan"].scaling_values == (1, 1.0)
+
+
 @pytest.mark.parametrize(
     "shape",
     (

--- a/tests/application/test_workloads.py
+++ b/tests/application/test_workloads.py
@@ -399,3 +399,134 @@ def test_experiment_requires_explicit_treatment_factor_and_factors() -> None:
     )
     assert config.treatment_factor == "mode"
     assert config.factors["length"] == (128, 256)
+
+
+def test_scalar_identity_distinguishes_exact_json_types() -> None:
+    """Scalar identity distinguishes bool/int/float even when Python equality treats them equal."""
+    from flameox.application import (
+        scalar_contains,
+        scalar_equal,
+        scalar_identity,
+        scalar_identity_set,
+        scalar_subset,
+    )
+
+    # True is not 1, 1 is not 1.0
+    assert scalar_identity(True) != scalar_identity(1)
+    assert scalar_identity(False) != scalar_identity(0)
+    assert scalar_identity(1) != scalar_identity(1.0)
+    assert scalar_identity(0) != scalar_identity(0.0)
+    assert scalar_identity(1) != scalar_identity("1")
+
+    assert not scalar_equal(True, 1)
+    assert not scalar_equal(False, 0)
+    assert not scalar_equal(1, 1.0)
+    assert not scalar_equal(1, "1")
+    assert scalar_equal(1, 1)
+    assert scalar_equal(True, True)
+    assert scalar_equal("a", "a")
+
+    # scalar_contains uses exact type
+    assert scalar_contains(1, (1,))
+    assert not scalar_contains(True, (1,))
+    assert not scalar_contains(1, (1.0,))
+    assert not scalar_contains(1.0, (1,))
+    assert not scalar_contains(1, (True,))
+    assert not scalar_contains(0, (False,))
+    assert scalar_contains(True, (True,))
+    assert scalar_contains(False, (False,))
+
+    # scalar_identity_set treats distinct-typed values as distinct
+    ids = scalar_identity_set([True, 1, 1.0, "1", True])
+    assert len(ids) == 4
+    ids2 = scalar_identity_set([1, 1, 1])
+    assert len(ids2) == 1
+
+    assert scalar_subset([1, 2], [1, 2, 3])
+    assert not scalar_subset([True], [1])
+    assert not scalar_subset([1.0], [1])
+    assert not scalar_subset([1], [1.0])
+    assert scalar_subset([True], [True])
+
+
+def test_resolve_rejects_int_for_bool_choice(tmp_path: Path) -> None:
+    """Regression for #258: integer 1 must not authorize a boolean True choice."""
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+    service.configure(
+        ConfigureWorkloadRequest(
+            name="probe",
+            operation=ConfigurationOperation.CREATE,
+            config=WorkloadConfig(
+                argv=("python", "-c", "print({mode})"),
+                parameters={"mode": (True,)},
+            ),
+        )
+    )
+
+    with pytest.raises(DomainError) as exc:
+        service.resolve("probe", {"mode": 1})
+    assert exc.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+    with pytest.raises(DomainError) as exc2:
+        service.resolve("probe", {"mode": 1.0})
+    assert exc2.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_resolve_rejects_float_for_int_choice(tmp_path: Path) -> None:
+    """Regression for #258: float 1.0 must not authorize an integer 1 choice."""
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+    service.configure(
+        ConfigureWorkloadRequest(
+            name="probe",
+            operation=ConfigurationOperation.CREATE,
+            config=WorkloadConfig(
+                argv=("python", "-c", "print({mode})"),
+                parameters={"mode": (1,)},
+            ),
+        )
+    )
+
+    with pytest.raises(DomainError) as exc:
+        service.resolve("probe", {"mode": 1.0})
+    assert exc.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_resolve_rejects_bool_for_int_choice(tmp_path: Path) -> None:
+    """Regression for #258: bool True must not authorize an integer 1 choice."""
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+    service.configure(
+        ConfigureWorkloadRequest(
+            name="probe",
+            operation=ConfigurationOperation.CREATE,
+            config=WorkloadConfig(
+                argv=("python", "-c", "print({mode})"),
+                parameters={"mode": (1,)},
+            ),
+        )
+    )
+
+    with pytest.raises(DomainError) as exc:
+        service.resolve("probe", {"mode": True})
+    assert exc.value.code is ErrorCode.INVALID_CAPTURE_PLAN
+
+
+def test_resolve_accepts_same_type_choices(tmp_path: Path) -> None:
+    """Regression for #258: same-typed values must still authorize normally."""
+    workspace = Workspace.initialize(tmp_path)
+    service = WorkloadService(workspace)
+    service.configure(
+        ConfigureWorkloadRequest(
+            name="probe",
+            operation=ConfigurationOperation.CREATE,
+            config=WorkloadConfig(
+                argv=("python", "-c", "print({mode})"),
+                parameters={"mode": (1, 2, 3)},
+            ),
+        )
+    )
+
+    instance = service.resolve("probe", {"mode": 2})
+    assert instance.parameters["mode"] == 2

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 1114
+expected_test_count = 1123
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -53,7 +53,7 @@ expected_test_count = 1114
 'tests/adapters/test_rocprofv3.py' = { count = 2, digest = '74d3cdec78f50bbeb071fef68b7d49e9263e65d1fd5fec74c622a13082bbe287' }
 'tests/adapters/test_rocprofv3_integration.py' = { count = 2, digest = '9fdd3be1c71747a60ed481fde51746d8b9fa4dcb47c5655f18df87ca007a9208' }
 'tests/adapters/test_triton_compiler_live.py' = { count = 1, digest = '0dfa64a2bfaaf94a441d80fac025d703bc267101e9ab748c31d25c8ee9ebfd5e' }
-'tests/adapters/test_inference_artifacts.py' = { count = 86, digest = '9a9ccc9c7cfa6204fa5dc02a04b1b23c4899b5b719ed98ce846608d80a43d739' }
+'tests/adapters/test_inference_artifacts.py' = { count = 87, digest = 'e12e28231cf501ea2bcfed6972e57ab65cbe9dcb43ee970d9d47baed650205d0' }
 'tests/adapters/test_coverage.py' = { count = 3, digest = 'a9aa85687b6f34101ebcf2d6b69c22c866f9279436bdb9cbaff2793dba714891' }
 'tests/adapters/test_memray.py' = { count = 3, digest = '929b943d44dd1e64914730a760870fb7f87154c0a036e7d6ef355ce42d858c66' }
 'tests/adapters/test_nsight_systems.py' = { count = 4, digest = 'd6762bee4c5f04bbd6d4fdb78fddd891aa59d08b06311b895cf46f968c756570' }
@@ -68,7 +68,7 @@ expected_test_count = 1114
 'tests/adapters/test_torch_profiler_options.py' = { count = 2, digest = '3b480faefa032c78b2441d34c82e359341e723046fb136bc5e6bfd9d5f4be1e4' }
 'tests/analysis/test_comparison.py' = { count = 4, digest = '311406582a5fda58dbd1e74e6f7dff58cbe2bb760536031bb160f0c50ff08fa2' }
 'tests/analysis/test_accelerator_launches.py' = { count = 5, digest = '18ccb9f28a57ca95ea14812749035748ee2d89a6b07bef45fc7376f5e12d58e3' }
-'tests/analysis/test_inference_protocol.py' = { count = 58, digest = 'a25e98d4a19819155f8b7bc1f7ad650b96335560a2bcf115ed53e3f6927bacb4' }
+'tests/analysis/test_inference_protocol.py' = { count = 59, digest = '3a8958320e88e242286502afbc5159c066b931f9170960c99aff8df44d4d5c6d' }
 'tests/analysis/test_recipes.py' = { count = 10, digest = 'b78c8d7935bd9ca634e869cec62e0fd87c12f94861c818671869245785fbcfd9' }
 'tests/application/test_analysis_records.py' = { count = 14, digest = '05c33a6e5af5a43a18fec3ecad8c27113882e035ee0d89a3ba15279e9defccf7' }
 'tests/application/test_artifact_workers.py' = { count = 6, digest = 'dd06d1ce7d46627d8cdfb5c8a3b0198e3e8e978d4cbdf0c1bed268a230102124' }
@@ -86,7 +86,7 @@ expected_test_count = 1114
 'tests/application/test_evidence_query.py' = { count = 3, digest = '619797e86687938c280892af2964aa021f45f32cef09b7ac265666a947753756' }
 'tests/application/test_evidence_scope.py' = { count = 2, digest = 'e3e51e28f67c6512e3943f88f469d937f88d5f7f88317a34868640e55b9f590b' }
 'tests/application/test_experiments.py' = { count = 18, digest = '95d084beefa0218c9b51932af825da046f1c5e504658808e4eb788bd3bd2e38c' }
-'tests/application/test_faults.py' = { count = 5, digest = '9330626143cdfb60660c3466aea29491ddce50d1cecd1e04fe4b4b7b11d2fe8a' }
+'tests/application/test_faults.py' = { count = 6, digest = 'fc535b155c5efc5d81e3fe5f989693f4d94f0558c4cf5fa902fab4906992146f' }
 'tests/application/test_inference.py' = { count = 24, digest = '94d1855f57a28a2fae76c90152ee90bcda00099789b37dd779ea005c35426634' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }
 'tests/application/test_inference_configuration.py' = { count = 25, digest = 'ebd8b0b6feb8fe9a82c1f47dfddbd699a3a3753de091443795c4451d0dae1948' }
@@ -107,11 +107,11 @@ expected_test_count = 1114
 'tests/application/test_setup.py' = { count = 19, digest = '4ca5627f631a69bde5ecca086bc2ce4daa71fd2d90f5e2723d9ec40fa1b2201a' }
 'tests/application/test_source_identity.py' = { count = 2, digest = '0a6d84aebe1dd3c6b877d4de131aebf44efa50a7e9ddc23a7390c16a0c1fb4e2' }
 'tests/application/test_status.py' = { count = 3, digest = '1ff4f1c315236e7e1207fc54890018db1c94071b8bc916e0b9fb75cd5d35f254' }
-'tests/application/test_summaries.py' = { count = 5, digest = 'dcfdb9b404200ec48e73a9155642cd2612f31620fa1e9a9a071997e684fcc830' }
+'tests/application/test_summaries.py' = { count = 6, digest = '851c3b1327361ea12223ce058031b6ecc62d409aa923bb5a8202226376752c86' }
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = '8e3cdabaab74c522b762fc616415f1dab272fa95afb12c152f1668a5b03089ce' }
 'tests/application/test_viewers.py' = { count = 9, digest = 'cb76ef25a45e1af1ec07f4c8a1f30a78a1bd6de0842073d11aa0b5a508a4458d' }
 'tests/application/test_run_set_variants.py' = { count = 2, digest = '8bdf8d791bd9734c165c5f94265522240f9af03e35b058d3654363462042c4f4' }
-'tests/application/test_workloads.py' = { count = 27, digest = 'e3563465e5b338de77d7c7dfb10b56a57bc7519541290572c265f6a15f50489b' }
+'tests/application/test_workloads.py' = { count = 32, digest = 'e7f92d989c6961a50fad105606f6a014df30132590c6bc36427f51eee9ba72c2' }
 'tests/application/test_workloads_and_capture.py' = { count = 61, digest = '4a3b82b3bf031b5178476cc42daeec7159bb26b887160cb11132af2218af387d' }
 'tests/application/test_operations.py' = { count = 12, digest = 'bf0944d7a9c98f44155ff2fe60c0be1fa2abf72f561237fb1cdf503d1c289e37' }
 'tests/application/test_otlp_lifecycle.py' = { count = 6, digest = 'b86df016da038f8d1d112e57c0f7a94ddd57ffc4d6e47a8785b048c20903eb34' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 1125
+expected_test_count = 1126
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -68,7 +68,7 @@ expected_test_count = 1125
 'tests/adapters/test_torch_profiler_options.py' = { count = 2, digest = '3b480faefa032c78b2441d34c82e359341e723046fb136bc5e6bfd9d5f4be1e4' }
 'tests/analysis/test_comparison.py' = { count = 4, digest = '311406582a5fda58dbd1e74e6f7dff58cbe2bb760536031bb160f0c50ff08fa2' }
 'tests/analysis/test_accelerator_launches.py' = { count = 5, digest = '18ccb9f28a57ca95ea14812749035748ee2d89a6b07bef45fc7376f5e12d58e3' }
-'tests/analysis/test_inference_protocol.py' = { count = 59, digest = '3a8958320e88e242286502afbc5159c066b931f9170960c99aff8df44d4d5c6d' }
+'tests/analysis/test_inference_protocol.py' = { count = 60, digest = 'ec13ae4237a074fa9f85128c7054811e0030f3ae9f047883b643180b8018be07' }
 'tests/analysis/test_recipes.py' = { count = 10, digest = 'b78c8d7935bd9ca634e869cec62e0fd87c12f94861c818671869245785fbcfd9' }
 'tests/application/test_analysis_records.py' = { count = 14, digest = '05c33a6e5af5a43a18fec3ecad8c27113882e035ee0d89a3ba15279e9defccf7' }
 'tests/application/test_artifact_workers.py' = { count = 6, digest = 'dd06d1ce7d46627d8cdfb5c8a3b0198e3e8e978d4cbdf0c1bed268a230102124' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 1127
+expected_test_count = 1129
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -116,7 +116,7 @@ expected_test_count = 1127
 'tests/application/test_operations.py' = { count = 12, digest = 'bf0944d7a9c98f44155ff2fe60c0be1fa2abf72f561237fb1cdf503d1c289e37' }
 'tests/application/test_otlp_lifecycle.py' = { count = 6, digest = 'b86df016da038f8d1d112e57c0f7a94ddd57ffc4d6e47a8785b048c20903eb34' }
 'tests/domain/test_identity.py' = { count = 3, digest = '0dd4b644c18a6e8d07d56f9feb07c9af53da4791f465627d4c0f0fe6060a71e5' }
-'tests/domain/test_models.py' = { count = 56, digest = '52f7a227258f1bb055b5bf34cf0cf6a6e4395da54858b25c8381ddee619fb214' }
+'tests/domain/test_models.py' = { count = 58, digest = '917a50e293bb3124c74784c7d989efcf4f0548a6652e3ad84c1ac79ade31bea7' }
 'tests/evidence/test_evidence_status.py' = { count = 4, digest = '3ffd4dee690575b98b6f0187f976abdeb6f8e5d14efbb389a4ebee3b5d4f9637' }
 'tests/evidence/test_numeric_values.py' = { count = 6, digest = '1ad6a03f72531453fb0c355938cc9e8ba2efc60dd3549467f2a48f3c676733d0' }
 'tests/evidence/test_publication_and_catalog.py' = { count = 19, digest = 'cc7b612afebfb3f235b098f75d67b599d2359713de9b708f57250eb12bda3ff5' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 1126
+expected_test_count = 1127
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -85,7 +85,7 @@ expected_test_count = 1126
 'tests/application/test_environment_identity.py' = { count = 10, digest = '22a3e3a5af0f747fcf9a680ba01e2d05dab7362ed5ac558d774e788826fb62c6' }
 'tests/application/test_evidence_query.py' = { count = 3, digest = '619797e86687938c280892af2964aa021f45f32cef09b7ac265666a947753756' }
 'tests/application/test_evidence_scope.py' = { count = 2, digest = 'e3e51e28f67c6512e3943f88f469d937f88d5f7f88317a34868640e55b9f590b' }
-'tests/application/test_experiments.py' = { count = 18, digest = '95d084beefa0218c9b51932af825da046f1c5e504658808e4eb788bd3bd2e38c' }
+'tests/application/test_experiments.py' = { count = 19, digest = '79c851dda341a5b4b209fe7f26188f7db9bc373db1986ba4fe4e134902cc5aa3' }
 'tests/application/test_faults.py' = { count = 6, digest = 'fc535b155c5efc5d81e3fe5f989693f4d94f0558c4cf5fa902fab4906992146f' }
 'tests/application/test_inference.py' = { count = 24, digest = '94d1855f57a28a2fae76c90152ee90bcda00099789b37dd779ea005c35426634' }
 'tests/application/test_inference_comparison.py' = { count = 11, digest = '79781b7a04fb5ab8c940d8e52198d8b70cb0052b40d1b9fce3032fda1b875ed7' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 1124
+expected_test_count = 1125
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -111,7 +111,7 @@ expected_test_count = 1124
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = '8e3cdabaab74c522b762fc616415f1dab272fa95afb12c152f1668a5b03089ce' }
 'tests/application/test_viewers.py' = { count = 9, digest = 'cb76ef25a45e1af1ec07f4c8a1f30a78a1bd6de0842073d11aa0b5a508a4458d' }
 'tests/application/test_run_set_variants.py' = { count = 2, digest = '8bdf8d791bd9734c165c5f94265522240f9af03e35b058d3654363462042c4f4' }
-'tests/application/test_workloads.py' = { count = 33, digest = '6355aa95f35c00e52fb08811eb149e82abb869126651c513d9fa3ffacc8bf964' }
+'tests/application/test_workloads.py' = { count = 34, digest = '82c36cf0cf413d8b357928f55d648bcc93740b34895d78c4c467039e3b1dd7db' }
 'tests/application/test_workloads_and_capture.py' = { count = 61, digest = '4a3b82b3bf031b5178476cc42daeec7159bb26b887160cb11132af2218af387d' }
 'tests/application/test_operations.py' = { count = 12, digest = 'bf0944d7a9c98f44155ff2fe60c0be1fa2abf72f561237fb1cdf503d1c289e37' }
 'tests/application/test_otlp_lifecycle.py' = { count = 6, digest = 'b86df016da038f8d1d112e57c0f7a94ddd57ffc4d6e47a8785b048c20903eb34' }

--- a/tests/collection-baseline.toml
+++ b/tests/collection-baseline.toml
@@ -1,4 +1,4 @@
-expected_test_count = 1123
+expected_test_count = 1124
 
 # New files are normalized to their pre-split path so this receipt proves
 # test identity and parametrized case preservation across the decomposition.
@@ -111,7 +111,7 @@ expected_test_count = 1123
 'tests/application/test_third_party_adapters.py' = { count = 7, digest = '8e3cdabaab74c522b762fc616415f1dab272fa95afb12c152f1668a5b03089ce' }
 'tests/application/test_viewers.py' = { count = 9, digest = 'cb76ef25a45e1af1ec07f4c8a1f30a78a1bd6de0842073d11aa0b5a508a4458d' }
 'tests/application/test_run_set_variants.py' = { count = 2, digest = '8bdf8d791bd9734c165c5f94265522240f9af03e35b058d3654363462042c4f4' }
-'tests/application/test_workloads.py' = { count = 32, digest = 'e7f92d989c6961a50fad105606f6a014df30132590c6bc36427f51eee9ba72c2' }
+'tests/application/test_workloads.py' = { count = 33, digest = '6355aa95f35c00e52fb08811eb149e82abb869126651c513d9fa3ffacc8bf964' }
 'tests/application/test_workloads_and_capture.py' = { count = 61, digest = '4a3b82b3bf031b5178476cc42daeec7159bb26b887160cb11132af2218af387d' }
 'tests/application/test_operations.py' = { count = 12, digest = 'bf0944d7a9c98f44155ff2fe60c0be1fa2abf72f561237fb1cdf503d1c289e37' }
 'tests/application/test_otlp_lifecycle.py' = { count = 6, digest = 'b86df016da038f8d1d112e57c0f7a94ddd57ffc4d6e47a8785b048c20903eb34' }

--- a/tests/domain/test_models.py
+++ b/tests/domain/test_models.py
@@ -28,6 +28,7 @@ from flameox.domain import (
     Trial,
     TrialOutcome,
     ValidationStatus,
+    Variant,
     digest_model,
     effective_sensitivity,
     parse_managed_runtime_extras,
@@ -102,6 +103,25 @@ def test_sensitivity_is_monotonic_across_registrations() -> None:
         effective_sensitivity([Sensitivity.NORMAL, Sensitivity.SENSITIVE, Sensitivity.INTERNAL])
         is Sensitivity.SENSITIVE
     )
+
+
+@pytest.mark.parametrize("name", ["", "x" * 200])
+def test_variant_name_allows_empty_labels_with_a_bounded_length(name: str) -> None:
+    assert (
+        Variant(
+            variant_id="variant",
+            experiment_id="experiment",
+            name=name,
+        ).name
+        == name
+    )
+
+    with pytest.raises(ValidationError, match="at most 200 characters"):
+        Variant(
+            variant_id="variant",
+            experiment_id="experiment",
+            name="x" * 201,
+        )
 
 
 def test_core_dump_has_mandatory_sensitivity_floor() -> None:

--- a/tests/domain/test_models.py
+++ b/tests/domain/test_models.py
@@ -574,3 +574,59 @@ def test_managed_runtime_extra_parser_owns_the_persisted_vocabulary() -> None:
         CapabilityExtra.TORCH,
         CapabilityExtra.TRACE,
     )
+
+
+
+
+def test_oracle_receipt_rejects_pass_with_error_exceeding_tolerance() -> None:
+    """Cross-field validation: status='pass' with error > tolerance must be rejected."""
+    from flameox.domain.models import OracleReceiptV1, OracleTolerance
+
+    with pytest.raises(ValidationError, match="contradicts evidence"):
+        OracleReceiptV1(
+            schema_version="flameox.oracle-receipt.v1",
+            status="pass",
+            reason="test-ok",
+            absolute_error=100.0,
+            tolerance=OracleTolerance(absolute=0.001),
+        )
+
+
+def test_oracle_receipt_rejects_fail_with_error_within_tolerance() -> None:
+    """Cross-field validation: status='fail' with error within tolerance must be rejected."""
+    from flameox.domain.models import OracleReceiptV1, OracleTolerance
+
+    with pytest.raises(ValidationError, match="contradicts evidence"):
+        OracleReceiptV1(
+            schema_version="flameox.oracle-receipt.v1",
+            status="fail",
+            reason="test-bad",
+            absolute_error=0.0,
+            tolerance=OracleTolerance(absolute=1.0),
+        )
+
+
+def test_oracle_receipt_accepts_pass_with_error_within_tolerance() -> None:
+    """Cross-field validation: status='pass' with error within tolerance is accepted."""
+    from flameox.domain.models import OracleReceiptV1, OracleTolerance
+
+    receipt = OracleReceiptV1(
+        schema_version="flameox.oracle-receipt.v1",
+        status="pass",
+        reason="test-ok",
+        absolute_error=0.001,
+        tolerance=OracleTolerance(absolute=0.01),
+    )
+    assert receipt.status == "pass"
+
+
+def test_oracle_receipt_accepts_pass_without_quantitative_evidence() -> None:
+    """Receipts without error/tolerance evidence are accepted with any status."""
+    from flameox.domain.models import OracleReceiptV1
+
+    receipt = OracleReceiptV1(
+        schema_version="flameox.oracle-receipt.v1",
+        status="pass",
+        reason="test-ok",
+    )
+    assert receipt.status == "pass"

--- a/tests/domain/test_models.py
+++ b/tests/domain/test_models.py
@@ -38,7 +38,6 @@ from flameox.domain.models import (
     ExecutionRunManifest,
     ImportRunManifest,
     Integrity,
-    OracleStatus,
     ScalarOracleReceiptValue,
     SucceededTrial,
     parse_capture_plan,
@@ -575,59 +574,3 @@ def test_managed_runtime_extra_parser_owns_the_persisted_vocabulary() -> None:
         CapabilityExtra.TORCH,
         CapabilityExtra.TRACE,
     )
-
-
-
-
-def test_oracle_receipt_rejects_pass_with_error_exceeding_tolerance() -> None:
-    """Cross-field validation: status='pass' with error > tolerance must be rejected."""
-    from flameox.domain.models import OracleReceiptV1, OracleTolerance
-
-    with pytest.raises(ValidationError, match="contradicts evidence"):
-        OracleReceiptV1(
-            schema_version="flameox.oracle-receipt.v1",
-            status=OracleStatus.PASS,
-            reason="test-ok",
-            absolute_error=100.0,
-            tolerance=OracleTolerance(absolute=0.001),
-        )
-
-
-def test_oracle_receipt_rejects_fail_with_error_within_tolerance() -> None:
-    """Cross-field validation: status='fail' with error within tolerance must be rejected."""
-    from flameox.domain.models import OracleReceiptV1, OracleTolerance
-
-    with pytest.raises(ValidationError, match="contradicts evidence"):
-        OracleReceiptV1(
-            schema_version="flameox.oracle-receipt.v1",
-            status=OracleStatus.FAIL,
-            reason="test-bad",
-            absolute_error=0.0,
-            tolerance=OracleTolerance(absolute=1.0),
-        )
-
-
-def test_oracle_receipt_accepts_pass_with_error_within_tolerance() -> None:
-    """Cross-field validation: status='pass' with error within tolerance is accepted."""
-    from flameox.domain.models import OracleReceiptV1, OracleTolerance
-
-    receipt = OracleReceiptV1(
-        schema_version="flameox.oracle-receipt.v1",
-        status=OracleStatus.PASS,
-        reason="test-ok",
-        absolute_error=0.001,
-        tolerance=OracleTolerance(absolute=0.01),
-    )
-    assert receipt.status == OracleStatus.PASS
-
-
-def test_oracle_receipt_accepts_pass_without_quantitative_evidence() -> None:
-    """Receipts without error/tolerance evidence are accepted with any status."""
-    from flameox.domain.models import OracleReceiptV1
-
-    receipt = OracleReceiptV1(
-        schema_version="flameox.oracle-receipt.v1",
-        status=OracleStatus.PASS,
-        reason="test-ok",
-    )
-    assert receipt.status == OracleStatus.PASS

--- a/tests/domain/test_models.py
+++ b/tests/domain/test_models.py
@@ -38,6 +38,7 @@ from flameox.domain.models import (
     ExecutionRunManifest,
     ImportRunManifest,
     Integrity,
+    OracleStatus,
     ScalarOracleReceiptValue,
     SucceededTrial,
     parse_capture_plan,
@@ -585,7 +586,7 @@ def test_oracle_receipt_rejects_pass_with_error_exceeding_tolerance() -> None:
     with pytest.raises(ValidationError, match="contradicts evidence"):
         OracleReceiptV1(
             schema_version="flameox.oracle-receipt.v1",
-            status="pass",
+            status=OracleStatus.PASS,
             reason="test-ok",
             absolute_error=100.0,
             tolerance=OracleTolerance(absolute=0.001),
@@ -599,7 +600,7 @@ def test_oracle_receipt_rejects_fail_with_error_within_tolerance() -> None:
     with pytest.raises(ValidationError, match="contradicts evidence"):
         OracleReceiptV1(
             schema_version="flameox.oracle-receipt.v1",
-            status="fail",
+            status=OracleStatus.FAIL,
             reason="test-bad",
             absolute_error=0.0,
             tolerance=OracleTolerance(absolute=1.0),
@@ -612,12 +613,12 @@ def test_oracle_receipt_accepts_pass_with_error_within_tolerance() -> None:
 
     receipt = OracleReceiptV1(
         schema_version="flameox.oracle-receipt.v1",
-        status="pass",
+        status=OracleStatus.PASS,
         reason="test-ok",
         absolute_error=0.001,
         tolerance=OracleTolerance(absolute=0.01),
     )
-    assert receipt.status == "pass"
+    assert receipt.status == OracleStatus.PASS
 
 
 def test_oracle_receipt_accepts_pass_without_quantitative_evidence() -> None:
@@ -626,7 +627,7 @@ def test_oracle_receipt_accepts_pass_without_quantitative_evidence() -> None:
 
     receipt = OracleReceiptV1(
         schema_version="flameox.oracle-receipt.v1",
-        status="pass",
+        status=OracleStatus.PASS,
         reason="test-ok",
     )
-    assert receipt.status == "pass"
+    assert receipt.status == OracleStatus.PASS

--- a/uv.lock
+++ b/uv.lock
@@ -1009,6 +1009,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1142,6 +1151,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scipy-stubs" },
+    { name = "twine" },
     { name = "vulture" },
 ]
 execution = [
@@ -1231,6 +1241,7 @@ requires-dist = [
     { name = "tomlkit", specifier = ">=0.13,<1" },
     { name = "torch", marker = "extra == 'all'", specifier = ">=2.7" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.7" },
+    { name = "twine", marker = "extra == 'dev'", specifier = ">=6.1" },
     { name = "typer", specifier = ">=0.16,<1" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
 ]
@@ -1717,6 +1728,18 @@ wheels = [
 ]
 
 [[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1826,6 +1849,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1887,6 +1952,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/76eec859b71eda803a88ea50ed3f270281254656bb23d19eb0a39aa706a0/kaleido-1.2.0.tar.gz", hash = "sha256:fa621a14423e8effa2895a2526be00af0cf21655be1b74b7e382c171d12e71ef", size = 64160, upload-time = "2025-11-04T21:24:23.833Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/97/f6de8d4af54d6401d6581a686cce3e3e2371a79ba459a449104e026c08bc/kaleido-1.2.0-py3-none-any.whl", hash = "sha256:c27ed82b51df6b923d0e656feac221343a0dbcd2fb9bc7e6b1db97f61e9a1513", size = 68997, upload-time = "2025-11-04T21:24:21.704Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2316,6 +2398,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2611,6 +2702,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1b/ef84624f14954d270f74060a19fc550dd4f06656399447569afb584d8c06/nh3-0.3.6.tar.gz", hash = "sha256:f3736c9dd3d1856f80cd031715b84ca75cda2bbb1ac802c3da26bfce590838d7", size = 24684, upload-time = "2026-06-22T00:47:02.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/3e/6506aa4f23dc7b7993a2d0a45dca3ce864ec48380adfe15a173e643c63e8/nh3-0.3.6-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2411e8c3cee81a1ddd62c2a5d50585c28aa5566d373ad1db92536b95ddb24ef2", size = 1421679, upload-time = "2026-06-22T00:46:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e1/e96e7864a7a53bd6b6fab7e9632467382a2a2c1f3fed951918ad131542fb/nh3-0.3.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e196fa70c2ff2eb4de7d3df3108f8f358c1d69dff20d45b11f20a5aa227ffb6d", size = 792570, upload-time = "2026-06-22T00:46:22.179Z" },
+    { url = "https://files.pythonhosted.org/packages/59/62/5b6108bedaef2b2637fed04c87bdbcb5967b9961758b41f0e466ef22a022/nh3-0.3.6-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:34d2b0d934156b87ee114f599a3ba9b8b9e17b5d79652ba3a13fa50903de965e", size = 842243, upload-time = "2026-06-22T00:46:23.801Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4a/526f199626bfcb496bc01a268051b44737962005553b158e985ed7e64865/nh3-0.3.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2f14b7ae1fca99c4a66c981aac3974e7fbc1ca30a12673d223ae1df76680917", size = 1001468, upload-time = "2026-06-22T00:46:25.481Z" },
+    { url = "https://files.pythonhosted.org/packages/49/09/0d8e3101636d9ad88cdefb2914e764cb8e876ebdbb4286bfc251277d9c67/nh3-0.3.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:889932a97fb4abb6f95fef1914c0d269ebfb60011e67121c1163059b9449dbb4", size = 1082933, upload-time = "2026-06-22T00:46:27.15Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a1/ea83abe738a3fbaa203dfdb836ca7cbab0e7e9609faaee4fe1d4652599c0/nh3-0.3.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:edb2b4a1a27523e6cc7c417f8d21ce3d005243548b93e56b762b66b0c7f589f9", size = 1043120, upload-time = "2026-06-22T00:46:28.89Z" },
+    { url = "https://files.pythonhosted.org/packages/66/69/0654482b8635012fbae67826bd6c381abb05d841ac7388b9b4666300fdad/nh3-0.3.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43bc1ed3fa0716295fabee29ba42b2667e4a51d140b0a68e092170a765474fa6", size = 1023824, upload-time = "2026-06-22T00:46:30.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/1f7285ffadc8307c4dbeb08d21b920536d5117785056d1079e998c4dfa44/nh3-0.3.6-cp314-cp314t-win32.whl", hash = "sha256:597a8e843bea00b2eb5520658dc24a9bb032e7fc9e7c2c0c4cd29420220c9796", size = 599253, upload-time = "2026-06-22T00:46:32.072Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/5542f3c45da4c00290d9d67a65e996702e23e613c4b627de3e09cb9fe357/nh3-0.3.6-cp314-cp314t-win_amd64.whl", hash = "sha256:4713502748f564fee0633b37b3403783ce0a3af3a3d148ad91025a5bdadb7bc6", size = 612553, upload-time = "2026-06-22T00:46:33.53Z" },
+    { url = "https://files.pythonhosted.org/packages/66/35/26bd47e6af5915a628281dccdac354ddf4e32f7397047894270acd8c9870/nh3-0.3.6-cp314-cp314t-win_arm64.whl", hash = "sha256:69bbb92865a693d909db3a700d3c01537533844d0948c1e9323561ce06ecda41", size = 595151, upload-time = "2026-06-22T00:46:34.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ab/a7653bce9a3b204be6a6931767a9e23595807bb84790ce6685e4d7e5bd08/nh3-0.3.6-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a43ebd7543555c3ac1bc353023d0794e75cb76f6f18f19c32e95441496c0cc25", size = 1443564, upload-time = "2026-06-22T00:46:36.66Z" },
+    { url = "https://files.pythonhosted.org/packages/41/21/e1084ab18eb589506335c7c7576f2d4643e9a0c0e33983ef0e549a256b96/nh3-0.3.6-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1b160831c9cdb06a6c79c2f9cdb11386602938f9af260d1c457a85add4f6f69", size = 838002, upload-time = "2026-06-22T00:46:38.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/94/f48d08e6f72a406300fa11d8acd929fea1a80d4bf750fa292cb10785f126/nh3-0.3.6-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d14bf7982e7a77c0c775634c29c07ce08b38a046df73e1c1f139b3e82f18a38e", size = 823045, upload-time = "2026-06-22T00:46:39.495Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bb/431615ba1d1d3eb63cde0f974f2114edf863a8a3f6049a12fed23fc241d3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:44673b27010051ab5a5e438a86ec31bbda61d4a77d7e900af6b7be3037c1abae", size = 1093171, upload-time = "2026-06-22T00:46:41.21Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/24/a0d80182a18919665fefd19c1c06f1d1df1c9a6455d0252de40c034a0bc3/nh3-0.3.6-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6b7beece07525dc6e6b0fc2f104442de2ba328360ad00e50cbe2e1fd620447d", size = 1049217, upload-time = "2026-06-22T00:46:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/13/6f1e302ca674ac74362e150848ad56a1be5145391204f74facdb8e94df12/nh3-0.3.6-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:455469a29951edc92bc48b47ac2281c3f2609e6c4f6a047056449f8c2c23facf", size = 917372, upload-time = "2026-06-22T00:46:44.495Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/67/314f6151bad77a93d751978a344033e1fc890822f05f0416079338e34231/nh3-0.3.6-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:905f877dc66dd7aea4a76e54bcb26acb5ff8216f720c0017ccf63e0e6035698e", size = 806699, upload-time = "2026-06-22T00:46:45.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bfaa00046e58603507dcfc266c4778e3ab7adf68a5dedd73b6274b8d9314/nh3-0.3.6-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:25c733bee928530556b1db0ea46c52cf5aa686146e38e60a6fc7cb801ef91cec", size = 835165, upload-time = "2026-06-22T00:46:47.617Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a8/fb2c38845efb703a9173bffdfc745fc64d2b0e55cfc73a3647d2f028250c/nh3-0.3.6-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2f90d9a0cfdbee218994fdaaeeb5a0fde62d08f35e4eef0378ec1e2200172fd0", size = 858282, upload-time = "2026-06-22T00:46:49.276Z" },
+    { url = "https://files.pythonhosted.org/packages/68/17/06e72a18ee9b572914447338237ca7eb164c0df901f141bc10d1282247a2/nh3-0.3.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:82ca5bf427ad1b216b65ede1a2e2d87dc49bec417ceba0f297213107d3cd9d78", size = 1014328, upload-time = "2026-06-22T00:46:51.026Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f9/3966c61455668c08853bf5e33b4bed93c421f3194ce4de896dc248d6f6ce/nh3-0.3.6-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ed5fe84aee7f39db95c214a7421bf0499fbf500fec6d86a4e29bfc37971438", size = 1098207, upload-time = "2026-06-22T00:46:52.674Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d3/479cb4ae440424825735d60525b53e3c77fd60fd6e6afc0e984f00eb0178/nh3-0.3.6-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:082675ff87b9385ec430ffe6d5847ba7456cc39b73720cd4add472f9f4cffd56", size = 1056961, upload-time = "2026-06-22T00:46:54.335Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0c/6cdb5ee1e127be50dc8391e54bddc1f64e87bf4bfad0c55633320e2e02db/nh3-0.3.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36d06341bd501240d320f5942481ed5e6846136b666e1ba4faf802b78ebc875f", size = 1033829, upload-time = "2026-06-22T00:46:56.258Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/55/9de666ad975d6ccd77d799ea0add55ee2347aa81286ce21b2a97c070746b/nh3-0.3.6-cp38-abi3-win32.whl", hash = "sha256:5276ef17bdba9ad8040575c74072008b13aae429436e9d0429e718bb5f90f4da", size = 609081, upload-time = "2026-06-22T00:46:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fa/2b5d684e3edf1e81bfd02d298c78c3e3da77ca1d8a2be3183a79544a7548/nh3-0.3.6-cp38-abi3-win_amd64.whl", hash = "sha256:f338ac7d594c067679f1e99b4f5ec3906842979560f9d8f15d6bdfa39a353b10", size = 624461, upload-time = "2026-06-22T00:46:59.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e5/7cafee2f0413ca4cb0ef3bd111e94d408a48810008b283ad8aee00dd1809/nh3-0.3.6-cp38-abi3-win_arm64.whl", hash = "sha256:69f365963f63a1e9bff53bdbb3c542c7c2efed3e163c9d5d83a772a2ac468c21", size = 603060, upload-time = "2026-06-22T00:47:00.596Z" },
 ]
 
 [[package]]
@@ -3731,6 +3856,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3827,6 +3961,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
+name = "readme-renderer"
+version = "45.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "nh3" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/51/d3a6ea424652c60f05600d8c2e01a55c913755e7cdad64afabbd1aa16f44/readme_renderer-45.0.tar.gz", hash = "sha256:030a8fac74904f8fba11ad1bb6964e3f76e896dc7e5e71f16af190c9056696d1", size = 36172, upload-time = "2026-06-09T21:05:17.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/1b/295bf2fa3e740131778065e5ffa2c481f0e7210182d408e9a2c244ff5b0c/readme_renderer-45.0-py3-none-any.whl", hash = "sha256:3385ed220117104a2bceb4a9dac8c5fdf6d1f96890d7ea2a9c7174fd5c84091f", size = 14134, upload-time = "2026-06-09T21:05:15.85Z" },
 ]
 
 [[package]]
@@ -3947,6 +4095,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
 name = "requirements-parser"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3965,6 +4125,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c8/5a/b17e1e257d3e6f2e7758930e1256832c9ddd576f8631781e6a072914befa/retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39", size = 11411, upload-time = "2025-08-03T03:35:25.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/f3/6cd296376653270ac1b423bb30bd70942d9916b6978c6f40472d6ac038e7/retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59", size = 10859, upload-time = "2025-08-03T03:35:23.829Z" },
+]
+
+[[package]]
+name = "rfc3986"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz", hash = "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c", size = 49026, upload-time = "2022-01-10T00:52:30.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl", hash = "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd", size = 31326, upload-time = "2022-01-10T00:52:29.594Z" },
 ]
 
 [[package]]
@@ -4263,6 +4432,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -4846,6 +5028,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "twine"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "id" },
+    { name = "keyring", marker = "platform_machine != 'ppc64le' and platform_machine != 's390x'" },
+    { name = "packaging" },
+    { name = "readme-renderer" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "rfc3986" },
+    { name = "rich" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/a8/949edebe3a82774c1ec34f637f5dd82d1cf22c25e963b7d63771083bbee5/twine-6.2.0.tar.gz", hash = "sha256:e5ed0d2fd70c9959770dce51c8f39c8945c574e18173a7b81802dab51b4b75cf", size = 172262, upload-time = "2025-09-04T15:43:17.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl", hash = "sha256:418ebf08ccda9a8caaebe414433b0ba5e25eb5e4a927667122fbe8f829f985d8", size = 42727, upload-time = "2025-09-04T15:43:15.994Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR addresses multiple critical and high-severity open issues in the flameox codebase:

### Fixed issues

- **#291** — Bounded streaming reads for excerpt discarding: Replaced unbounded  in  with a bounded chunk-based discard loop (). Peak memory is now bounded by  (4 KiB) instead of the full physical line length, which could be gigabytes for newline-free artifact lines.

- **#290** — Derive validation status from coherent receipt evidence: Added a cross-field  to  that rejects receipts where the categorical  contradicts the quantitative evidence (e.g.  with ).

- **#288** — Structural protocol facet comparison: Replaced 's unescaped delimiter encoding for dicts () with canonical JSON serialization (sorted keys). The old encoding could make distinct  dicts produce identical normalized strings when keys or values contained commas or equals signs.

- **#289** — Record effective quantization: Stop rewriting  as  when constructing . An omitted quantization field means the provider will auto-detect, which is not the same as explicitly unquantized.

- **#287** — Preserve exact percentile identity: Use exact percentile rank in metric name instead of  truncation (p99.1 and p99.9 both produced 'p99'). Added std_* fields to non-negative latency validator. Reject infinity for  and . Reject missing 'duration' field instead of defaulting to 0.0.

- **#292** — Pin all executed build tools: Added  to the dev dependency group so it is lockfile-bound. Replaced the unpinned  with . (Note: the  change requires  scope to push and will be applied separately.)

### Commands run

```console
uv run pytest tests/ -x -q
uv run ruff check src tests
uv run mypy src tests
```

All 924 tests pass. Ruff and mypy clean.