### PR TITLE
refactor(adapters): share bounded filter constraint

### DIFF
--- a/src/flameox/adapters/bounded_types.py
+++ b/src/flameox/adapters/bounded_types.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+BoundedFilter = Annotated[
+    str,
+    StringConstraints(min_length=1, max_length=500, pattern=r"^[^\x00\r\n]+$"),
+]

--- a/src/flameox/adapters/nsight_compute_options.py
+++ b/src/flameox/adapters/nsight_compute_options.py
@@ -4,12 +4,8 @@ from typing import Annotated, Any, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
+from flameox.adapters.bounded_types import BoundedFilter
 from flameox.models import ContractModel
-
-_BoundedFilter = Annotated[
-    str,
-    StringConstraints(min_length=1, max_length=500, pattern=r"^[^\x00\r\n]+$"),
-]
 
 
 class NsightComputeOptions(ContractModel):
@@ -39,7 +35,7 @@ class NsightComputeOptions(ContractModel):
         ]
         | None
     ) = None
-    kernel_name: _BoundedFilter | None = None
+    kernel_name: BoundedFilter | None = None
     launch_skip: Annotated[int, Field(ge=0, le=1_000_000)] = 0
     launch_count: Annotated[int, Field(ge=1, le=1_000_000)] = 1
     replay_mode: Literal["kernel", "application", "range", "app-range"] = "kernel"

--- a/src/flameox/adapters/options.py
+++ b/src/flameox/adapters/options.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, Literal, cast
 
 from pydantic import Field, JsonValue, StringConstraints, field_validator, model_validator
 
+from flameox.adapters.bounded_types import BoundedFilter
 from flameox.adapters.memray_options import MemrayCaptureOptions, memray_capture_options
 from flameox.adapters.nsight_compute_options import NsightComputeOptions
 from flameox.adapters.torch_benchmark import TorchBenchmarkOptions, torch_benchmark_options
@@ -16,10 +17,6 @@ from flameox.domain import CaptureScope, DomainError, ErrorCode, RunSemantics, S
 from flameox.domain.compiler_build import CompilerTarget
 from flameox.models import ContractModel
 
-BoundedFilter = Annotated[
-    str,
-    StringConstraints(min_length=1, max_length=500, pattern=r"^[^\x00\r\n]+$"),
-]
 _MAX_SUPPRESSION_BYTES = 1024 * 1024
 
 

--- a/tests/adapters/test_nsight_compute_options.py
+++ b/tests/adapters/test_nsight_compute_options.py
@@ -4,13 +4,23 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from pydantic import ValidationError
 
 from flameox.adapters.builtins import build_capture_invocation
 from flameox.adapters.nsight_compute import find_ncu_report_interface
-from flameox.adapters.options import bind_adapter_options
+from flameox.adapters.nsight_compute_options import NsightComputeOptions
+from flameox.adapters.options import ComputeSanitizerCaptureOptions, bind_adapter_options
 from flameox.domain import ArtifactKind, DomainError, ErrorCode
 
 pytestmark = pytest.mark.unit
+
+
+def test_bounded_filter_constraints_are_shared() -> None:
+    for options in (ComputeSanitizerCaptureOptions, NsightComputeOptions):
+        with pytest.raises(ValidationError):
+            options(kernel_name="")
+        with pytest.raises(ValidationError):
+            options(kernel_name="line\nbreak")
 
 
 def test_strict_options_build_only_documented_bounded_arguments(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #385.

`BoundedFilter` was defined twice with identical Pydantic constraints, allowing the two adapter options to drift independently. This change moves the type alias into a shared adapter module and reuses it from both option models.

## Implementation

- Added the shared `flameox.adapters.bounded_types.BoundedFilter` alias.
- Updated the general adapter options and Nsight Compute options to import the shared alias.
- Added regression coverage for the shared empty and newline validation boundaries.

## Compatibility and impact

This is an internal refactor with no API or serialized-schema changes. Both consumers retain the existing length and character constraints.

## Validation

- `uv sync --extra dev` — passed. The repository's broader optional install command was not run because `memray` does not support Windows; it fails during build on this host.
- `python -m pytest tests/adapters/test_nsight_compute_options.py -q --basetemp=.pytest-tmp-flameox` — 3 passed.
- `ruff format --check src tests tools` — passed.
- `ruff check src tests tools` — passed.
- `mypy src tests tools` — passed.
- `python -m pytest -q --basetemp=.pytest-tmp-flameox` — collection is unsupported on Windows because `tests/cli/test_setup_process.py` imports POSIX-only `termios`; 272 tests were deselected before the collection error.

The change does not affect runtime services or external integrations.
