### PR TITLE
feat(runtime): unify bounded capture contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ coverage, truncation, limitations, and optional immutable preservation.
 
 ## MCP interface
 
-The server exposes exactly six tools:
+The server exposes exactly seven tools:
 
 - `discover_capabilities`
 - `inspect_capabilities`
 - `analyze`
+- `preflight_capture`
 - `capture_and_analyze`
 - `preserve_evidence`
 - `query_evidence`

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -15,6 +15,10 @@ Each capability registry entry owns:
 - capture and analysis handlers;
 - bounded examples, limits, overhead, and limitations.
 
+One immutable capture-provider contract owns each provider's argument model, declared artifact
+roles and formats, and discovery description. Inspection, pre-execution compatibility checks, and
+capture argument validation consume that same contract so their format claims cannot drift.
+
 Discovery probes packages, executables, platform, supported version, permission,
 and required external resources without mutating the host. Missing dependencies
 are successful availability results with remediation outside Flameox. Invoking
@@ -29,7 +33,7 @@ Artifact analysis and typed capture are separate contracts:
 
 | Evidence family | Explicit artifact analysis | Typed capture provider |
 | --- | --- | --- |
-| CPU profiles | Node/V8, py-spy Speedscope, perf collapsed stacks, perf data | `node-cpu-profile`, `py-spy`, `perf` |
+| CPU profiles | Node/V8, cProfile pstats, py-spy Speedscope, perf collapsed stacks, perf data | `node-cpu-profile`, `py-spy`, `perf` |
 | Memory profiles | Memray | `memray` |
 | Benchmarks | pyperf, benchmark samples, PyTorch samples, NVBench | `pyperf`, `benchmark-samples`, `nvbench` |
 | Execution traces | Perfetto/Chrome, PyTorch, OTLP, ROCprof PFTrace, xctrace, Nsight Systems | `torch-profiler`, `rocprofv3`, `xctrace`, `nsight-systems` |
@@ -44,6 +48,10 @@ the format is unsupported. The offline inference readers omit prompts,
 generations, error text, endpoints, tools, payloads, and prefix-hash values.
 Pytest capture runs an explicit `python -m pytest` target with a request-bound,
 bounded event plugin.
+
+`failures.summary` scans the complete bounded pytest event artifact for aggregate outcomes, but its
+table projects only failed, errored, interrupted, and unexecuted identities. Passing, skipped, and
+collection events cannot consume the diagnostic row budget.
 
 Support is honest rather than substitutive. A missing Trace Processor does not
 turn a Perfetto request into a JSON preview; a missing `ncu` does not become an
@@ -93,3 +101,8 @@ with Flameox, such as py-spy, execute from the managed tool environment rather
 than ambient request `PATH`. In-process collectors, including coverage.py and
 Memray, must be installed in the declared workload interpreter; capture probes
 that interpreter before execution and never substitutes Flameox's interpreter.
+
+Pyperf command capture preserves multiline typed argv through a metadata-safe launcher because
+pyperf rejects newline characters in its display metadata. The launcher executes the original argv
+without shell parsing, but its startup is included in each command measurement; exact Flameox
+capture provenance remains authoritative for the requested argv.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -5,13 +5,14 @@ provider behavior, or lifecycle state.
 
 ## MCP catalog
 
-The catalog contains exactly six tools:
+The catalog contains exactly seven tools:
 
 | Tool | Behavior |
 | --- | --- |
 | `discover_capabilities` | Rank by intent and bounded source sniffing; report provider state and external remediation. |
 | `inspect_capabilities` | Inspect 1-16 IDs with source modes, strict argument schema, examples, limits, and capture semantics. |
 | `analyze` | Analyze 1-32 explicit path/evidence sources and return bounded inline evidence plus a session `analysis_id`. |
+| `preflight_capture` | Resolve and validate one capture request without executing it or creating plan authority. |
 | `capture_and_analyze` | Run typed argv through the broker in single or bounded experiment mode, then analyze outputs. |
 | `preserve_evidence` | Idempotently publish one session analysis and return an evidence reference plus `ResourceLink`. |
 | `query_evidence` | Search a deterministic immutable manifest inventory with bounded pagination. |
@@ -27,9 +28,10 @@ canonical manifest with its own versioned media type. It omits argv, environment
 directories, and host paths. The local CLI `evidence show` command is the explicit full-provenance
 view. A missing resource is a protocol error.
 
-Tools do not advertise output schemas. Success uses structured content directly,
-without an `ok/result/error` envelope. Tool failures set `isError=true` and carry
-a stable code, message, and details.
+Every tool advertises a compact output schema for its stable result envelope. Provider-specific
+metrics and rows remain open JSON values. Success uses structured content directly, without an
+`ok/result/error` wrapper. Tool failures set `isError=true` and carry a stable code, message, and
+details; both success and failure shapes validate against the advertised schema.
 
 ## Sources and limits
 
@@ -65,6 +67,12 @@ bounded environment overrides after experiment-case overrides are merged,
 provider ID, provider capture arguments, analysis arguments, and request limits.
 Shell command strings are not accepted.
 
+Provider output formats are compared with the requested capability before scratch creation or
+execution. Statically incompatible pairs fail with the declared formats and compatible capture
+providers. `preflight_capture` shares this validation, resolves executable identity and policy,
+and returns ephemeral-path argv templates and expected artifacts without creating support files or
+running probes. Its digest is informational; capture always resolves and validates again.
+
 Callers may request preservation as part of capture. Once native collection succeeds, requested
 preservation publishes the native artifacts even if immediate analysis fails; the result then
 reports separate capture execution state and a typed `analysis_failure`. An analysis failure is
@@ -95,6 +103,7 @@ flameox setup
 flameox mcp serve|inspect
 flameox capabilities discover|inspect
 flameox analyze [--continuation TOKEN] [--preserve]
+flameox preflight --provider ID --capability ID -- <argv...>
 flameox capture [--preserve] -- <argv...>
 flameox evidence query|show
 ```

--- a/docs/runtime-safety.md
+++ b/docs/runtime-safety.md
@@ -28,6 +28,10 @@ Session scratch has byte and file ceilings. A capture is rejected before its
 declared output budget could exhaust remaining capacity. Unpreserved files are
 never silently evicted and disappear at shutdown.
 
+Capture preflight is read-only and request-local. It may resolve and hash executable files, but it
+does not execute workload or oracle processes, run workload-interpreter package probes, create
+scratch children, publish evidence, or grant later execution authority.
+
 ## Input and output bounds
 
 - discovery sniffs at most 16 sources and reads only bounded headers;
@@ -41,6 +45,10 @@ never silently evicted and disappear at shutdown.
 
 Invalid digests fail before decoding. Decode and format failures never become
 empty successful evidence.
+
+Capture execution results identify the cancellation cause, configured threshold, available
+observation, unit, and a bounded recovery hint when the broker terminates a process for timeout,
+output, memory, writable-growth, or storage-reserve policy.
 
 ## Repository integrity
 

--- a/docs/storage-and-evidence.md
+++ b/docs/storage-and-evidence.md
@@ -34,6 +34,11 @@ manifest roles bind their relative paths. An `EvidenceSource` rebuilds such a
 bundle only in session scratch, so NVBench and similar directory formats remain
 reanalyzable without introducing a mutable repository checkout.
 
+When an analysis composes independently preserved bundles, their source-local artifact roles may
+legitimately collide. Publication assigns deterministic `source-NNNN/` role namespaces only to
+colliding artifacts; the analysis inputs retain each original bundle role and evidence identity as
+provenance.
+
 Evidence identity is SHA-256 of the RFC 8785 canonical manifest body. The body
 contains capability/provider identity, input digests, effective capture and
 analysis requests, the evidence-episode timestamp, data-file digests, coverage,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,8 +19,8 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly six MCP tools, one resource template, no concrete
-resource list, no output schemas, truthful annotations, a catalog below 128 KiB,
+Contract tests assert exactly seven MCP tools, one resource template, no concrete
+resource list, compact output schemas, truthful annotations, a catalog below 40 KiB,
 and direct structured success content without a universal wrapper.
 
 Runtime tests cover bounded streaming analysis, digest-bound continuation,

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -234,6 +234,46 @@ def capture(
         runtime.close()
 
 
+@app.command(
+    "preflight", context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+def preflight(
+    ctx: typer.Context,
+    provider_id: Annotated[str, typer.Option("--provider")],
+    capability_id: Annotated[str, typer.Option("--capability")] = "artifact.preview",
+    cwd: Annotated[str, typer.Option("--cwd")] = ".",
+    capture_arguments: Annotated[str, typer.Option("--capture-arguments")] = "{}",
+    analysis_arguments: Annotated[str, typer.Option("--analysis-arguments")] = "{}",
+    project_root: Annotated[Path, typer.Option("--project-root")] = Path("."),
+) -> None:
+    """Resolve a typed capture request after `--` without executing it."""
+    argv = list(ctx.args)
+    if argv and argv[0] == "--":
+        argv.pop(0)
+    if not argv:
+        raise typer.BadParameter("preflight requires an argv after --")
+    runtime = _runtime(project_root)
+    try:
+        _write(
+            runtime.preflight_capture(
+                CaptureTarget(
+                    argv=argv,
+                    cwd=cwd,
+                    provider_id=provider_id,
+                    capture_arguments=_json_object(capture_arguments, option="--capture-arguments"),
+                    analysis_arguments=_json_object(
+                        analysis_arguments, option="--analysis-arguments"
+                    ),
+                ),
+                capability_id,
+            )
+        )
+    except (RuntimeFailure, ValidationError) as error:
+        _cli_failure(error)
+    finally:
+        runtime.close()
+
+
 @evidence_app.command("query")
 def evidence_query(
     capability_id: Annotated[str | None, typer.Option("--capability")] = None,

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -1,4 +1,4 @@
-"""Six-tool MCP transport for the process-lifespan Flameox runtime."""
+"""Thin MCP transport for the process-lifespan Flameox runtime."""
 
 from __future__ import annotations
 
@@ -8,12 +8,20 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from mcp_types import CallToolResult, ContentBlock, ResourceLink, TextContent, ToolAnnotations
-from pydantic import ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    GetJsonSchemaHandler,
+    JsonValue,
+    RootModel,
+    ValidationError,
+)
+from pydantic.json_schema import JsonSchemaValue
 
 from flameox import __version__
 from flameox.repository import AGENT_EVIDENCE_MEDIA_TYPE
@@ -39,6 +47,100 @@ PRESERVE = ToolAnnotations(
     idempotent_hint=True,
     open_world_hint=False,
 )
+
+
+class _Envelope(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class ToolFailureEnvelope(_Envelope):
+    code: str
+    message: str
+    details: dict[str, JsonValue]
+
+
+class CoverageEnvelope(_Envelope):
+    rows_returned: int
+    rows_observed: int
+    complete: bool
+
+
+class AnalysisEnvelope(_Envelope):
+    analysis_id: str
+    capability_id: str
+    provider: dict[str, JsonValue]
+    inputs: list[dict[str, JsonValue]]
+    blocks: list[dict[str, JsonValue]]
+    coverage: CoverageEnvelope
+    truncation: dict[str, JsonValue] | None
+    limitations: list[str]
+    continuation: str | None
+
+
+class DiscoveryEnvelope(_Envelope):
+    sniffed_sources: list[dict[str, JsonValue]]
+    capabilities: list[dict[str, JsonValue]]
+
+
+class InspectionEnvelope(_Envelope):
+    capabilities: list[dict[str, JsonValue]]
+
+
+class PreflightEnvelope(_Envelope):
+    request_sha256: str
+    authoritative: bool
+    compatibility: dict[str, JsonValue]
+    execution_count: int
+    cwd: str
+    cases: list[dict[str, JsonValue]]
+    effective_limits: dict[str, JsonValue]
+    limitations: list[str]
+
+
+class PreservationEnvelope(_Envelope):
+    evidence_id: str
+    uri: str
+    artifact_count: int
+
+
+class QueryEnvelope(_Envelope):
+    evidence: list[dict[str, JsonValue]]
+    continuation: str | None
+    inventory_digest: str
+
+
+class _ObjectOutcome(RootModel[Any]):
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: Any, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        schema = handler(core_schema)
+        schema["type"] = "object"
+        return schema
+
+
+class DiscoveryOutcome(_ObjectOutcome):
+    root: DiscoveryEnvelope | ToolFailureEnvelope
+
+
+class InspectionOutcome(_ObjectOutcome):
+    root: InspectionEnvelope | ToolFailureEnvelope
+
+
+class AnalysisOutcome(_ObjectOutcome):
+    root: AnalysisEnvelope | ToolFailureEnvelope
+
+
+class PreflightOutcome(_ObjectOutcome):
+    root: PreflightEnvelope | ToolFailureEnvelope
+
+
+class PreservationOutcome(_ObjectOutcome):
+    root: PreservationEnvelope | ToolFailureEnvelope
+
+
+class QueryOutcome(_ObjectOutcome):
+    root: QueryEnvelope | ToolFailureEnvelope
 
 
 def _success(value: dict[str, Any], *, resource: ResourceLink | None = None) -> CallToolResult:
@@ -93,18 +195,20 @@ def create_server(
         instructions=(
             "Pass explicit artifact paths or a typed direct target. Analysis and capture are "
             "session-local unless preserve_evidence is called. Flameox never installs providers, "
-            "searches parent directories, accepts shell strings, or creates durable jobs."
+            "searches parent directories, accepts shell strings, or creates durable jobs. Use "
+            "inspect_capabilities before capture; use preflight_capture when the resolved command, "
+            "bounds, artifacts, or compatibility decision needs review before execution."
         ),
         lifespan=lifespan,
     )
 
-    @server.tool(annotations=READ_ONLY, structured_output=False)
+    @server.tool(annotations=READ_ONLY, structured_output=True)
     async def discover_capabilities(
         intent: str | None = None,
         sources: list[Source] | None = None,
         include_unavailable: bool = False,
         limit: int = 10,
-    ) -> CallToolResult:
+    ) -> Annotated[CallToolResult, DiscoveryOutcome]:
         """Rank capabilities by intent and bounded source sniffing; never install providers."""
         try:
             return _success(
@@ -117,22 +221,24 @@ def create_server(
                 return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
             return _failure(error)
 
-    @server.tool(annotations=READ_ONLY, structured_output=False)
-    async def inspect_capabilities(capability_ids: list[str]) -> CallToolResult:
+    @server.tool(annotations=READ_ONLY, structured_output=True)
+    async def inspect_capabilities(
+        capability_ids: list[str],
+    ) -> Annotated[CallToolResult, InspectionOutcome]:
         """Batch-inspect 1-16 capability contracts, providers, limits, and examples."""
         try:
             return _success(runtime().inspect_capabilities(capability_ids))
         except RuntimeFailure as error:
             return _failure(error)
 
-    @server.tool(annotations=READ_ONLY, structured_output=False)
+    @server.tool(annotations=READ_ONLY, structured_output=True)
     async def analyze(
         capability_id: str,
         sources: list[Source],
         arguments: dict[str, Any],
         limits: RequestLimits | None = None,
         continuation: str | None = None,
-    ) -> CallToolResult:
+    ) -> Annotated[CallToolResult, AnalysisOutcome]:
         """Analyze 1-32 explicit path or evidence sources without durable writes."""
         try:
             return _success(
@@ -151,7 +257,31 @@ def create_server(
         except (OSError, ValueError, json.JSONDecodeError) as error:
             return _failure(RuntimeFailure("DECODE_FAILURE", str(error)))
 
-    @server.tool(annotations=CAPTURE, structured_output=False)
+    @server.tool(annotations=READ_ONLY, structured_output=True)
+    async def preflight_capture(
+        target: CaptureTarget,
+        capability_id: str = "artifact.preview",
+        mode: Literal["single", "experiment"] = "single",
+        experiment: ExperimentDesign | None = None,
+        limits: RequestLimits | None = None,
+    ) -> Annotated[CallToolResult, PreflightOutcome]:
+        """Resolve and validate one exact capture request without executing it or creating state."""
+        try:
+            return _success(
+                runtime().preflight_capture(
+                    target,
+                    capability_id,
+                    mode=mode,
+                    experiment=experiment,
+                    limits=limits,
+                )
+            )
+        except RuntimeFailure as error:
+            return _failure(error)
+        except ValidationError as error:
+            return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
+
+    @server.tool(annotations=CAPTURE, structured_output=True)
     async def capture_and_analyze(
         target: CaptureTarget,
         capability_id: str = "artifact.preview",
@@ -160,8 +290,8 @@ def create_server(
         limits: RequestLimits | None = None,
         preserve: bool = False,
         ctx: Context[AnalysisRuntime] | None = None,
-    ) -> CallToolResult:
-        """Execute a typed target through the broker and immediately analyze its outputs."""
+    ) -> Annotated[CallToolResult, AnalysisOutcome]:
+        """Execute and analyze a typed target; use preflight_capture first when review is needed."""
 
         async def progress(current: int, total: int, message: str) -> None:
             if ctx is not None:
@@ -207,8 +337,10 @@ def create_server(
         except Exception as error:
             return _failure(RuntimeFailure("EXECUTION_FAILURE", str(error) or type(error).__name__))
 
-    @server.tool(annotations=PRESERVE, structured_output=False)
-    async def preserve_evidence(analysis_id: str) -> CallToolResult:
+    @server.tool(annotations=PRESERVE, structured_output=True)
+    async def preserve_evidence(
+        analysis_id: str,
+    ) -> Annotated[CallToolResult, PreservationOutcome]:
         """Idempotently preserve one session analysis and its native artifacts."""
         try:
             value = runtime().preserve_evidence(analysis_id)
@@ -222,7 +354,7 @@ def create_server(
         except RuntimeFailure as error:
             return _failure(error)
 
-    @server.tool(annotations=READ_ONLY, structured_output=False)
+    @server.tool(annotations=READ_ONLY, structured_output=True)
     async def query_evidence(
         evidence_kind: str | None = None,
         capability_id: str | None = None,
@@ -232,7 +364,7 @@ def create_server(
         created_before: datetime | None = None,
         limit: int = 50,
         cursor: str | None = None,
-    ) -> CallToolResult:
+    ) -> Annotated[CallToolResult, QueryOutcome]:
         """Search an immutable, request-pinned manifest inventory in deterministic order."""
         try:
             return _success(

--- a/src/flameox/providers/reliability.py
+++ b/src/flameox/providers/reliability.py
@@ -24,14 +24,12 @@ class ReliabilityProvider:
         )
 
     def _pytest(self, path: Path, *, max_rows: int) -> ProviderAnalysis:
-        rows: list[dict[str, Any]] = []
-        observed = 0
         collected: set[str] = set()
-        phases: dict[str, dict[str, str]] = defaultdict(dict)
+        phase_events: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        global_failures: list[dict[str, Any]] = []
         finished = False
         interrupted = False
         for index, event in self._events(path):
-            observed += 1
             event_name = event.get("event")
             if event_name == "test_collected" and isinstance(event.get("nodeid"), str):
                 collected.add(event["nodeid"])
@@ -40,14 +38,48 @@ class ReliabilityProvider:
                 phase = event.get("phase")
                 outcome = event.get("outcome")
                 if all(isinstance(item, str) for item in (nodeid, phase, outcome)):
-                    phases[str(nodeid)][str(phase)] = str(outcome)
+                    phase_events[str(nodeid)][str(phase)] = self._pytest_row(index, event)
             elif event_name == "run_finished":
                 finished = True
             elif event_name in {"interrupted", "internal_error"}:
                 interrupted = True
-            if len(rows) < max_rows:
-                rows.append(self._pytest_row(index, event))
+                global_failures.append(
+                    {"index": index, "classification": str(event_name), "nodeid": None}
+                )
+        phases = {
+            nodeid: {phase: str(event["outcome"]) for phase, event in reports.items()}
+            for nodeid, reports in phase_events.items()
+        }
         outcomes = self._outcomes(phases)
+        diagnostic_rows = [
+            self._pytest_outcome_row(nodeid, reports)
+            for nodeid, reports in phase_events.items()
+            if self._pytest_classification(phases[nodeid]) in {"failed", "errored"}
+        ]
+        diagnostic_rows.extend(global_failures)
+        diagnostic_rows.extend(
+            {
+                "index": None,
+                "nodeid": nodeid,
+                "classification": "unexecuted",
+                "failing_phase": None,
+                "phase_outcomes": {},
+            }
+            for nodeid in sorted(collected.difference(phases))
+        )
+        priority = {
+            "errored": 0,
+            "failed": 1,
+            "internal_error": 2,
+            "interrupted": 3,
+            "unexecuted": 4,
+        }
+        diagnostic_rows.sort(
+            key=lambda row: (
+                priority[str(row["classification"])],
+                str(row.get("nodeid") or ""),
+            )
+        )
         completion = "interrupted" if interrupted else "complete" if finished else "incomplete"
         return ProviderAnalysis(
             provider_id="pytest",
@@ -63,14 +95,44 @@ class ReliabilityProvider:
                         **outcomes,
                     },
                 },
-                {"type": "table", "rows": rows},
+                {"type": "table", "rows": diagnostic_rows[:max_rows]},
             ],
-            rows_observed=observed,
-            complete=observed <= len(rows),
+            rows_observed=len(diagnostic_rows),
+            complete=len(diagnostic_rows) <= max_rows,
             limitations=[
-                "Failure tracebacks remain in the native pytest artifact and are not projected."
+                "Rows contain failure, error, interruption, and unexecuted identities; passing "
+                "and skipped identities remain summarized in metrics.",
+                "Failure tracebacks remain in the native pytest artifact and are not projected.",
             ],
         )
+
+    @staticmethod
+    def _pytest_classification(reports: dict[str, str]) -> str:
+        if reports.get("setup") == "failed" or reports.get("teardown") == "failed":
+            return "errored"
+        if reports.get("call") == "failed":
+            return "failed"
+        if "skipped" in reports.values():
+            return "skipped"
+        if reports.get("call") == "passed":
+            return "passed"
+        return "errored"
+
+    @classmethod
+    def _pytest_outcome_row(cls, nodeid: str, reports: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        outcomes = {phase: str(event["outcome"]) for phase, event in reports.items()}
+        classification = cls._pytest_classification(outcomes)
+        failing_phase = next(
+            (phase for phase in ("setup", "call", "teardown") if outcomes.get(phase) == "failed"),
+            None,
+        )
+        return {
+            "index": min(int(event["index"]) for event in reports.values()),
+            "nodeid": nodeid,
+            "classification": classification,
+            "failing_phase": failing_phase,
+            "phase_outcomes": outcomes,
+        }
 
     def _observations(self, path: Path, *, max_rows: int) -> ProviderAnalysis:
         rows: list[dict[str, Any]] = []

--- a/src/flameox/providers/structured_workers.py
+++ b/src/flameox/providers/structured_workers.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
-from flameox.providers.contracts import ProviderAnalysis
+from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 from flameox.workers.compute_sanitizer_contract import (
     COMPUTE_SANITIZER_WORKER,
     ComputeSanitizerWorkerRequest,
 )
 from flameox.workers.harness import IsolatedWorkerHarness
+from flameox.workers.pstats_contract import PSTATS_WORKER, PstatsMetric, PstatsWorkerRequest
 from flameox.workers.v8_profiles_contract import (
     V8_PROFILE_WORKER,
     V8ProfileRequest,
@@ -27,12 +29,51 @@ class StructuredWorkerProviders:
         path: Path,
         input_sha256: str,
         format_name: str,
+        arguments: dict[str, object],
         *,
         max_rows: int,
         timeout_seconds: float,
         maximum_rss_bytes: int,
         maximum_output_bytes: int,
     ) -> ProviderAnalysis | None:
+        if capability_id == "cpu.hotspots" and format_name == "pstats":
+            metric = str(arguments.get("metric") or "self_time_seconds")
+            if metric not in {
+                "self_time_seconds",
+                "cumulative_time_seconds",
+                "total_calls",
+                "primitive_calls",
+            }:
+                raise ProviderFailure("INVALID_INPUT", f"Unsupported pstats metric: {metric}")
+            pstats_result = self.harness.run_typed_sync(
+                PSTATS_WORKER,
+                PstatsWorkerRequest(
+                    metric=cast(PstatsMetric, metric),
+                    artifact_path=str(path),
+                    max_rows=max_rows,
+                ),
+                timeout_seconds=timeout_seconds,
+                maximum_rss_bytes=maximum_rss_bytes,
+                maximum_writable_growth_bytes=maximum_output_bytes,
+            )
+            return ProviderAnalysis(
+                provider_id="python-pstats",
+                provider_version=PSTATS_WORKER.implementation,
+                blocks=[
+                    {
+                        "type": "metrics",
+                        "values": {
+                            "function_count": pstats_result.function_count,
+                            "metric": pstats_result.metric,
+                            "reader_python_version": pstats_result.reader_version,
+                        },
+                    },
+                    {"type": "table", "rows": [dict(row) for row in pstats_result.rows]},
+                ],
+                rows_observed=pstats_result.function_count,
+                complete=not pstats_result.truncated,
+                limitations=list(pstats_result.limitations),
+            )
         if capability_id == "cpu.hotspots" and format_name == "cpuprofile":
             result = self.harness.run_typed_sync(
                 V8_PROFILE_WORKER,

--- a/src/flameox/runtime_contracts.py
+++ b/src/flameox/runtime_contracts.py
@@ -281,6 +281,141 @@ type CaptureArguments = (
 )
 
 
+@dataclass(frozen=True, slots=True)
+class CaptureArtifactContract:
+    role: str
+    format: str
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureProviderContract:
+    id: str
+    argument_model: type[StrictModel]
+    artifacts: tuple[CaptureArtifactContract, ...]
+    artifact_description: str
+    preview_streams: bool = False
+
+
+def _capture_provider(
+    provider_id: str,
+    argument_model: type[StrictModel],
+    artifacts: tuple[tuple[str, str], ...],
+    description: str,
+    *,
+    preview_streams: bool = False,
+) -> CaptureProviderContract:
+    return CaptureProviderContract(
+        provider_id,
+        argument_model,
+        tuple(CaptureArtifactContract(role, format_name) for role, format_name in artifacts),
+        description,
+        preview_streams,
+    )
+
+
+CAPTURE_PROVIDER_CONTRACTS = {
+    item.id: item
+    for item in (
+        _capture_provider(
+            "direct", EmptyArguments, (), "stdout and stderr text", preview_streams=True
+        ),
+        _capture_provider(
+            "pyperf", PyperfCaptureArguments, (("benchmark", "pyperf"),), "native pyperf JSON suite"
+        ),
+        _capture_provider(
+            "py-spy",
+            PySpyCaptureArguments,
+            (("cpu-profile", "py-spy"),),
+            "py-spy Speedscope profile",
+        ),
+        _capture_provider(
+            "perf",
+            PerfCaptureArguments,
+            (("cpu-profile", "perf-data"),),
+            "native perf.data profile",
+        ),
+        _capture_provider(
+            "node-cpu-profile",
+            EmptyArguments,
+            (("cpu-profile", "cpuprofile"),),
+            "native V8 CPU profile",
+        ),
+        _capture_provider(
+            "memray",
+            MemrayCaptureArguments,
+            (("memory", "memray"),),
+            "native Memray allocation file",
+        ),
+        _capture_provider(
+            "torch-profiler",
+            TorchProfilerCaptureArguments,
+            (("trace", "pytorch"),),
+            "native PyTorch Chrome trace",
+        ),
+        _capture_provider(
+            "benchmark-samples",
+            BenchmarkSamplesCaptureArguments,
+            (("benchmark", "samples"),),
+            "native Flameox benchmark samples",
+        ),
+        _capture_provider(
+            "nvbench",
+            EmptyArguments,
+            (("benchmark", "nvbench"),),
+            "native NVBench JSON-bin directory",
+        ),
+        _capture_provider(
+            "compute-sanitizer",
+            ComputeSanitizerCaptureArguments,
+            (("sanitizer", "compute-sanitizer"),),
+            "native Compute Sanitizer log",
+        ),
+        _capture_provider(
+            "nsight-systems",
+            NsightSystemsCaptureArguments,
+            (("trace", "nsys-rep"),),
+            "native Nsight Systems report",
+        ),
+        _capture_provider(
+            "nsight-compute",
+            NsightComputeCaptureArguments,
+            (("report", "nsight-compute"),),
+            "native Nsight Compute report",
+        ),
+        _capture_provider(
+            "rocprofv3",
+            RocprofCaptureArguments,
+            (("trace", "rocprof-pftrace"),),
+            "native ROCprof PFTrace",
+        ),
+        _capture_provider(
+            "xctrace",
+            XctraceCaptureArguments,
+            (("trace", "xctrace"),),
+            "native Apple .trace bundle",
+        ),
+        _capture_provider(
+            "coverage",
+            CoverageCaptureArguments,
+            (("coverage", "coverage"),),
+            "native coverage.py data file",
+        ),
+        _capture_provider(
+            "observations",
+            EmptyArguments,
+            (("observations", "observations"),),
+            "native Flameox observation stream",
+        ),
+        _capture_provider(
+            "pytest",
+            EmptyArguments,
+            (("reliability", "pytest"),),
+            "bounded native pytest event stream",
+        ),
+    )
+}
+
+
 class ExperimentCase(StrictModel):
     name: str = Field(min_length=1, max_length=80)
     argv: list[str] | None = Field(default=None, min_length=1, max_length=256)
@@ -460,7 +595,7 @@ CAPABILITIES = tuple(
     + _caps(
         ("cpu.hotspots",),
         "Rank bounded CPU evidence.",
-        ("cpuprofile", "py-spy", "perf", "perf-data"),
+        ("cpuprofile", "pstats", "py-spy", "perf", "perf-data"),
         SummaryArguments,
     )
     + _caps(

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -38,7 +38,7 @@ from flameox.execution import (
     ResourcePolicy,
     SubprocessBroker,
 )
-from flameox.process_models import process_exit_code
+from flameox.process_models import ProcessResult, process_exit_code
 from flameox.providers.aiperf import AIPerfProvider
 from flameox.providers.benchmarks import BenchmarkProvider
 from flameox.providers.contracts import (
@@ -69,6 +69,7 @@ from flameox.runtime_contracts import (
     CAPABILITIES,
     CAPABILITY_BY_ID,
     CAPTURE_PROBES,
+    CAPTURE_PROVIDER_CONTRACTS,
     FORMAT_PROBES,
     MAX_INPUTS,
     MAX_ROWS,
@@ -97,7 +98,6 @@ from flameox.runtime_contracts import (
     RocprofCaptureArguments,
     RuntimeFailure,
     Source,
-    StrictModel,
     TorchProfilerCaptureArguments,
     XctraceCaptureArguments,
 )
@@ -138,6 +138,15 @@ class CaptureInvocation:
     argv: tuple[str, ...]
     environment: dict[str, str]
     artifacts: tuple[tuple[Path, str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedCaptureRequest:
+    capability: Capability
+    capture_arguments: CaptureArguments
+    limits: RequestLimits
+    cases: list[ExperimentCase]
+    blocks: int
 
 
 def _perf_permission_limited(executable_path: str) -> bool:
@@ -296,77 +305,26 @@ class AnalysisRuntime:
         }
 
     def _capture_provider_details(self, capability: Capability) -> list[dict[str, Any]]:
-        providers: list[tuple[str, type[StrictModel], str]] = []
-        if capability.id == "artifact.preview":
-            providers.append(("direct", EmptyArguments, "stdout and stderr text"))
-        if "pyperf" in capability.formats:
-            providers.append(("pyperf", PyperfCaptureArguments, "native pyperf JSON suite"))
-        if "py-spy" in capability.formats:
-            providers.append(("py-spy", PySpyCaptureArguments, "py-spy Speedscope profile"))
-        if "perf-data" in capability.formats:
-            providers.append(("perf", PerfCaptureArguments, "native perf.data profile"))
-        if "cpuprofile" in capability.formats:
-            providers.append(("node-cpu-profile", EmptyArguments, "native V8 CPU profile"))
-        if "memray" in capability.formats:
-            providers.append(("memray", MemrayCaptureArguments, "native Memray allocation file"))
-        if "pytorch" in capability.formats:
-            providers.append(
-                (
-                    "torch-profiler",
-                    TorchProfilerCaptureArguments,
-                    "native PyTorch Chrome trace",
+        providers = [
+            contract
+            for contract in CAPTURE_PROVIDER_CONTRACTS.values()
+            if (
+                (capability.id == "artifact.preview" and contract.preview_streams)
+                or set(capability.formats).intersection(
+                    artifact.format for artifact in contract.artifacts
                 )
             )
-        if "samples" in capability.formats:
-            providers.append(
-                (
-                    "benchmark-samples",
-                    BenchmarkSamplesCaptureArguments,
-                    "native Flameox benchmark samples",
-                )
-            )
-        if "nvbench" in capability.formats:
-            providers.append(("nvbench", EmptyArguments, "native NVBench JSON-bin directory"))
-        if "compute-sanitizer" in capability.formats:
-            providers.append(
-                (
-                    "compute-sanitizer",
-                    ComputeSanitizerCaptureArguments,
-                    "native Compute Sanitizer log",
-                )
-            )
-        if "nsys-rep" in capability.formats:
-            providers.append(
-                (
-                    "nsight-systems",
-                    NsightSystemsCaptureArguments,
-                    "native Nsight Systems report",
-                )
-            )
-        if "nsight-compute" in capability.formats:
-            providers.append(
-                (
-                    "nsight-compute",
-                    NsightComputeCaptureArguments,
-                    "native Nsight Compute report",
-                )
-            )
-        if "rocprof-pftrace" in capability.formats:
-            providers.append(("rocprofv3", RocprofCaptureArguments, "native ROCprof PFTrace"))
-        if "xctrace" in capability.formats:
-            providers.append(("xctrace", XctraceCaptureArguments, "native Apple .trace bundle"))
-        if "coverage" in capability.formats:
-            providers.append(("coverage", CoverageCaptureArguments, "native coverage.py data file"))
-        if "pytest" in capability.formats:
-            providers.append(("pytest", EmptyArguments, "bounded native pytest event stream"))
+        ]
         return [
             {
-                "id": provider_id,
-                "capture_argument_schema": model.model_json_schema(mode="validation"),
-                "artifact": artifact,
-                "availability": self._capture_provider_availability(provider_id),
+                "id": contract.id,
+                "capture_argument_schema": contract.argument_model.model_json_schema(
+                    mode="validation"
+                ),
+                "artifact": contract.artifact_description,
+                "availability": self._capture_provider_availability(contract.id),
             }
-            for provider_id, model, artifact in providers
+            for contract in providers
         ]
 
     def _capture_provider_availability(self, provider_id: str) -> dict[str, Any]:
@@ -543,6 +501,149 @@ class AnalysisRuntime:
         )
         return self._copy_result(validated_result)
 
+    def preflight_capture(
+        self,
+        target: CaptureTarget,
+        capability_id: str,
+        *,
+        mode: Literal["single", "experiment"] = "single",
+        experiment: ExperimentDesign | None = None,
+        limits: RequestLimits | None = None,
+    ) -> dict[str, Any]:
+        validated = self._validate_capture_request(
+            target, capability_id, mode=mode, experiment=experiment, limits=limits
+        )
+        total = len(validated.cases) * validated.blocks
+        self._reserve_capture_capacity(
+            total,
+            provider_id=target.provider_id,
+            has_oracle=experiment is not None and experiment.semantic_oracle is not None,
+            limits=validated.limits,
+        )
+        cwd = self._resolve_project_cwd(target.cwd)
+        case_plans: list[dict[str, Any]] = []
+        for case_index, case in enumerate(validated.cases, start=1):
+            argv = case.argv or target.argv
+            environment = {**target.environment, **case.environment}
+            if len(environment) > 32:
+                raise RuntimeFailure(
+                    "INVALID_INPUT", "merged capture environment must contain at most 32 entries"
+                )
+            directory = Path("<request-scratch>") / f"case-{case_index:04d}"
+            invocation = self._capture_invocation(
+                target.provider_id,
+                argv,
+                environment,
+                validated.capture_arguments,
+                directory,
+            )
+            binding = self._require_host_tool(
+                invocation.argv[0], cwd=cwd, environment={**os.environ, **invocation.environment}
+            )
+            case_plans.append(
+                {
+                    "case": case.name,
+                    "requested_argv": argv,
+                    "capture_argv_template": list(invocation.argv),
+                    "environment_names": sorted(invocation.environment),
+                    "executable": binding.model_dump(mode="json"),
+                    "expected_artifacts": [
+                        {
+                            "role": role,
+                            "format": format_name,
+                            "path_template": str(path),
+                        }
+                        for path, format_name, role in invocation.artifacts
+                    ],
+                }
+            )
+        request = {
+            "target": target.model_dump(mode="json"),
+            "capability_id": capability_id,
+            "mode": mode,
+            "experiment": experiment.model_dump(mode="json") if experiment else None,
+            "limits": validated.limits.model_dump(mode="json"),
+        }
+        return {
+            "request_sha256": hashlib.sha256(canonical_bytes(request)).hexdigest(),
+            "authoritative": False,
+            "compatibility": {
+                "status": "compatible",
+                "provider_id": target.provider_id,
+                "output_formats": self._capture_output_formats(target.provider_id),
+                "capability_id": capability_id,
+                "accepted_formats": list(validated.capability.formats),
+            },
+            "execution_count": total,
+            "cwd": str(cwd),
+            "cases": case_plans,
+            "effective_limits": validated.limits.model_dump(mode="json"),
+            "limitations": [
+                "Preflight creates no plan or execution authority.",
+                "Capture resolves and validates the request again before execution.",
+                "Workload-interpreter package readiness remains target-dependent.",
+            ],
+        }
+
+    def _validate_capture_request(
+        self,
+        target: CaptureTarget,
+        capability_id: str,
+        *,
+        mode: Literal["single", "experiment"],
+        experiment: ExperimentDesign | None,
+        limits: RequestLimits | None,
+    ) -> ValidatedCaptureRequest:
+        selected_limits = limits.lowered_against(self.limits) if limits else self.limits
+        capability = CAPABILITY_BY_ID.get(capability_id)
+        if capability is None:
+            raise RuntimeFailure("UNKNOWN_CAPABILITY", f"Unknown capability: {capability_id}")
+        capture_arguments = self._capture_arguments(target.provider_id, target.capture_arguments)
+        TypeAdapter(capability.model).validate_python(target.analysis_arguments)
+        if (mode == "experiment") != (experiment is not None):
+            raise RuntimeFailure(
+                "INVALID_INPUT", "experiment mode and design must be supplied together"
+            )
+        output_formats = set(self._capture_output_formats(target.provider_id))
+        compatible = (
+            capability_id == "artifact.preview" and target.provider_id == "direct"
+        ) or bool(output_formats.intersection(capability.formats))
+        if not compatible:
+            compatible_providers = [
+                contract.id
+                for contract in CAPTURE_PROVIDER_CONTRACTS.values()
+                if set(capability.formats).intersection(
+                    artifact.format for artifact in contract.artifacts
+                )
+            ]
+            raise RuntimeFailure(
+                "UNSUPPORTED_FORMAT",
+                (
+                    f"Capture provider {target.provider_id!r} cannot feed capability "
+                    f"{capability_id!r}."
+                ),
+                details={
+                    "provider_id": target.provider_id,
+                    "output_formats": sorted(output_formats),
+                    "capability_id": capability_id,
+                    "accepted_formats": list(capability.formats),
+                    "compatible_capture_providers": compatible_providers,
+                },
+            )
+        cases = experiment.cases if experiment else [ExperimentCase(name="single")]
+        return ValidatedCaptureRequest(
+            capability=capability,
+            capture_arguments=capture_arguments,
+            limits=selected_limits,
+            cases=cases,
+            blocks=experiment.blocks if experiment else 1,
+        )
+
+    @staticmethod
+    def _capture_output_formats(provider_id: str) -> list[str]:
+        contract = CAPTURE_PROVIDER_CONTRACTS[provider_id]
+        return [artifact.format for artifact in contract.artifacts]
+
     async def capture_and_analyze(  # noqa: C901 - capture lifecycle keeps failure artifacts together
         self,
         target: CaptureTarget,
@@ -554,18 +655,13 @@ class AnalysisRuntime:
         progress: Any | None = None,
         preserve: bool = False,
     ) -> dict[str, Any]:
-        selected_limits = limits.lowered_against(self.limits) if limits else self.limits
-        capability = CAPABILITY_BY_ID.get(capability_id)
-        if capability is None:
-            raise RuntimeFailure("UNKNOWN_CAPABILITY", f"Unknown capability: {capability_id}")
-        capture_arguments = self._capture_arguments(target.provider_id, target.capture_arguments)
-        TypeAdapter(capability.model).validate_python(target.analysis_arguments)
-        if (mode == "experiment") != (experiment is not None):
-            raise RuntimeFailure(
-                "INVALID_INPUT", "experiment mode and design must be supplied together"
-            )
-        cases = experiment.cases if experiment else [ExperimentCase(name="single")]
-        blocks = experiment.blocks if experiment else 1
+        validated_capture = self._validate_capture_request(
+            target, capability_id, mode=mode, experiment=experiment, limits=limits
+        )
+        selected_limits = validated_capture.limits
+        capture_arguments = validated_capture.capture_arguments
+        cases = validated_capture.cases
+        blocks = validated_capture.blocks
         total = len(cases) * blocks
         self._reserve_capture_capacity(
             total,
@@ -597,6 +693,7 @@ class AnalysisRuntime:
                 cwd = self._resolve_project_cwd(target.cwd)
                 directory = request_scratch / f"case-{sequence:04d}"
                 directory.mkdir()
+                self._materialize_capture_support(target.provider_id, directory)
                 invocation, binding = self._bind_capture_invocation(
                     target.provider_id,
                     argv,
@@ -765,6 +862,7 @@ class AnalysisRuntime:
                         "semantic_oracle": oracle,
                         "wall_time_ns": process.wall_time_ns,
                         "containment": containment,
+                        "limit": self._terminated_limit(process, selected_limits),
                     }
                 )
                 self._check_capture_provenance_capacity(
@@ -1185,29 +1283,10 @@ class AnalysisRuntime:
 
     @staticmethod
     def _capture_arguments(provider_id: str, arguments: Mapping[str, Any]) -> CaptureArguments:
-        models: dict[str, type[CaptureArguments]] = {
-            "direct": EmptyArguments,
-            "pyperf": PyperfCaptureArguments,
-            "py-spy": PySpyCaptureArguments,
-            "perf": PerfCaptureArguments,
-            "node-cpu-profile": EmptyArguments,
-            "memray": MemrayCaptureArguments,
-            "torch-profiler": TorchProfilerCaptureArguments,
-            "nvbench": EmptyArguments,
-            "compute-sanitizer": ComputeSanitizerCaptureArguments,
-            "nsight-systems": NsightSystemsCaptureArguments,
-            "nsight-compute": NsightComputeCaptureArguments,
-            "rocprofv3": RocprofCaptureArguments,
-            "xctrace": XctraceCaptureArguments,
-            "coverage": CoverageCaptureArguments,
-            "benchmark-samples": BenchmarkSamplesCaptureArguments,
-            "observations": EmptyArguments,
-            "pytest": EmptyArguments,
-        }
-        model = models.get(provider_id)
-        if model is None:
+        contract = CAPTURE_PROVIDER_CONTRACTS.get(provider_id)
+        if contract is None:
             raise RuntimeFailure("UNKNOWN_CAPABILITY", f"Unknown capture provider: {provider_id}")
-        return model.model_validate(arguments)
+        return cast(CaptureArguments, contract.argument_model.model_validate(arguments))
 
     @staticmethod
     def _capture_invocation(
@@ -1233,6 +1312,17 @@ class AnalysisRuntime:
             )
         if provider_id == "pyperf" and isinstance(arguments, PyperfCaptureArguments):
             output = directory / "benchmark.json"
+            pyperf_target = tuple(target_argv)
+            if any("\n" in item or "\r" in item for item in target_argv):
+                encoded_argv = base64.urlsafe_b64encode(
+                    json.dumps(target_argv, ensure_ascii=False).encode("utf-8")
+                ).decode("ascii")
+                pyperf_target = (
+                    sys.executable,
+                    "-m",
+                    "flameox.workers.pyperf_target",
+                    encoded_argv,
+                )
             argv = (
                 sys.executable,
                 "-m",
@@ -1253,7 +1343,7 @@ class AnalysisRuntime:
                 str(arguments.min_time),
                 "--name",
                 arguments.name,
-                *target_argv,
+                *pyperf_target,
             )
             return CaptureInvocation(argv, environment, ((output, "pyperf", "benchmark"),))
         if provider_id == "py-spy" and isinstance(arguments, PySpyCaptureArguments):
@@ -1302,7 +1392,6 @@ class AnalysisRuntime:
             )
         if provider_id == "nvbench" and isinstance(arguments, EmptyArguments):
             output_root = directory / "nvbench"
-            output_root.mkdir()
             output = output_root / "results.json"
             return CaptureInvocation(
                 (*target_argv, "--jsonbin", str(output)),
@@ -1386,7 +1475,6 @@ class AnalysisRuntime:
             )
         output = directory / ".coverage"
         empty_config = directory / "coverage.ini"
-        empty_config.write_text("[run]\n")
         options: list[str] = [
             "--data-file",
             str(output),
@@ -1437,7 +1525,6 @@ class AnalysisRuntime:
             )
         if provider_id == "torch-profiler" and isinstance(arguments, TorchProfilerCaptureArguments):
             output_root = directory / "torch-profiler"
-            output_root.mkdir()
             config = {
                 "mode": "sdk",
                 "activities": arguments.activities,
@@ -1544,7 +1631,6 @@ class AnalysisRuntime:
             )
         if provider_id == "rocprofv3" and isinstance(arguments, RocprofCaptureArguments):
             output_root = directory / "rocprof"
-            output_root.mkdir()
             output = output_root / "rocprofv3_results.pftrace"
             options: list[str] = []
             for enabled, flag in (
@@ -1595,6 +1681,18 @@ class AnalysisRuntime:
             "INVALID_INPUT", f"Invalid arguments for capture provider: {provider_id}"
         )
 
+    @staticmethod
+    def _materialize_capture_support(provider_id: str, directory: Path) -> None:
+        child_directory = {
+            "nvbench": "nvbench",
+            "torch-profiler": "torch-profiler",
+            "rocprofv3": "rocprof",
+        }.get(provider_id)
+        if child_directory is not None:
+            (directory / child_directory).mkdir()
+        if provider_id == "coverage":
+            (directory / "coverage.ini").write_text("[run]\n")
+
     def _reserve_capture_capacity(
         self,
         total: int,
@@ -1635,12 +1733,20 @@ class AnalysisRuntime:
                 return dict(cached.preserved)
         if cached.preserved is None:
             artifacts: list[NativeArtifact] = []
+            role_counts: dict[str, int] = {}
             for source in cached.sources:
+                role_counts[source.role] = role_counts.get(source.role, 0) + 1
+            for source_index, source in enumerate(cached.sources, start=1):
+                publication_role = (
+                    source.role
+                    if role_counts[source.role] == 1
+                    else f"source-{source_index:04d}/{source.role}"
+                )
                 if source.path.is_file():
                     artifacts.append(
                         NativeArtifact(
                             source.path,
-                            source.role,
+                            publication_role,
                             source.sha256,
                             source.size_bytes,
                             source.format,
@@ -1660,7 +1766,7 @@ class AnalysisRuntime:
                     artifacts.append(
                         NativeArtifact(
                             path,
-                            f"{source.role}:{relative}",
+                            f"{publication_role}:{relative}",
                             digest,
                             size,
                             source.format,
@@ -1678,6 +1784,51 @@ class AnalysisRuntime:
             except OSError as exc:
                 raise RuntimeFailure("REPOSITORY_IO_FAILURE", str(exc)) from exc
         return dict(cached.preserved)
+
+    @staticmethod
+    def _terminated_limit(process: ProcessResult, limits: RequestLimits) -> dict[str, Any] | None:
+        cause = process.cancellation_cause
+        if cause is None:
+            return None
+        resources = process.resources
+        configured: int | float | None = None
+        observed: int | float | None = None
+        unit: str | None = None
+        recovery: str | None = None
+        if cause.value == "timeout":
+            configured = limits.timeout_seconds
+            observed = process.wall_time_ns / 1_000_000_000 if process.wall_time_ns else None
+            unit = "seconds"
+            recovery = "Retry with a larger timeout_seconds if the workload duration is expected."
+        elif cause.value == "output_limit":
+            configured = limits.max_output_bytes
+            unit = "bytes"
+            recovery = "Retry with a larger max_output_bytes or reduce target output."
+        elif cause.value == "memory_limit_exceeded":
+            configured = limits.max_memory_bytes
+            observed = process.peak_rss_bytes
+            unit = "bytes"
+            recovery = "Retry with a larger max_memory_bytes only if the workload is trusted."
+        elif cause.value == "writable_limit_exceeded":
+            configured = limits.max_output_bytes
+            if resources is not None and resources.writable_root_growth_bytes:
+                observed = sum(resources.writable_root_growth_bytes.values())
+            unit = "bytes"
+            recovery = "Retry with a larger max_output_bytes or reduce capture artifacts."
+        elif cause.value == "storage_reserve_exceeded":
+            configured = resources.minimum_free_bytes if resources is not None else None
+            unit = "bytes_free"
+            recovery = "Free storage before retrying; do not lower the reserve blindly."
+        else:
+            return None
+        return {
+            "kind": cause.value,
+            "configured": configured,
+            "observed": observed,
+            "unit": unit,
+            "observation_available": observed is not None,
+            "recovery": recovery,
+        }
 
     @staticmethod
     def _durable_analysis(result: Mapping[str, Any]) -> dict[str, Any]:
@@ -2074,6 +2225,7 @@ class AnalysisRuntime:
                     sources[0].path,
                     sources[0].sha256,
                     sources[0].format,
+                    dict(arguments),
                     max_rows=max_rows,
                     timeout_seconds=limits.timeout_seconds,
                     maximum_rss_bytes=limits.max_memory_bytes,
@@ -2427,6 +2579,7 @@ class AnalysisRuntime:
                 "failure_code": item["failure_code"],
                 "wall_time_ns": item["wall_time_ns"],
                 "containment": item["containment"],
+                "limit": item["limit"],
                 "semantic_oracle": (
                     {
                         "status": item["semantic_oracle"]["status"],
@@ -2641,6 +2794,7 @@ class AnalysisRuntime:
             ".ncu-rep": "nsight-compute",
             ".ncu-repz": "nsight-compute",
             ".sarif": "sarif",
+            ".pstats": "pstats",
         }
         if path.suffix.lower() in known:
             return known[path.suffix.lower()]

--- a/src/flameox/workers/protocol.py
+++ b/src/flameox/workers/protocol.py
@@ -27,6 +27,7 @@ class WorkerOperationId(StrEnum):
     NSIGHT_SYSTEMS_PARSE = "nsight_systems.parse"
     OTLP_PARSE = "otlp.parse"
     PERFETTO_QUERY = "perfetto.query"
+    PSTATS_PARSE = "pstats.parse"
     PYPERF_PARSE = "pyperf.parse"
     V8_PROFILE_PARSE = "v8_profile.parse"
 

--- a/src/flameox/workers/pstats.py
+++ b/src/flameox/workers/pstats.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pstats
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic import JsonValue
+
+from flameox.workers.protocol import WorkerApplication, WorkerFailureKind, run_typed_worker
+from flameox.workers.pstats_contract import PSTATS_WORKER, PstatsWorkerRequest, PstatsWorkerResult
+
+
+def _handle(request: PstatsWorkerRequest, _job_root: Path) -> PstatsWorkerResult:
+    stats = cast(Any, pstats.Stats(request.artifact_path)).stats
+    rows: list[dict[str, Any]] = []
+    for (filename, line, function), values in stats.items():
+        primitive_calls, total_calls, self_time, cumulative_time, _callers = values
+        rows.append(
+            {
+                "function": function,
+                "file": filename,
+                "line": line,
+                "primitive_calls": primitive_calls,
+                "total_calls": total_calls,
+                "self_time_seconds": self_time,
+                "cumulative_time_seconds": cumulative_time,
+            }
+        )
+    rows.sort(key=lambda row: (-float(row[request.metric]), str(row["file"]), int(row["line"])))
+    return PstatsWorkerResult(
+        reader_version=".".join(map(str, sys.version_info[:3])),
+        metric=request.metric,
+        function_count=len(rows),
+        rows=cast(tuple[dict[str, JsonValue], ...], tuple(rows[: request.max_rows])),
+        truncated=len(rows) > request.max_rows,
+        limitations=(
+            "cProfile is deterministic instrumentation; call counts are not sampling frequency.",
+            "pstats files have no compatibility guarantee across Python versions or profilers.",
+            "Profile observations rank work but do not establish causal optimization impact.",
+        ),
+    )
+
+
+def main() -> int:
+    return run_typed_worker(
+        WorkerApplication(
+            definition=PSTATS_WORKER,
+            handler=_handle,
+            invalid_failure=WorkerFailureKind.INPUT_MALFORMED,
+            invalid_message="pstats profile is unsupported or invalid",
+            caught=(OSError, EOFError, ValueError, TypeError),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/flameox/workers/pstats_contract.py
+++ b/src/flameox/workers/pstats_contract.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field, JsonValue, TypeAdapter
+
+from flameox.models import ContractModel
+from flameox.workers.protocol import WorkerDefinition, WorkerOperationId
+
+PstatsMetric = Literal[
+    "self_time_seconds",
+    "cumulative_time_seconds",
+    "total_calls",
+    "primitive_calls",
+]
+
+
+class PstatsWorkerRequest(ContractModel):
+    artifact_path: str = Field(min_length=1, max_length=4_096)
+    metric: PstatsMetric = "self_time_seconds"
+    max_rows: Annotated[int, Field(gt=0, le=1_001)]
+
+
+class PstatsWorkerResult(ContractModel):
+    reader_version: str = Field(min_length=1, max_length=100)
+    metric: PstatsMetric
+    function_count: Annotated[int, Field(ge=0)]
+    rows: tuple[dict[str, JsonValue], ...]
+    truncated: bool
+    limitations: tuple[str, ...] = Field(default=(), max_length=16)
+
+
+PSTATS_WORKER = WorkerDefinition(
+    operation=WorkerOperationId.PSTATS_PARSE,
+    module="flameox.workers.pstats",
+    request=TypeAdapter(PstatsWorkerRequest),
+    response=TypeAdapter(PstatsWorkerResult),
+    name="pstats",
+    implementation="flameox.workers.pstats/v1",
+)

--- a/src/flameox/workers/pyperf_target.py
+++ b/src/flameox/workers/pyperf_target.py
@@ -1,0 +1,25 @@
+"""Metadata-safe launcher for pyperf command targets with multiline argv."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        return 2
+    try:
+        argv = json.loads(base64.urlsafe_b64decode(sys.argv[1]).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return 2
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+        return 2
+    os.execvpe(argv[0], argv, os.environ)
+    return 127
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/providers/test_cpu.py
+++ b/tests/providers/test_cpu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import cProfile
 import json
 import os
 import sys
@@ -11,6 +12,34 @@ import pytest
 
 from flameox.runtime_contracts import CaptureTarget, PathSource, RuntimeFailure
 from flameox.stateless import AnalysisRuntime
+
+
+def test_pstats_profile_is_bounded_deterministic_cpu_evidence(tmp_path: Path) -> None:
+    profile = tmp_path / "profile.pstats"
+
+    def work() -> int:
+        return sum(range(20))
+
+    profiler = cProfile.Profile()
+    profiler.runcall(work)
+    profiler.dump_stats(profile)
+    runtime = AnalysisRuntime(tmp_path)
+    try:
+        result = runtime.analyze(
+            "cpu.hotspots",
+            [PathSource(path=str(profile), format="pstats", producer="cProfile")],
+            {"metric": "cumulative_time_seconds"},
+        )
+    finally:
+        runtime.close()
+
+    assert result["provider"]["id"] == "python-pstats"
+    assert result["blocks"][0]["values"]["metric"] == "cumulative_time_seconds"
+    work_row = next(row for row in result["blocks"][1]["rows"] if row["function"] == "work")
+    assert work_row["total_calls"] == 1
+    assert work_row["primitive_calls"] == 1
+    assert work_row["cumulative_time_seconds"] >= work_row["self_time_seconds"]
+    assert any("no compatibility guarantee" in item for item in result["limitations"])
 
 
 def test_pyspy_speedscope_profile_ranks_typed_frames(tmp_path: Path) -> None:

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -20,7 +20,15 @@ def test_help_exposes_only_stateless_command_families() -> None:
     assert result.exit_code == 0, result.output
     assert all(
         command in result.output
-        for command in ("setup", "analyze", "capture", "capabilities", "mcp", "evidence")
+        for command in (
+            "setup",
+            "analyze",
+            "preflight",
+            "capture",
+            "capabilities",
+            "mcp",
+            "evidence",
+        )
     )
     assert all(
         removed not in result.output

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -91,6 +91,73 @@ def test_typed_capability_never_falls_back_to_generic_rows(tmp_path: Path) -> No
     assert failure.value.code == "UNSUPPORTED_FORMAT"
 
 
+@pytest.mark.unit
+def test_capture_rejects_declared_provider_capability_mismatch_before_execution(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "executed"
+
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(tmp_path)
+        try:
+            with pytest.raises(RuntimeFailure) as failure:
+                await runtime.capture_and_analyze(
+                    CaptureTarget(
+                        argv=[
+                            sys.executable,
+                            "-c",
+                            f"from pathlib import Path; Path({str(marker)!r}).touch()",
+                        ],
+                        provider_id="pyperf",
+                    ),
+                    "failures.summary",
+                )
+        finally:
+            runtime.close()
+        assert failure.value.code == "UNSUPPORTED_FORMAT"
+        assert failure.value.details["output_formats"] == ["pyperf"]
+        assert failure.value.details["compatible_capture_providers"] == [
+            "observations",
+            "pytest",
+        ]
+
+    anyio.run(exercise)
+    assert not marker.exists()
+
+
+@pytest.mark.unit
+def test_capture_preflight_is_read_only_and_returns_resolved_template(tmp_path: Path) -> None:
+    marker = tmp_path / "executed"
+    runtime = AnalysisRuntime(tmp_path)
+    before = list(runtime.scratch.rglob("*"))
+    try:
+        result = runtime.preflight_capture(
+            CaptureTarget(
+                argv=[
+                    sys.executable,
+                    "-c",
+                    f"from pathlib import Path; Path({str(marker)!r}).touch()",
+                ],
+                provider_id="pyperf",
+            ),
+            "benchmark.summary",
+        )
+        after = list(runtime.scratch.rglob("*"))
+    finally:
+        runtime.close()
+
+    assert result["authoritative"] is False
+    assert result["compatibility"]["status"] == "compatible"
+    assert result["cases"][0]["expected_artifacts"][0] == {
+        "role": "benchmark",
+        "format": "pyperf",
+        "path_template": "<request-scratch>/case-0001/benchmark.json",
+    }
+    assert result["cases"][0]["capture_argv_template"][1:4] == ["-m", "pyperf", "command"]
+    assert before == after == []
+    assert not marker.exists()
+
+
 def test_special_file_sources_are_rejected_before_decoding(tmp_path: Path) -> None:
     fifo = tmp_path / "input.fifo"
     os.mkfifo(fifo)
@@ -793,6 +860,66 @@ def test_pyperf_capture_binds_native_output_before_analysis(tmp_path: Path) -> N
 
 
 @pytest.mark.process
+def test_pyperf_capture_preserves_multiline_target_argv(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(tmp_path, limits=RequestLimits(timeout_seconds=20))
+        try:
+            code = "value = 1\nassert value == 1"
+            result = await runtime.capture_and_analyze(
+                CaptureTarget(
+                    argv=[sys.executable, "-c", code],
+                    provider_id="pyperf",
+                    capture_arguments={
+                        "processes": 1,
+                        "values": 1,
+                        "warmups": 0,
+                        "loops": 1,
+                        "min_time": 0.001,
+                        "name": "multiline",
+                    },
+                ),
+                "benchmark.summary",
+            )
+            assert result["provider"]["id"] == "pyperf"
+            assert result["capture"]["executions"][0]["argv"] == [sys.executable, "-c", code]
+            assert result["capture"]["executions"][0]["status"] == "succeeded"
+        finally:
+            runtime.close()
+
+    anyio.run(exercise)
+
+
+def test_composed_evidence_namespaces_colliding_source_roles(tmp_path: Path) -> None:
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+    _write_pyperf_suite(first_path, [0.01])
+    _write_pyperf_suite(second_path, [0.02])
+    runtime = AnalysisRuntime(tmp_path)
+    try:
+        evidence_ids = []
+        for path in (first_path, second_path):
+            analysis = runtime.analyze(
+                "benchmark.summary", [PathSource(path=str(path), format="pyperf")], {}
+            )
+            evidence_ids.append(runtime.preserve_evidence(analysis["analysis_id"])["evidence_id"])
+        composed = runtime.analyze(
+            "benchmark.scaling",
+            [EvidenceSource(kind="evidence", evidence_id=value) for value in evidence_ids],
+            {},
+        )
+        preserved = runtime.preserve_evidence(composed["analysis_id"])
+        manifest = runtime.read_evidence(preserved["evidence_id"])
+    finally:
+        runtime.close()
+
+    assert {item["role"] for item in manifest["body"]["artifacts"]} == {
+        "source-0001/input",
+        "source-0002/input",
+    }
+    assert [item["role"] for item in manifest["body"]["inputs"]] == ["input", "input"]
+
+
+@pytest.mark.process
 def test_failed_provider_capture_returns_preservable_stream_evidence(tmp_path: Path) -> None:
     async def exercise() -> None:
         runtime = AnalysisRuntime(tmp_path, limits=RequestLimits(timeout_seconds=20))
@@ -1060,7 +1187,49 @@ def test_pytest_stream_has_typed_summary_and_bounded_rows(tmp_path: Path) -> Non
         "skipped": 0,
         "errored": 0,
     }
-    assert result["coverage"] == {"rows_returned": 2, "rows_observed": 5, "complete": False}
+    assert result["coverage"] == {"rows_returned": 1, "rows_observed": 1, "complete": True}
+    assert result["blocks"][1]["rows"][0]["classification"] == "unexecuted"
+
+
+@pytest.mark.unit
+def test_pytest_failure_identities_precede_large_successful_population(tmp_path: Path) -> None:
+    events = tmp_path / "pytest.jsonl"
+    nodeids = [f"tests/test_large.py::test_{index:04d}" for index in range(1_472)]
+    failing = set(nodeids[-15:])
+    payloads = [{"event": "test_collected", "nodeid": nodeid} for nodeid in nodeids]
+    payloads.extend(
+        {
+            "event": "test_phase",
+            "nodeid": nodeid,
+            "phase": "call",
+            "outcome": "failed" if nodeid in failing else "passed",
+        }
+        for nodeid in nodeids
+    )
+    payloads.append({"event": "run_finished"})
+    events.write_text("\n".join(json.dumps(item) for item in payloads) + "\n")
+    runtime = AnalysisRuntime(tmp_path)
+    try:
+        result = runtime.analyze(
+            "failures.summary",
+            [PathSource(path=str(events), format="pytest")],
+            {},
+            limits=RequestLimits(max_rows=10),
+        )
+        second = runtime.analyze(
+            "failures.summary",
+            [PathSource(path=str(events), format="pytest")],
+            {},
+            limits=RequestLimits(max_rows=10),
+            continuation=result["continuation"],
+        )
+    finally:
+        runtime.close()
+
+    rows = [*result["blocks"][1]["rows"], *second["blocks"][1]["rows"]]
+    assert {row["nodeid"] for row in rows} == failing
+    assert all(row["classification"] == "failed" for row in rows)
+    assert second["coverage"]["complete"] is True
 
 
 @pytest.mark.process
@@ -1598,7 +1767,7 @@ def test_discovery_requires_nsight_compute_official_reader(
 
 
 @pytest.mark.unit
-def test_mcp_catalog_is_exact_small_and_has_one_resource_template() -> None:
+def test_mcp_catalog_is_exact_small_typed_and_has_one_resource_template() -> None:
     async def inspect() -> None:
         server = create_server()
         tools = await server.list_tools()
@@ -1608,17 +1777,18 @@ def test_mcp_catalog_is_exact_small_and_has_one_resource_template() -> None:
             "discover_capabilities",
             "inspect_capabilities",
             "analyze",
+            "preflight_capture",
             "capture_and_analyze",
             "preserve_evidence",
             "query_evidence",
         ]
-        assert all(tool.output_schema is None for tool in tools)
+        assert all(tool.output_schema is not None for tool in tools)
         assert all(tool.annotations and tool.annotations.open_world_hint is False for tool in tools)
         assert await server.list_resources() == []
         assert [item.uri_template for item in templates] == ["flameox://evidence/{evidence_id}"]
         assert templates[0].mime_type == AGENT_EVIDENCE_MEDIA_TYPE
         catalog = json.dumps([tool.model_dump(mode="json") for tool in tools])
-        assert len(catalog) < 128 * 1024
+        assert len(catalog) < 40 * 1024
 
     anyio.run(inspect)
 
@@ -1644,17 +1814,27 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
             tools = await session.list_tools()
             resources = await session.list_resources()
             templates = await session.list_resource_templates()
+            inspected = await session.call_tool(
+                "inspect_capabilities", {"capability_ids": ["cpu.hotspots"]}
+            )
+            invalid = await session.call_tool(
+                "inspect_capabilities", {"capability_ids": ["unknown.capability"]}
+            )
+            await session.validate_tool_result("inspect_capabilities", inspected)
+            await session.validate_tool_result("inspect_capabilities", invalid)
 
         assert initialized.server_info.version == __version__
         assert [tool.name for tool in tools.tools] == [
             "discover_capabilities",
             "inspect_capabilities",
             "analyze",
+            "preflight_capture",
             "capture_and_analyze",
             "preserve_evidence",
             "query_evidence",
         ]
-        assert all(tool.output_schema is None for tool in tools.tools)
+        assert all(tool.output_schema is not None for tool in tools.tools)
+        assert invalid.is_error is True
         assert resources.resources == []
         assert [item.uri_template for item in templates.resource_templates] == [
             "flameox://evidence/{evidence_id}"
@@ -1902,6 +2082,9 @@ def test_timed_out_capture_returns_preservable_partial_evidence(tmp_path: Path) 
             execution = result["capture"]["executions"][0]
             assert execution["status"] == "failed"
             assert execution["failure_code"] == "EXECUTION_TIMEOUT"
+            assert execution["limit"]["kind"] == "timeout"
+            assert execution["limit"]["configured"] == 0.2
+            assert execution["limit"]["unit"] == "seconds"
             assert result["blocks"][1]["rows"][0]["text"] == "before-timeout"
             assert runtime.preserve_evidence(result["analysis_id"])["evidence_id"]
         finally:


### PR DESCRIPTION
Closes #410.
Closes #411.
Closes #412.
Closes #413.
Closes #414.
Closes #415.
Closes #416.
Related to #32.

## Problem

Capture provider knowledge was distributed across discovery, validation, execution, and transport code. That allowed several bounded-evidence contracts to drift: incompatible provider/capability pairs executed before failing, pytest collection events could hide every failure, composed artifact roles could collide, and capture termination did not identify the exhausted bound. Pyperf also could not preserve typed arguments containing newlines, while Python cProfile artifacts had no bounded analysis path.

The stateless rewrite also removed resolved preflight inspection and MCP output schemas, leaving callers unable to review the exact bounded request before execution or validate structured tool results from the advertised catalog.

## Change

This introduces one capture-provider registry as the authority for provider arguments, artifact roles and formats, compatibility, discovery metadata, and preflight resolution. Capture validates the same request contract before allocating scratch state or executing the target.

A new read-only `preflight_capture` operation is available through MCP and `flameox preflight`. It reports the resolved executable identity and policy decision, capture argv template, effective bounds, expected artifacts, compatibility, and an informational request digest. It creates no plan or execution authority, and capture resolves the request again before mutation.

Bounded evidence handling now also:

- isolates and projects cProfile pstats files through a typed worker;
- reserves pytest summary rows for failures, errors, interruptions, and unexecuted tests rather than collection noise;
- namespaces only colliding roles when preserving composed evidence;
- reports the exact timeout, output, or memory bound that terminated capture;
- launches pyperf targets through an encoded argv adapter so embedded newlines remain data;
- advertises compact success/error output schemas for all seven MCP tools.

Representative preflight output is intentionally request-local and non-authoritative:

```json
{
  "authoritative": false,
  "compatibility": {
    "provider_id": "pyperf",
    "capability_id": "benchmark.summary",
    "status": "compatible"
  },
  "execution_count": 1,
  "cases": [{
    "capture_argv_template": ["<python>", "-m", "pyperf", "command", "..."],
    "expected_artifacts": [{
      "role": "benchmark",
      "format": "pyperf",
      "path_template": "<request-scratch>/case-0001/benchmark.json"
    }]
  }]
}
```

## Regression coverage

The new tests prove that an incompatible pyperf/failure-summary request cannot execute its marker command, preflight leaves scratch and the target untouched, and all 15 failure identities remain reachable after 1,472 successful/failed pytest records under a ten-row page bound. Process coverage exercises multiline pyperf argv, bound reporting, artifact-role composition, and MCP schema validation over real stdio.

## Compatibility and scope

The MCP catalog grows from six to seven tools and now advertises output schemas. Existing tool names and direct structured success/error envelopes remain unchanged. Pytest table rows become diagnostic outcome records rather than a prefix of raw collection events; aggregate metrics and native artifacts remain available.

Pstats compatibility remains explicitly limited by the Python implementation and version that produced the file. Preflight is advisory by design and does not replace capture-time validation.

Suggested review order: the provider registry and shared validation in `runtime_contracts.py` and `stateless.py`; the bounded evidence projections and isolated workers; then the CLI/MCP surfaces and contract tests.

## Validation

- `uv run pytest -q` — 126 passed, 76 deselected
- `uv run pytest -m process tests/test_stateless.py::test_real_stdio_initialize_and_catalog_match_the_stateless_contract -q` — 1 passed
- `uv run ruff check src tests tools` — passed
- `uv run ruff format --check src tests tools` — 108 files already formatted
- `uv run mypy src tests tools` — no issues in 107 source files
- `uv run lint-imports` — 2 contracts kept, 0 broken
- `git diff --check` — passed