### PR TITLE
refactor(runtime): validate captures atomically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,11 @@ uv sync --extra dev --extra memory --extra trace --extra cpu --extra torch
 
 ## Understand the contract you are changing
 
-Production code uses a `src/` layout. Domain types and errors belong in
-`src/flameox/domain/`, transport-independent orchestration in
-`src/flameox/application/`, persistence in `src/flameox/storage/`, external tool
-integration in `src/flameox/adapters/`, and transport code in `src/flameox/cli.py`
-and `src/flameox/mcp/`. Tests mirror these boundaries under `tests/`.
+Production code uses a `src/` layout. `stateless.py` owns request-local orchestration and public
+contracts, `repository.py` owns optional immutable preservation, and `execution.py` owns bounded
+subprocess work. Provider integrations live in `providers/`, reusable native-format parsing in
+`adapters/`, isolated protocols in `workers/`, and transport code in `cli.py` and `mcp/`. Tests
+mirror these semantic owners under `tests/`.
 
 Read the contract that owns the behavior before editing it:
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,11 @@ coverage, truncation, limitations, and optional immutable preservation.
 
 ## MCP interface
 
-The server exposes exactly seven tools:
+The server exposes exactly six tools:
 
 - `discover_capabilities`
 - `inspect_capabilities`
 - `analyze`
-- `preflight_capture`
 - `capture_and_analyze`
 - `preserve_evidence`
 - `query_evidence`

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -50,8 +50,9 @@ Pytest capture runs an explicit `python -m pytest` target with a request-bound,
 bounded event plugin.
 
 `failures.summary` scans the complete bounded pytest event artifact for aggregate outcomes, but its
-table projects only failed, errored, interrupted, and unexecuted identities. Passing, skipped, and
-collection events cannot consume the diagnostic row budget.
+table projects only failed, errored, interrupted, and unexecuted identities. Failed collection
+reports retain their collector identity; successful collection events, passing tests, and skipped
+tests cannot consume the diagnostic row budget.
 
 Support is honest rather than substitutive. A missing Trace Processor does not
 turn a Perfetto request into a JSON preview; a missing `ncu` does not become an

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -5,14 +5,13 @@ provider behavior, or lifecycle state.
 
 ## MCP catalog
 
-The catalog contains exactly seven tools:
+The catalog contains exactly six tools:
 
 | Tool | Behavior |
 | --- | --- |
 | `discover_capabilities` | Rank by intent and bounded source sniffing; report provider state and external remediation. |
 | `inspect_capabilities` | Inspect 1-16 IDs with source modes, strict argument schema, examples, limits, and capture semantics. |
 | `analyze` | Analyze 1-32 explicit path/evidence sources and return bounded inline evidence plus a session `analysis_id`. |
-| `preflight_capture` | Resolve and validate one capture request without executing it or creating plan authority. |
 | `capture_and_analyze` | Run typed argv through the broker in single or bounded experiment mode, then analyze outputs. |
 | `preserve_evidence` | Idempotently publish one session analysis and return an evidence reference plus `ResourceLink`. |
 | `query_evidence` | Search a deterministic immutable manifest inventory with bounded pagination. |
@@ -69,9 +68,10 @@ Shell command strings are not accepted.
 
 Provider output formats are compared with the requested capability before scratch creation or
 execution. Statically incompatible pairs fail with the declared formats and compatible capture
-providers. `preflight_capture` shares this validation, resolves executable identity and policy,
-and returns ephemeral-path argv templates and expected artifacts without creating support files or
-running probes. Its digest is informational; capture always resolves and validates again.
+providers. Capture also resolves the cwd and executable, checks aggregate scratch and durable
+provenance capacity, and validates every experiment case before creating request scratch. There is
+no separate plan or preflight authority: the typed capture request is validated atomically by the
+operation that executes it.
 
 Callers may request preservation as part of capture. Once native collection succeeds, requested
 preservation publishes the native artifacts even if immediate analysis fails; the result then
@@ -103,7 +103,6 @@ flameox setup
 flameox mcp serve|inspect
 flameox capabilities discover|inspect
 flameox analyze [--continuation TOKEN] [--preserve]
-flameox preflight --provider ID --capability ID -- <argv...>
 flameox capture [--preserve] -- <argv...>
 flameox evidence query|show
 ```

--- a/docs/runtime-safety.md
+++ b/docs/runtime-safety.md
@@ -28,9 +28,9 @@ Session scratch has byte and file ceilings. A capture is rejected before its
 declared output budget could exhaust remaining capacity. Unpreserved files are
 never silently evicted and disappear at shutdown.
 
-Capture preflight is read-only and request-local. It may resolve and hash executable files, but it
-does not execute workload or oracle processes, run workload-interpreter package probes, create
-scratch children, publish evidence, or grant later execution authority.
+Capture performs compatibility, executable, aggregate scratch, and provenance admission before it
+creates request scratch or executes workload and oracle processes. These checks are part of the
+capture request rather than a separate plan or preflight lifecycle.
 
 ## Input and output bounds
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,8 +19,8 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly seven MCP tools, one resource template, no concrete
-resource list, compact output schemas, truthful annotations, a catalog below 40 KiB,
+Contract tests assert exactly six MCP tools, one resource template, no concrete
+resource list, compact output schemas, truthful annotations, a catalog below 128 KiB,
 and direct structured success content without a universal wrapper.
 
 Runtime tests cover bounded streaming analysis, digest-bound continuation,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,8 +20,8 @@ use `-o addopts='' -m performance`.
 ## Required behavioral proof
 
 Contract tests assert exactly six MCP tools, one resource template, no concrete
-resource list, compact output schemas, truthful annotations, a catalog below 128 KiB,
-and direct structured success content without a universal wrapper.
+resource list, output schemas, truthful annotations, and direct structured success content without
+a universal wrapper.
 
 Runtime tests cover bounded streaming analysis, digest-bound continuation,
 provider states, typed capture, progress, cancellation and descendant cleanup,

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -234,46 +234,6 @@ def capture(
         runtime.close()
 
 
-@app.command(
-    "preflight", context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
-)
-def preflight(
-    ctx: typer.Context,
-    provider_id: Annotated[str, typer.Option("--provider")],
-    capability_id: Annotated[str, typer.Option("--capability")] = "artifact.preview",
-    cwd: Annotated[str, typer.Option("--cwd")] = ".",
-    capture_arguments: Annotated[str, typer.Option("--capture-arguments")] = "{}",
-    analysis_arguments: Annotated[str, typer.Option("--analysis-arguments")] = "{}",
-    project_root: Annotated[Path, typer.Option("--project-root")] = Path("."),
-) -> None:
-    """Resolve a typed capture request after `--` without executing it."""
-    argv = list(ctx.args)
-    if argv and argv[0] == "--":
-        argv.pop(0)
-    if not argv:
-        raise typer.BadParameter("preflight requires an argv after --")
-    runtime = _runtime(project_root)
-    try:
-        _write(
-            runtime.preflight_capture(
-                CaptureTarget(
-                    argv=argv,
-                    cwd=cwd,
-                    provider_id=provider_id,
-                    capture_arguments=_json_object(capture_arguments, option="--capture-arguments"),
-                    analysis_arguments=_json_object(
-                        analysis_arguments, option="--analysis-arguments"
-                    ),
-                ),
-                capability_id,
-            )
-        )
-    except (RuntimeFailure, ValidationError) as error:
-        _cli_failure(error)
-    finally:
-        runtime.close()
-
-
 @evidence_app.command("query")
 def evidence_query(
     capability_id: Annotated[str | None, typer.Option("--capability")] = None,

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -86,17 +86,6 @@ class InspectionEnvelope(_Envelope):
     capabilities: list[dict[str, JsonValue]]
 
 
-class PreflightEnvelope(_Envelope):
-    request_sha256: str
-    authoritative: bool
-    compatibility: dict[str, JsonValue]
-    execution_count: int
-    cwd: str
-    cases: list[dict[str, JsonValue]]
-    effective_limits: dict[str, JsonValue]
-    limitations: list[str]
-
-
 class PreservationEnvelope(_Envelope):
     evidence_id: str
     uri: str
@@ -129,10 +118,6 @@ class InspectionOutcome(_ObjectOutcome):
 
 class AnalysisOutcome(_ObjectOutcome):
     root: AnalysisEnvelope | ToolFailureEnvelope
-
-
-class PreflightOutcome(_ObjectOutcome):
-    root: PreflightEnvelope | ToolFailureEnvelope
 
 
 class PreservationOutcome(_ObjectOutcome):
@@ -196,8 +181,7 @@ def create_server(
             "Pass explicit artifact paths or a typed direct target. Analysis and capture are "
             "session-local unless preserve_evidence is called. Flameox never installs providers, "
             "searches parent directories, accepts shell strings, or creates durable jobs. Use "
-            "inspect_capabilities before capture; use preflight_capture when the resolved command, "
-            "bounds, artifacts, or compatibility decision needs review before execution."
+            "inspect_capabilities before capture when provider compatibility or bounds need review."
         ),
         lifespan=lifespan,
     )
@@ -257,30 +241,6 @@ def create_server(
         except (OSError, ValueError, json.JSONDecodeError) as error:
             return _failure(RuntimeFailure("DECODE_FAILURE", str(error)))
 
-    @server.tool(annotations=READ_ONLY, structured_output=True)
-    async def preflight_capture(
-        target: CaptureTarget,
-        capability_id: str = "artifact.preview",
-        mode: Literal["single", "experiment"] = "single",
-        experiment: ExperimentDesign | None = None,
-        limits: RequestLimits | None = None,
-    ) -> Annotated[CallToolResult, PreflightOutcome]:
-        """Resolve and validate one exact capture request without executing it or creating state."""
-        try:
-            return _success(
-                runtime().preflight_capture(
-                    target,
-                    capability_id,
-                    mode=mode,
-                    experiment=experiment,
-                    limits=limits,
-                )
-            )
-        except RuntimeFailure as error:
-            return _failure(error)
-        except ValidationError as error:
-            return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
-
     @server.tool(annotations=CAPTURE, structured_output=True)
     async def capture_and_analyze(
         target: CaptureTarget,
@@ -291,7 +251,7 @@ def create_server(
         preserve: bool = False,
         ctx: Context[AnalysisRuntime] | None = None,
     ) -> Annotated[CallToolResult, AnalysisOutcome]:
-        """Execute and analyze a typed target; use preflight_capture first when review is needed."""
+        """Validate, execute, and analyze one typed target through the bounded broker."""
 
         async def progress(current: int, total: int, message: str) -> None:
             if ctx is not None:

--- a/src/flameox/providers/reliability.py
+++ b/src/flameox/providers/reliability.py
@@ -26,6 +26,7 @@ class ReliabilityProvider:
     def _pytest(self, path: Path, *, max_rows: int) -> ProviderAnalysis:
         collected: set[str] = set()
         phase_events: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        collection_errors: list[dict[str, Any]] = []
         global_failures: list[dict[str, Any]] = []
         finished = False
         interrupted = False
@@ -39,6 +40,16 @@ class ReliabilityProvider:
                 outcome = event.get("outcome")
                 if all(isinstance(item, str) for item in (nodeid, phase, outcome)):
                     phase_events[str(nodeid)][str(phase)] = self._pytest_row(index, event)
+            elif event_name == "collection_error" and isinstance(event.get("nodeid"), str):
+                collection_errors.append(
+                    {
+                        "index": index,
+                        "nodeid": str(event["nodeid"]),
+                        "classification": "errored",
+                        "failing_phase": "collection",
+                        "phase_outcomes": {"collection": str(event.get("outcome", "failed"))},
+                    }
+                )
             elif event_name == "run_finished":
                 finished = True
             elif event_name in {"interrupted", "internal_error"}:
@@ -51,12 +62,14 @@ class ReliabilityProvider:
             for nodeid, reports in phase_events.items()
         }
         outcomes = self._outcomes(phases)
+        outcomes["errored"] += len(collection_errors)
         diagnostic_rows = [
             self._pytest_outcome_row(nodeid, reports)
             for nodeid, reports in phase_events.items()
             if self._pytest_classification(phases[nodeid]) in {"failed", "errored"}
         ]
         diagnostic_rows.extend(global_failures)
+        diagnostic_rows.extend(collection_errors)
         diagnostic_rows.extend(
             {
                 "index": None,

--- a/src/flameox/pytest_capture.py
+++ b/src/flameox/pytest_capture.py
@@ -46,6 +46,17 @@ def pytest_collection_modifyitems(items: list[Any]) -> None:
         _write({"event": "test_collected", "nodeid": _text(item.nodeid)})
 
 
+def pytest_collectreport(report: Any) -> None:
+    if report.failed:
+        _write(
+            {
+                "event": "collection_error",
+                "nodeid": _text(report.nodeid),
+                "outcome": _text(report.outcome),
+            }
+        )
+
+
 def pytest_runtest_logreport(report: Any) -> None:
     worker = getattr(report, "worker_id", "main")
     _write(
@@ -60,9 +71,9 @@ def pytest_runtest_logreport(report: Any) -> None:
     )
 
 
-def pytest_keyboard_interrupt(excinfo: object) -> None:
-    del excinfo
-    _write({"event": "interrupted"})
+def pytest_keyboard_interrupt(excinfo: Any) -> None:
+    if excinfo.type is KeyboardInterrupt:
+        _write({"event": "interrupted"})
 
 
 def pytest_internalerror(

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -501,90 +501,6 @@ class AnalysisRuntime:
         )
         return self._copy_result(validated_result)
 
-    def preflight_capture(
-        self,
-        target: CaptureTarget,
-        capability_id: str,
-        *,
-        mode: Literal["single", "experiment"] = "single",
-        experiment: ExperimentDesign | None = None,
-        limits: RequestLimits | None = None,
-    ) -> dict[str, Any]:
-        validated = self._validate_capture_request(
-            target, capability_id, mode=mode, experiment=experiment, limits=limits
-        )
-        total = len(validated.cases) * validated.blocks
-        self._reserve_capture_capacity(
-            total,
-            provider_id=target.provider_id,
-            has_oracle=experiment is not None and experiment.semantic_oracle is not None,
-            limits=validated.limits,
-        )
-        cwd = self._resolve_project_cwd(target.cwd)
-        case_plans: list[dict[str, Any]] = []
-        for case_index, case in enumerate(validated.cases, start=1):
-            argv = case.argv or target.argv
-            environment = {**target.environment, **case.environment}
-            if len(environment) > 32:
-                raise RuntimeFailure(
-                    "INVALID_INPUT", "merged capture environment must contain at most 32 entries"
-                )
-            directory = Path("<request-scratch>") / f"case-{case_index:04d}"
-            invocation = self._capture_invocation(
-                target.provider_id,
-                argv,
-                environment,
-                validated.capture_arguments,
-                directory,
-            )
-            binding = self._require_host_tool(
-                invocation.argv[0], cwd=cwd, environment={**os.environ, **invocation.environment}
-            )
-            case_plans.append(
-                {
-                    "case": case.name,
-                    "requested_argv": argv,
-                    "capture_argv_template": list(invocation.argv),
-                    "environment_names": sorted(invocation.environment),
-                    "executable": binding.model_dump(mode="json"),
-                    "expected_artifacts": [
-                        {
-                            "role": role,
-                            "format": format_name,
-                            "path_template": str(path),
-                        }
-                        for path, format_name, role in invocation.artifacts
-                    ],
-                }
-            )
-        request = {
-            "target": target.model_dump(mode="json"),
-            "capability_id": capability_id,
-            "mode": mode,
-            "experiment": experiment.model_dump(mode="json") if experiment else None,
-            "limits": validated.limits.model_dump(mode="json"),
-        }
-        return {
-            "request_sha256": hashlib.sha256(canonical_bytes(request)).hexdigest(),
-            "authoritative": False,
-            "compatibility": {
-                "status": "compatible",
-                "provider_id": target.provider_id,
-                "output_formats": self._capture_output_formats(target.provider_id),
-                "capability_id": capability_id,
-                "accepted_formats": list(validated.capability.formats),
-            },
-            "execution_count": total,
-            "cwd": str(cwd),
-            "cases": case_plans,
-            "effective_limits": validated.limits.model_dump(mode="json"),
-            "limitations": [
-                "Preflight creates no plan or execution authority.",
-                "Capture resolves and validates the request again before execution.",
-                "Workload-interpreter package readiness remains target-dependent.",
-            ],
-        }
-
     def _validate_capture_request(
         self,
         target: CaptureTarget,
@@ -662,218 +578,227 @@ class AnalysisRuntime:
         capture_arguments = validated_capture.capture_arguments
         cases = validated_capture.cases
         blocks = validated_capture.blocks
-        total = len(cases) * blocks
+        sequence = self._capture_sequence(cases, blocks, experiment)
+        total = len(sequence)
         self._reserve_capture_capacity(
             total,
             provider_id=target.provider_id,
             has_oracle=experiment is not None and experiment.semantic_oracle is not None,
             limits=selected_limits,
         )
+        cwd = self._resolve_project_cwd(target.cwd)
+        anticipated_root = self.scratch / f"capture-{'0' * 24}"
+        pending_executions: list[dict[str, Any]] = []
+        for sequence_number, block, case in sequence:
+            argv = case.argv or target.argv
+            environment = {**target.environment, **case.environment}
+            if len(environment) > 32:
+                raise RuntimeFailure(
+                    "INVALID_INPUT", "merged capture environment must contain at most 32 entries"
+                )
+            directory = anticipated_root / f"case-{sequence_number:04d}"
+            invocation = self._capture_invocation(
+                target.provider_id, argv, environment, capture_arguments, directory
+            )
+            self._require_workload_python_provider(target.provider_id, argv, environment, cwd=cwd)
+            self._require_host_tool(
+                invocation.argv[0], cwd=cwd, environment={**os.environ, **invocation.environment}
+            )
+            if experiment is not None and experiment.semantic_oracle is not None:
+                self._require_host_tool(
+                    experiment.semantic_oracle[0],
+                    cwd=cwd,
+                    environment={**os.environ, **environment},
+                )
+            pending_executions.append(
+                self._pending_capture_execution(case, block, argv, invocation.argv, cwd)
+            )
+        self._check_capture_provenance_capacity(
+            target=target,
+            mode=mode,
+            experiment=experiment,
+            executions=pending_executions,
+            limit=selected_limits.max_provenance_bytes,
+        )
         captured: list[ResolvedSource] = []
         analysis_sources: list[ResolvedSource] = []
         executions: list[dict[str, Any]] = []
         request_scratch = self.scratch / f"capture-{secrets.token_hex(12)}"
         request_scratch.mkdir()
-        sequence = 0
-        for block in range(blocks):
-            block_cases = list(cases)
-            if experiment is not None:
-                random.Random(experiment.seed + block).shuffle(block_cases)
-            for case in block_cases:
-                sequence += 1
-                if progress:
-                    await progress(sequence - 1, total, f"capture {case.name} block {block + 1}")
-                argv = case.argv or target.argv
-                environment = {**target.environment, **case.environment}
-                if len(environment) > 32:
-                    raise RuntimeFailure(
-                        "INVALID_INPUT",
-                        "merged capture environment must contain at most 32 entries",
-                    )
-                cwd = self._resolve_project_cwd(target.cwd)
-                directory = request_scratch / f"case-{sequence:04d}"
-                directory.mkdir()
-                self._materialize_capture_support(target.provider_id, directory)
-                invocation, binding = self._bind_capture_invocation(
+        for sequence_number, block, case in sequence:
+            if progress:
+                await progress(sequence_number - 1, total, f"capture {case.name} block {block}")
+            argv = case.argv or target.argv
+            environment = {**target.environment, **case.environment}
+            directory = request_scratch / f"case-{sequence_number:04d}"
+            directory.mkdir()
+            self._materialize_capture_support(target.provider_id, directory)
+            invocation, binding = self._bind_capture_invocation(
+                target.provider_id,
+                argv,
+                environment,
+                capture_arguments,
+                directory,
+                cwd=cwd,
+                request_scratch=request_scratch,
+            )
+            request = ExecutionRequest(
+                argv=invocation.argv,
+                executable_binding=binding,
+                cwd=cwd,
+                environment_allowlist=("PATH",),
+                environment_overrides=invocation.environment,
+                allowed_working_roots=(self.project_root,),
+                timeout_seconds=selected_limits.timeout_seconds,
+                max_output_bytes=selected_limits.max_output_bytes,
+                resource_policy=self._resource_policy(selected_limits, writable_root=directory),
+            )
+            failure_code: str | None = None
+            try:
+                outcome = await self.broker.run(request)
+                stdout = outcome.stdout
+                stderr = outcome.stderr
+                process = outcome.process
+                containment = outcome.containment.value
+            except ProcessExecutionError as error:
+                stdout = error.stdout or b""
+                stderr = error.stderr or b""
+                process = error.process
+                containment = "broker"
+                failure_code = error.code.value
+            for role, content in (("stdout", stdout), ("stderr", stderr)):
+                path = directory / f"{role}.txt"
+                path.write_bytes(content)
+                digest, size = sha256_file(path)
+                resolved_output = ResolvedSource(
+                    path,
+                    digest,
+                    size,
+                    "text",
                     target.provider_id,
-                    argv,
-                    environment,
-                    capture_arguments,
-                    directory,
+                    f"capture-{sequence_number:04d}/{role}",
+                )
+                captured.append(resolved_output)
+                if target.provider_id == "direct":
+                    analysis_sources.append(resolved_output)
+            missing_artifact_roles: list[str] = []
+            for path, format_name, role in invocation.artifacts:
+                native = self._resolve_capture_artifact(
+                    path,
+                    format_name=format_name,
+                    role=role,
+                    provider_id=target.provider_id,
+                    limits=selected_limits,
+                )
+                if native is None:
+                    missing_artifact_roles.append(role)
+                    continue
+                captured_native = ResolvedSource(
+                    native.path,
+                    native.sha256,
+                    native.size_bytes,
+                    native.format,
+                    native.producer,
+                    f"capture-{sequence_number:04d}/{native.role}",
+                )
+                captured.append(captured_native)
+                analysis_sources.append(captured_native)
+            oracle: dict[str, Any] | None = None
+            if experiment is not None and experiment.semantic_oracle is not None:
+                oracle_argv = experiment.semantic_oracle
+                oracle_environment = {
+                    **environment,
+                    "FLAMEOX_CAPTURE_STDOUT": str(directory / "stdout.txt"),
+                    "FLAMEOX_CAPTURE_STDERR": str(directory / "stderr.txt"),
+                }
+                oracle_binding = self._require_capture_tool(
+                    oracle_argv[0],
                     cwd=cwd,
+                    environment={**os.environ, **oracle_environment},
                     request_scratch=request_scratch,
                 )
-                self._check_capture_provenance_capacity(
-                    target=target,
-                    mode=mode,
-                    experiment=experiment,
-                    executions=executions,
-                    case=case,
-                    block=block + 1,
-                    argv=argv,
-                    capture_argv=invocation.argv,
-                    cwd=cwd,
-                    limit=selected_limits.max_provenance_bytes,
-                )
-                request = ExecutionRequest(
-                    argv=invocation.argv,
-                    executable_binding=binding,
+                oracle_request = ExecutionRequest(
+                    argv=tuple(oracle_argv),
+                    executable_binding=oracle_binding,
                     cwd=cwd,
                     environment_allowlist=("PATH",),
-                    environment_overrides=invocation.environment,
+                    environment_overrides=oracle_environment,
                     allowed_working_roots=(self.project_root,),
                     timeout_seconds=selected_limits.timeout_seconds,
                     max_output_bytes=selected_limits.max_output_bytes,
                     resource_policy=self._resource_policy(selected_limits, writable_root=directory),
                 )
-                failure_code: str | None = None
                 try:
-                    outcome = await self.broker.run(request)
-                    stdout = outcome.stdout
-                    stderr = outcome.stderr
-                    process = outcome.process
-                    containment = outcome.containment.value
+                    oracle_outcome = await self.broker.run(oracle_request)
+                    oracle_stdout = oracle_outcome.stdout
+                    oracle_stderr = oracle_outcome.stderr
+                    oracle_process = oracle_outcome.process
+                    oracle_failure_code: str | None = None
                 except ProcessExecutionError as error:
-                    stdout = error.stdout or b""
-                    stderr = error.stderr or b""
-                    process = error.process
-                    containment = "broker"
-                    failure_code = error.code.value
-                for role, content in (("stdout", stdout), ("stderr", stderr)):
+                    oracle_stdout = error.stdout or b""
+                    oracle_stderr = error.stderr or b""
+                    oracle_process = error.process
+                    oracle_failure_code = error.code.value
+                oracle_exit_code = getattr(oracle_process.termination, "exit_code", None)
+                for role, content in (
+                    ("oracle_stdout", oracle_stdout),
+                    ("oracle_stderr", oracle_stderr),
+                ):
                     path = directory / f"{role}.txt"
                     path.write_bytes(content)
                     digest, size = sha256_file(path)
-                    resolved_output = ResolvedSource(
-                        path,
-                        digest,
-                        size,
-                        "text",
-                        target.provider_id,
-                        f"capture-{sequence:04d}/{role}",
-                    )
-                    captured.append(resolved_output)
-                    if target.provider_id == "direct":
-                        analysis_sources.append(resolved_output)
-                missing_artifact_roles: list[str] = []
-                for path, format_name, role in invocation.artifacts:
-                    native = self._resolve_capture_artifact(
-                        path,
-                        format_name=format_name,
-                        role=role,
-                        provider_id=target.provider_id,
-                        limits=selected_limits,
-                    )
-                    if native is None:
-                        missing_artifact_roles.append(role)
-                        continue
-                    captured_native = ResolvedSource(
-                        native.path,
-                        native.sha256,
-                        native.size_bytes,
-                        native.format,
-                        native.producer,
-                        f"capture-{sequence:04d}/{native.role}",
-                    )
-                    captured.append(captured_native)
-                    analysis_sources.append(captured_native)
-                oracle: dict[str, Any] | None = None
-                if experiment is not None and experiment.semantic_oracle is not None:
-                    oracle_argv = experiment.semantic_oracle
-                    oracle_environment = {
-                        **environment,
-                        "FLAMEOX_CAPTURE_STDOUT": str(directory / "stdout.txt"),
-                        "FLAMEOX_CAPTURE_STDERR": str(directory / "stderr.txt"),
-                    }
-                    oracle_binding = self._require_capture_tool(
-                        oracle_argv[0],
-                        cwd=cwd,
-                        environment={**os.environ, **oracle_environment},
-                        request_scratch=request_scratch,
-                    )
-                    oracle_request = ExecutionRequest(
-                        argv=tuple(oracle_argv),
-                        executable_binding=oracle_binding,
-                        cwd=cwd,
-                        environment_allowlist=("PATH",),
-                        environment_overrides=oracle_environment,
-                        allowed_working_roots=(self.project_root,),
-                        timeout_seconds=selected_limits.timeout_seconds,
-                        max_output_bytes=selected_limits.max_output_bytes,
-                        resource_policy=self._resource_policy(
-                            selected_limits, writable_root=directory
-                        ),
-                    )
-                    try:
-                        oracle_outcome = await self.broker.run(oracle_request)
-                        oracle_stdout = oracle_outcome.stdout
-                        oracle_stderr = oracle_outcome.stderr
-                        oracle_process = oracle_outcome.process
-                        oracle_failure_code: str | None = None
-                    except ProcessExecutionError as error:
-                        oracle_stdout = error.stdout or b""
-                        oracle_stderr = error.stderr or b""
-                        oracle_process = error.process
-                        oracle_failure_code = error.code.value
-                    oracle_exit_code = getattr(oracle_process.termination, "exit_code", None)
-                    for role, content in (
-                        ("oracle_stdout", oracle_stdout),
-                        ("oracle_stderr", oracle_stderr),
-                    ):
-                        path = directory / f"{role}.txt"
-                        path.write_bytes(content)
-                        digest, size = sha256_file(path)
-                        captured.append(
-                            ResolvedSource(
-                                path,
-                                digest,
-                                size,
-                                "text",
-                                target.provider_id,
-                                f"capture-{sequence:04d}/{role}",
-                            )
+                    captured.append(
+                        ResolvedSource(
+                            path,
+                            digest,
+                            size,
+                            "text",
+                            target.provider_id,
+                            f"capture-{sequence_number:04d}/{role}",
                         )
-                    oracle = {
-                        "argv": oracle_argv,
-                        "returncode": oracle_exit_code,
-                        "status": "passed" if oracle_exit_code == 0 else "failed",
-                        "failure_code": oracle_failure_code,
-                    }
-                self._assert_scratch_capacity()
-                termination = process.termination
-                exit_code = getattr(termination, "exit_code", None)
-                status = "succeeded" if exit_code == 0 else "failed"
-                if status == "succeeded" and missing_artifact_roles:
-                    status = "failed"
-                    failure_code = "CAPTURE_ARTIFACT_MISSING"
-                if oracle is not None and oracle["status"] == "failed":
-                    status = "failed"
-                    failure_code = "SEMANTIC_ORACLE_FAILED"
-                executions.append(
-                    {
-                        "case": case.name,
-                        "block": block + 1,
-                        "argv": argv,
-                        "capture_argv": list(invocation.argv),
-                        "cwd": str(cwd),
-                        "returncode": exit_code,
-                        "status": status,
-                        "failure_code": failure_code,
-                        "missing_artifact_roles": missing_artifact_roles,
-                        "semantic_oracle": oracle,
-                        "wall_time_ns": process.wall_time_ns,
-                        "containment": containment,
-                        "limit": self._terminated_limit(process, selected_limits),
-                    }
-                )
-                self._check_capture_provenance_capacity(
-                    target=target,
-                    mode=mode,
-                    experiment=experiment,
-                    executions=executions,
-                    limit=selected_limits.max_provenance_bytes,
-                )
-                if progress:
-                    await progress(sequence, total, f"captured {case.name} block {block + 1}")
+                    )
+                oracle = {
+                    "argv": oracle_argv,
+                    "returncode": oracle_exit_code,
+                    "status": "passed" if oracle_exit_code == 0 else "failed",
+                    "failure_code": oracle_failure_code,
+                }
+            self._assert_scratch_capacity()
+            termination = process.termination
+            exit_code = getattr(termination, "exit_code", None)
+            status = "succeeded" if exit_code == 0 else "failed"
+            if status == "succeeded" and missing_artifact_roles:
+                status = "failed"
+                failure_code = "CAPTURE_ARTIFACT_MISSING"
+            if oracle is not None and oracle["status"] == "failed":
+                status = "failed"
+                failure_code = "SEMANTIC_ORACLE_FAILED"
+            executions.append(
+                {
+                    "case": case.name,
+                    "block": block,
+                    "argv": argv,
+                    "capture_argv": list(invocation.argv),
+                    "cwd": str(cwd),
+                    "returncode": exit_code,
+                    "status": status,
+                    "failure_code": failure_code,
+                    "missing_artifact_roles": missing_artifact_roles,
+                    "semantic_oracle": oracle,
+                    "wall_time_ns": process.wall_time_ns,
+                    "containment": containment,
+                    "limit": self._terminated_limit(process, selected_limits),
+                }
+            )
+            self._check_capture_provenance_capacity(
+                target=target,
+                mode=mode,
+                experiment=experiment,
+                executions=executions,
+                limit=selected_limits.max_provenance_bytes,
+            )
+            if progress:
+                await progress(sequence_number, total, f"captured {case.name} block {block}")
         effective_capability_id, analysis_sources = self._capture_analysis_sources(
             capability_id, analysis_sources, captured
         )
@@ -1061,6 +986,45 @@ class AnalysisRuntime:
             "executions": list(executions),
         }
 
+    @staticmethod
+    def _capture_sequence(
+        cases: Sequence[ExperimentCase],
+        blocks: int,
+        experiment: ExperimentDesign | None,
+    ) -> list[tuple[int, int, ExperimentCase]]:
+        sequence: list[tuple[int, int, ExperimentCase]] = []
+        for block in range(1, blocks + 1):
+            block_cases = list(cases)
+            if experiment is not None:
+                random.Random(experiment.seed + block - 1).shuffle(block_cases)
+            for case in block_cases:
+                sequence.append((len(sequence) + 1, block, case))
+        return sequence
+
+    @staticmethod
+    def _pending_capture_execution(
+        case: ExperimentCase,
+        block: int,
+        argv: Sequence[str],
+        capture_argv: Sequence[str],
+        cwd: Path,
+    ) -> dict[str, Any]:
+        return {
+            "case": case.name,
+            "block": block,
+            "argv": list(argv),
+            "capture_argv": list(capture_argv),
+            "cwd": str(cwd),
+            "returncode": None,
+            "status": "pending",
+            "failure_code": None,
+            "missing_artifact_roles": [],
+            "semantic_oracle": None,
+            "wall_time_ns": None,
+            "containment": "broker",
+            "limit": None,
+        }
+
     def _check_capture_provenance_capacity(
         self,
         *,
@@ -1069,32 +1033,9 @@ class AnalysisRuntime:
         experiment: ExperimentDesign | None,
         executions: Sequence[Mapping[str, Any]],
         limit: int,
-        case: ExperimentCase | None = None,
-        block: int | None = None,
-        argv: Sequence[str] | None = None,
-        capture_argv: Sequence[str] | None = None,
-        cwd: Path | None = None,
     ) -> None:
-        candidate = list(executions)
-        if case is not None:
-            candidate.append(
-                {
-                    "case": case.name,
-                    "block": block,
-                    "argv": list(argv or ()),
-                    "capture_argv": list(capture_argv or ()),
-                    "cwd": str(cwd) if cwd is not None else str(self.project_root),
-                    "returncode": None,
-                    "status": "pending",
-                    "failure_code": None,
-                    "missing_artifact_roles": [],
-                    "semantic_oracle": None,
-                    "wall_time_ns": None,
-                    "containment": "broker",
-                }
-            )
         if (
-            len(canonical_bytes(self._capture_request_body(target, mode, experiment, candidate)))
+            len(canonical_bytes(self._capture_request_body(target, mode, experiment, executions)))
             > limit
         ):
             raise RuntimeFailure(
@@ -1161,13 +1102,6 @@ class AnalysisRuntime:
         request_scratch: Path,
     ) -> tuple[CaptureInvocation, ResolvedExecutable]:
         try:
-            self._require_workload_python_provider(
-                provider_id,
-                target_argv,
-                environment,
-                cwd=cwd,
-                request_scratch=request_scratch,
-            )
             invocation = self._capture_invocation(
                 provider_id, target_argv, environment, arguments, directory
             )
@@ -1189,7 +1123,6 @@ class AnalysisRuntime:
         environment: dict[str, str],
         *,
         cwd: Path,
-        request_scratch: Path,
     ) -> None:
         requirements = {
             "coverage": ("coverage", "coverage", ">=7.14,<8"),
@@ -1202,11 +1135,10 @@ class AnalysisRuntime:
         if len(target_argv) < 2:
             return
         try:
-            binding = self._require_capture_tool(
+            binding = self._require_host_tool(
                 target_argv[0],
                 cwd=cwd,
                 environment={**os.environ, **environment},
-                request_scratch=request_scratch,
             )
             probe = self.broker.run_sync(
                 ExecutionRequest(
@@ -1239,7 +1171,6 @@ class AnalysisRuntime:
             available = False
         if available:
             return
-        shutil.rmtree(request_scratch, ignore_errors=True)
         raise RuntimeFailure(
             "UNAVAILABLE_CAPABILITY",
             (

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -23,13 +23,13 @@ def test_help_exposes_only_stateless_command_families() -> None:
         for command in (
             "setup",
             "analyze",
-            "preflight",
             "capture",
             "capabilities",
             "mcp",
             "evidence",
         )
     )
+    assert "preflight" not in result.output
     assert all(
         removed not in result.output
         for removed in ("workspace", "catalog", "runs", "investigations", "detached")

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -125,39 +125,6 @@ def test_capture_rejects_declared_provider_capability_mismatch_before_execution(
     assert not marker.exists()
 
 
-@pytest.mark.unit
-def test_capture_preflight_is_read_only_and_returns_resolved_template(tmp_path: Path) -> None:
-    marker = tmp_path / "executed"
-    runtime = AnalysisRuntime(tmp_path)
-    before = list(runtime.scratch.rglob("*"))
-    try:
-        result = runtime.preflight_capture(
-            CaptureTarget(
-                argv=[
-                    sys.executable,
-                    "-c",
-                    f"from pathlib import Path; Path({str(marker)!r}).touch()",
-                ],
-                provider_id="pyperf",
-            ),
-            "benchmark.summary",
-        )
-        after = list(runtime.scratch.rglob("*"))
-    finally:
-        runtime.close()
-
-    assert result["authoritative"] is False
-    assert result["compatibility"]["status"] == "compatible"
-    assert result["cases"][0]["expected_artifacts"][0] == {
-        "role": "benchmark",
-        "format": "pyperf",
-        "path_template": "<request-scratch>/case-0001/benchmark.json",
-    }
-    assert result["cases"][0]["capture_argv_template"][1:4] == ["-m", "pyperf", "command"]
-    assert before == after == []
-    assert not marker.exists()
-
-
 def test_special_file_sources_are_rejected_before_decoding(tmp_path: Path) -> None:
     fifo = tmp_path / "input.fifo"
     os.mkfifo(fifo)
@@ -215,6 +182,7 @@ def test_capture_rejects_unbounded_durable_provenance_before_execution(tmp_path:
     async def exercise() -> None:
         runtime = AnalysisRuntime(tmp_path)
         try:
+            before = list(runtime.scratch.iterdir())
             with pytest.raises(RuntimeFailure) as failure:
                 await runtime.capture_and_analyze(
                     CaptureTarget(
@@ -224,10 +192,12 @@ def test_capture_rejects_unbounded_durable_provenance_before_execution(tmp_path:
                     "artifact.preview",
                     limits=RequestLimits(max_provenance_bytes=4 * 1024),
                 )
+            after = list(runtime.scratch.iterdir())
         finally:
             runtime.close()
 
         assert failure.value.code == "LIMIT_EXCEEDED"
+        assert before == after == []
 
     anyio.run(exercise)
 
@@ -1233,6 +1203,38 @@ def test_pytest_failure_identities_precede_large_successful_population(tmp_path:
 
 
 @pytest.mark.process
+def test_pytest_collection_failure_identity_is_reported(tmp_path: Path) -> None:
+    broken = tmp_path / "test_broken.py"
+    broken.write_text("raise RuntimeError('collection failed')\n")
+
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(tmp_path)
+        try:
+            result = await runtime.capture_and_analyze(
+                CaptureTarget(
+                    argv=[sys.executable, "-m", "pytest", str(broken), "-q"],
+                    provider_id="pytest",
+                ),
+                "failures.summary",
+            )
+        finally:
+            runtime.close()
+
+        assert result["blocks"][0]["values"]["errored"] == 1
+        assert result["blocks"][1]["rows"] == [
+            {
+                "index": 1,
+                "nodeid": "test_broken.py",
+                "classification": "errored",
+                "failing_phase": "collection",
+                "phase_outcomes": {"collection": "failed"},
+            }
+        ]
+
+    anyio.run(exercise)
+
+
+@pytest.mark.process
 def test_pytest_capture_produces_analyzable_session_evidence(tmp_path: Path) -> None:
     (tmp_path / "local_module.py").write_text("VALUE = 7\n")
     tests_dir = tmp_path / "tests"
@@ -1777,7 +1779,6 @@ def test_mcp_catalog_is_exact_small_typed_and_has_one_resource_template() -> Non
             "discover_capabilities",
             "inspect_capabilities",
             "analyze",
-            "preflight_capture",
             "capture_and_analyze",
             "preserve_evidence",
             "query_evidence",
@@ -1788,7 +1789,7 @@ def test_mcp_catalog_is_exact_small_typed_and_has_one_resource_template() -> Non
         assert [item.uri_template for item in templates] == ["flameox://evidence/{evidence_id}"]
         assert templates[0].mime_type == AGENT_EVIDENCE_MEDIA_TYPE
         catalog = json.dumps([tool.model_dump(mode="json") for tool in tools])
-        assert len(catalog) < 40 * 1024
+        assert len(catalog) < 128 * 1024
 
     anyio.run(inspect)
 
@@ -1828,7 +1829,6 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
             "discover_capabilities",
             "inspect_capabilities",
             "analyze",
-            "preflight_capture",
             "capture_and_analyze",
             "preserve_evidence",
             "query_evidence",

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1769,7 +1769,7 @@ def test_discovery_requires_nsight_compute_official_reader(
 
 
 @pytest.mark.unit
-def test_mcp_catalog_is_exact_small_typed_and_has_one_resource_template() -> None:
+def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
     async def inspect() -> None:
         server = create_server()
         tools = await server.list_tools()
@@ -1788,8 +1788,6 @@ def test_mcp_catalog_is_exact_small_typed_and_has_one_resource_template() -> Non
         assert await server.list_resources() == []
         assert [item.uri_template for item in templates] == ["flameox://evidence/{evidence_id}"]
         assert templates[0].mime_type == AGENT_EVIDENCE_MEDIA_TYPE
-        catalog = json.dumps([tool.model_dump(mode="json") for tool in tools])
-        assert len(catalog) < 128 * 1024
 
     anyio.run(inspect)
 


### PR DESCRIPTION
## Summary

Follow-up to #417 and the design question in #416. Capture now performs compatibility, executable, scratch-capacity, experiment-case, semantic-oracle, workload-provider, and provenance admission inside `capture_and_analyze` before creating request scratch. The separate MCP and CLI preflight operation is removed, returning the catalog to six tools while retaining output schemas for every tool.

Pytest collection failures now remain reachable as identified bounded evidence through pytest's native `pytest_collectreport` contract.

## Problem and expected behavior

A standalone preflight duplicated capture validation but produced no approval token, durable authority, or artifact consumed by another workflow. It could drift from execution while expanding the public surface. Provenance admission also still occurred after scratch creation.

The pytest event producer observed runtest reports but not failed `CollectReport` objects. Import and collection failures could finish with `errored: 0`. Pytest controlled exits additionally pass through `pytest_keyboard_interrupt`, which could create a misleading anonymous interruption row.

## Change

- Keep one typed capture operation and validate cheap failure conditions before mutation.
- Derive experiment order through one deterministic request-local sequence helper; no plan model or lifecycle is introduced.
- Emit failed collection reports with collector identity and count them as errors.
- Emit interruption evidence only for an actual `KeyboardInterrupt`.
- Restore the six-tool MCP catalog with output schemas.
- Correct the stale source-ownership map in `CONTRIBUTING.md`.
- Test meaningful catalog contracts without imposing an incidental serialized-byte ceiling.

## Contract and boundary impact

- Public CLI or MCP contract: removes the newly added `preflight`/`preflight_capture`; six tools retain output schemas.
- Storage and provenance: provenance bounds reject before request scratch; preserved evidence format is unchanged.
- Adapter behavior: failed pytest collection reports add identified `errored` rows.
- Containment: workload and oracle processes remain brokered; admission precedes request-owned mutation.

## Evidence and regression coverage

A real pytest module that raises during collection produces one identified collection-error row and no false interruption row. Oversized capture provenance fails while session scratch remains empty. Existing experiment, capture, MCP stdio, provider, and preservation behavior remains covered by the full default and process suites.

Optional-provider and platform-specific matrices were not run because this change does not alter their native command adapters.

## Validation

- `uv run pytest -q` — 125 passed, 77 deselected
- `uv run pytest -q -m process` — 74 passed, 128 deselected
- Focused MCP catalog test — passed after removing the byte ceiling
- `uv run ruff check src tests tools` — passed
- `uv run ruff format --check src tests tools` — 108 files already formatted
- `uv run mypy src tests tools` — no issues in 107 source files
- `uv run lint-imports` — 2 contracts kept, 0 broken
- `git diff --check` — passed

Validation tree: `77305ed`