### PR TITLE
feat(mcp): restore explicit provider preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ coverage, truncation, limitations, and optional immutable preservation.
 
 ## MCP interface
 
-The server exposes exactly six tools:
+The server exposes exactly seven tools:
 
 - `discover_capabilities`
 - `inspect_capabilities`
+- `prepare_capabilities`
 - `analyze`
 - `capture_and_analyze`
 - `preserve_evidence`
@@ -91,7 +92,11 @@ restart-surviving tasks.
 Managed external collectors such as py-spy execute from Flameox's uv tool
 environment. In-process collectors such as coverage.py and Memray are verified
 in, and run with, the workload's declared Python interpreter. Flameox does not
-substitute one Python runtime for the other.
+substitute one Python runtime for the other. When discovery reports a missing
+managed provider, `prepare_capabilities` explicitly installs its version-pinned
+extra and returns the launcher to use after reconnecting. Host tools, drivers,
+and permissions are never installed or changed; the same result reports their
+setup guidance.
 
 ## Evidence quality
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,9 +55,10 @@ One registry entry owns a capability descriptor, strict argument model,
 accepted formats, provider probes, and capture/analysis semantics. Discovery
 performs only bounded suffix/header sniffing. Missing packages, executables,
 permissions, versions, or platforms are successful discovery states; Flameox
-never installs remediation automatically. The separately invoked CLI setup
-command may install an explicitly selected Python provider-extra set into a uv
-tool environment; it creates no project state and owns no durable operation.
+never installs remediation automatically. The separately invoked CLI setup command or MCP
+`prepare_capabilities` tool may install an explicitly selected Python provider-extra set into a uv
+tool environment; neither creates project state nor owns a durable operation. Host profilers,
+drivers, and permissions remain external and receive guidance only.
 
 Direct capture is trusted local execution, not containment. Typed argv prevents
 shell interpretation, while the broker provides process-group cleanup, bounded

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -38,7 +38,9 @@ already configured Flameox extras, verifies the resulting managed-tool receipt, 
 the MCP client must reconnect. Repeating a fully satisfied request is a no-op. System profilers,
 drivers, device access, and OS permissions remain external requirements; Flameox returns guidance
 for them but does not invoke a system package manager or elevate privileges. Preparation creates no
-project state, durable job, plan, or setup receipt of its own.
+project state, durable job, plan, or setup receipt of its own. The result distinguishes configured
+managed providers from external requirements; a provider such as Perfetto may appear in both when
+its Python support is configured but its host Trace Processor still needs setup.
 
 ## Sources and limits
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -5,12 +5,13 @@ provider behavior, or lifecycle state.
 
 ## MCP catalog
 
-The catalog contains exactly six tools:
+The catalog contains exactly seven tools:
 
 | Tool | Behavior |
 | --- | --- |
 | `discover_capabilities` | Rank by intent and bounded source sniffing; report provider state and external remediation. |
 | `inspect_capabilities` | Inspect 1-16 IDs with source modes, strict argument schema, examples, limits, and capture semantics. |
+| `prepare_capabilities` | Explicitly install 1-16 selected Flameox-managed providers and return a reconnect launcher; report host-tool guidance without changing the host. |
 | `analyze` | Analyze 1-32 explicit path/evidence sources and return bounded inline evidence plus a session `analysis_id`. |
 | `capture_and_analyze` | Run typed argv through the broker in single or bounded experiment mode, then analyze outputs. |
 | `preserve_evidence` | Idempotently publish one session analysis and return an evidence reference plus `ResourceLink`. |
@@ -31,6 +32,13 @@ Every tool advertises a compact output schema for its stable result envelope. Pr
 metrics and rows remain open JSON values. Success uses structured content directly, without an
 `ok/result/error` wrapper. Tool failures set `isError=true` and carry a stable code, message, and
 details; both success and failure shapes validate against the advertised schema.
+
+`prepare_capabilities` is the only open-world tool. It may resolve packages through `uv`, retains
+already configured Flameox extras, verifies the resulting managed-tool receipt, and reports whether
+the MCP client must reconnect. Repeating a fully satisfied request is a no-op. System profilers,
+drivers, device access, and OS permissions remain external requirements; Flameox returns guidance
+for them but does not invoke a system package manager or elevate privileges. Preparation creates no
+project state, durable job, plan, or setup receipt of its own.
 
 ## Sources and limits
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly six MCP tools, one resource template, no concrete
+Contract tests assert exactly seven MCP tools, one resource template, no concrete
 resource list, output schemas, truthful annotations, and direct structured success content without
 a universal wrapper.
 

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -83,14 +83,14 @@ def setup(
     root = project_root.resolve(strict=True)
     selected = provider or []
     try:
-        preparation = prepare_providers(selected)
+        preparation = prepare_providers(selected, root)
     except SetupFailure as error:
         raise typer.BadParameter(str(error), param_hint="--provider") from error
     configured_providers = preparation.configured_managed_providers
     external_providers = [item.provider_id for item in preparation.external_requirements]
     guidance = [item.guidance for item in preparation.external_requirements]
     launcher, launcher_args = preparation.launcher_command, preparation.launcher_args
-    args = [*launcher_args, "mcp", "serve", "--project-root", str(root)]
+    args = launcher_args
     value = {
         "command": launcher,
         "args": args,

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from flameox import __version__
 from flameox.mcp import create_server, run_server
 from flameox.runtime_contracts import CaptureTarget, PathSource, RuntimeFailure
-from flameox.setup import SetupFailure, install_providers, mcp_launcher, provider_guidance
+from flameox.setup import SetupFailure, prepare_providers
 from flameox.stateless import AnalysisRuntime
 
 app = typer.Typer(
@@ -83,13 +83,13 @@ def setup(
     root = project_root.resolve(strict=True)
     selected = provider or []
     try:
-        installation = install_providers(selected) if selected else None
-        command = installation.command if installation is not None else []
-        configured_providers = installation.providers if installation is not None else []
-        guidance = provider_guidance(selected)
+        preparation = prepare_providers(selected)
     except SetupFailure as error:
         raise typer.BadParameter(str(error), param_hint="--provider") from error
-    launcher, launcher_args = mcp_launcher(configured_providers)
+    configured_providers = preparation.configured_managed_providers
+    external_providers = [item.provider_id for item in preparation.external_requirements]
+    guidance = [item.guidance for item in preparation.external_requirements]
+    launcher, launcher_args = preparation.launcher_command, preparation.launcher_args
     args = [*launcher_args, "mcp", "serve", "--project-root", str(root)]
     value = {
         "command": launcher,
@@ -99,8 +99,8 @@ def setup(
         "project_root": str(root),
         "durable_repository": str(root / ".flameox"),
         "repository_created": False,
-        "providers": configured_providers,
-        "install_command": command,
+        "providers": sorted(set(configured_providers) | set(external_providers)),
+        "install_command": preparation.install_command,
         "external_guidance": guidance,
     }
     if json_output:
@@ -112,7 +112,7 @@ def setup(
             + (
                 "Installed the selected Python provider extras into the persistent Flameox "
                 "uv tool environment.\n"
-                if command
+                if preparation.changed
                 else "No Python provider packages were installed.\n"
             )
             + "\n".join(guidance)

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -16,6 +16,7 @@ from mcp_types import CallToolResult, ContentBlock, ResourceLink, TextContent, T
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     GetJsonSchemaHandler,
     JsonValue,
     RootModel,
@@ -32,6 +33,13 @@ from flameox.runtime_contracts import (
     RuntimeFailure,
     Source,
 )
+from flameox.setup import (
+    PYTHON_PROVIDER_EXTRAS,
+    SYSTEM_PROVIDER_GUIDANCE,
+    SetupFailure,
+    install_providers,
+    mcp_launcher,
+)
 from flameox.stateless import AnalysisRuntime
 
 READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_world_hint=False)
@@ -46,6 +54,12 @@ PRESERVE = ToolAnnotations(
     destructive_hint=False,
     idempotent_hint=True,
     open_world_hint=False,
+)
+PREPARE = ToolAnnotations(
+    read_only_hint=False,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=True,
 )
 
 
@@ -86,6 +100,30 @@ class InspectionEnvelope(_Envelope):
     capabilities: list[dict[str, JsonValue]]
 
 
+class ExternalRequirementEnvelope(BaseModel):
+    provider_id: str
+    guidance: str
+
+
+class InstallationEnvelope(BaseModel):
+    status: Literal["installed", "already_configured", "not_applicable"]
+    command: list[str]
+
+
+class LauncherEnvelope(BaseModel):
+    command: str
+    args: list[str]
+
+
+class PreparationEnvelope(_Envelope):
+    requested_providers: list[str]
+    configured_providers: list[str]
+    external_requirements: list[ExternalRequirementEnvelope]
+    installation: InstallationEnvelope
+    launcher: LauncherEnvelope
+    restart_required: bool
+
+
 class PreservationEnvelope(_Envelope):
     evidence_id: str
     uri: str
@@ -114,6 +152,10 @@ class DiscoveryOutcome(_ObjectOutcome):
 
 class InspectionOutcome(_ObjectOutcome):
     root: InspectionEnvelope | ToolFailureEnvelope
+
+
+class PreparationOutcome(_ObjectOutcome):
+    root: PreparationEnvelope | ToolFailureEnvelope
 
 
 class AnalysisOutcome(_ObjectOutcome):
@@ -179,9 +221,10 @@ def create_server(
         description="Bounded local runtime evidence without a prerequisite workspace.",
         instructions=(
             "Pass explicit artifact paths or a typed direct target. Analysis and capture are "
-            "session-local unless preserve_evidence is called. Flameox never installs providers, "
-            "searches parent directories, accepts shell strings, or creates durable jobs. Use "
-            "inspect_capabilities before capture when provider compatibility or bounds need review."
+            "session-local unless preserve_evidence is called. Use prepare_capabilities only when "
+            "discovery reports a missing Flameox-managed provider; reconnect with its returned "
+            "launcher after installation. Flameox never installs host tools, searches parent "
+            "directories, accepts shell strings, or creates durable jobs."
         ),
         lifespan=lifespan,
     )
@@ -214,6 +257,58 @@ def create_server(
             return _success(runtime().inspect_capabilities(capability_ids))
         except RuntimeFailure as error:
             return _failure(error)
+
+    @server.tool(annotations=PREPARE, structured_output=True)
+    async def prepare_capabilities(
+        provider_ids: Annotated[list[str], Field(min_length=1, max_length=16)],
+    ) -> Annotated[CallToolResult, PreparationOutcome]:
+        """Install selected managed providers; report host-tool setup without changing it."""
+
+        requested = list(dict.fromkeys(provider_ids))
+        unknown = sorted(
+            set(requested).difference(PYTHON_PROVIDER_EXTRAS).difference(SYSTEM_PROVIDER_GUIDANCE)
+        )
+        if unknown:
+            supported = ", ".join(sorted(PYTHON_PROVIDER_EXTRAS | SYSTEM_PROVIDER_GUIDANCE))
+            return _failure(
+                RuntimeFailure(
+                    "INVALID_INPUT",
+                    f"Unknown provider {unknown[0]!r}; choose one of: {supported}",
+                )
+            )
+
+        managed = [item for item in requested if item in PYTHON_PROVIDER_EXTRAS]
+        external = [
+            {"provider_id": item, "guidance": SYSTEM_PROVIDER_GUIDANCE[item]}
+            for item in requested
+            if item in SYSTEM_PROVIDER_GUIDANCE
+        ]
+        try:
+            installation = await asyncio.to_thread(install_providers, managed)
+        except SetupFailure as error:
+            return _failure(RuntimeFailure("SETUP_FAILURE", str(error)))
+
+        launcher_command, launcher_args = mcp_launcher(installation.providers)
+        installation_status: Literal["installed", "already_configured", "not_applicable"]
+        if not managed:
+            installation_status = "not_applicable"
+        elif installation.changed:
+            installation_status = "installed"
+        else:
+            installation_status = "already_configured"
+        return _success(
+            {
+                "requested_providers": requested,
+                "configured_providers": installation.providers,
+                "external_requirements": external,
+                "installation": {
+                    "status": installation_status,
+                    "command": installation.command,
+                },
+                "launcher": {"command": launcher_command, "args": launcher_args},
+                "restart_required": installation.changed,
+            }
+        )
 
     @server.tool(annotations=READ_ONLY, structured_output=True)
     async def analyze(

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -34,11 +34,9 @@ from flameox.runtime_contracts import (
     Source,
 )
 from flameox.setup import (
-    PYTHON_PROVIDER_EXTRAS,
-    SYSTEM_PROVIDER_GUIDANCE,
+    ProviderSelectionFailure,
     SetupFailure,
-    install_providers,
-    mcp_launcher,
+    prepare_providers,
 )
 from flameox.stateless import AnalysisRuntime
 
@@ -107,7 +105,6 @@ class ExternalRequirementEnvelope(BaseModel):
 
 class InstallationEnvelope(BaseModel):
     status: Literal["installed", "already_configured", "not_applicable"]
-    command: list[str]
 
 
 class LauncherEnvelope(BaseModel):
@@ -117,7 +114,7 @@ class LauncherEnvelope(BaseModel):
 
 class PreparationEnvelope(_Envelope):
     requested_providers: list[str]
-    configured_providers: list[str]
+    configured_managed_providers: list[str]
     external_requirements: list[ExternalRequirementEnvelope]
     installation: InstallationEnvelope
     launcher: LauncherEnvelope
@@ -264,49 +261,30 @@ def create_server(
     ) -> Annotated[CallToolResult, PreparationOutcome]:
         """Install selected managed providers; report host-tool setup without changing it."""
 
-        requested = list(dict.fromkeys(provider_ids))
-        unknown = sorted(
-            set(requested).difference(PYTHON_PROVIDER_EXTRAS).difference(SYSTEM_PROVIDER_GUIDANCE)
-        )
-        if unknown:
-            supported = ", ".join(sorted(PYTHON_PROVIDER_EXTRAS | SYSTEM_PROVIDER_GUIDANCE))
-            return _failure(
-                RuntimeFailure(
-                    "INVALID_INPUT",
-                    f"Unknown provider {unknown[0]!r}; choose one of: {supported}",
-                )
-            )
-
-        managed = [item for item in requested if item in PYTHON_PROVIDER_EXTRAS]
-        external = [
-            {"provider_id": item, "guidance": SYSTEM_PROVIDER_GUIDANCE[item]}
-            for item in requested
-            if item in SYSTEM_PROVIDER_GUIDANCE
-        ]
         try:
-            installation = await asyncio.to_thread(install_providers, managed)
+            preparation = await asyncio.to_thread(prepare_providers, provider_ids)
+        except ProviderSelectionFailure as error:
+            return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
         except SetupFailure as error:
             return _failure(RuntimeFailure("SETUP_FAILURE", str(error)))
 
-        launcher_command, launcher_args = mcp_launcher(installation.providers)
-        installation_status: Literal["installed", "already_configured", "not_applicable"]
-        if not managed:
-            installation_status = "not_applicable"
-        elif installation.changed:
-            installation_status = "installed"
-        else:
-            installation_status = "already_configured"
         return _success(
             {
-                "requested_providers": requested,
-                "configured_providers": installation.providers,
-                "external_requirements": external,
-                "installation": {
-                    "status": installation_status,
-                    "command": installation.command,
+                "requested_providers": preparation.requested_providers,
+                "configured_managed_providers": preparation.configured_managed_providers,
+                "external_requirements": [
+                    {
+                        "provider_id": requirement.provider_id,
+                        "guidance": requirement.guidance,
+                    }
+                    for requirement in preparation.external_requirements
+                ],
+                "installation": {"status": preparation.installation_status},
+                "launcher": {
+                    "command": preparation.launcher_command,
+                    "args": preparation.launcher_args,
                 },
-                "launcher": {"command": launcher_command, "args": launcher_args},
-                "restart_required": installation.changed,
+                "restart_required": preparation.changed,
             }
         )
 

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
+import anyio
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from mcp_types import CallToolResult, ContentBlock, ResourceLink, TextContent, ToolAnnotations
@@ -55,7 +56,7 @@ PRESERVE = ToolAnnotations(
 )
 PREPARE = ToolAnnotations(
     read_only_hint=False,
-    destructive_hint=False,
+    destructive_hint=True,
     idempotent_hint=True,
     open_world_hint=True,
 )
@@ -262,7 +263,7 @@ def create_server(
         """Install selected managed providers; report host-tool setup without changing it."""
 
         try:
-            preparation = await asyncio.to_thread(prepare_providers, provider_ids)
+            preparation = await anyio.to_thread.run_sync(prepare_providers, provider_ids, root)
         except ProviderSelectionFailure as error:
             return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
         except SetupFailure as error:
@@ -284,7 +285,7 @@ def create_server(
                     "command": preparation.launcher_command,
                     "args": preparation.launcher_args,
                 },
-                "restart_required": preparation.changed,
+                "restart_required": preparation.restart_required,
             }
         )
 

--- a/src/flameox/setup.py
+++ b/src/flameox/setup.py
@@ -65,8 +65,12 @@ class ProviderPreparation:
             return "not_applicable"
         return "installed" if self.changed else "already_configured"
 
+    @property
+    def restart_required(self) -> bool:
+        return any(item in PYTHON_PROVIDER_EXTRAS for item in self.requested_providers)
 
-def managed_tool_extras(tool_directory: Path) -> set[str]:
+
+def installed_tool_extras(tool_directory: Path) -> set[str]:
     """Read the optional extras uv will replace when reinstalling the Flameox tool."""
 
     receipt = tool_directory / "flameox" / "uv-receipt.toml"
@@ -86,22 +90,25 @@ def managed_tool_extras(tool_directory: Path) -> set[str]:
         KeyError,
         StopIteration,
         TypeError,
+        UnicodeError,
         tomllib.TOMLDecodeError,
     ) as exc:
         raise SetupFailure(f"Cannot read the existing uv tool receipt: {receipt}") from exc
     if not isinstance(extras, list) or not all(isinstance(item, str) for item in extras):
         raise SetupFailure(f"The existing uv tool receipt has invalid extras: {receipt}")
-    known_extras = set(PYTHON_PROVIDER_EXTRAS.values())
-    return {item for item in extras if item in known_extras}
+    return set(extras)
 
 
 def _uv_tool_directory(uv: Path) -> Path:
-    completed = subprocess.run(
-        [str(uv), "tool", "dir"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        completed = subprocess.run(
+            [str(uv), "tool", "dir"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise SetupFailure("uv tool dir could not start the uv executable.") from error
     if completed.returncode != 0 or not completed.stdout.strip():
         raise SetupFailure("uv tool dir could not locate the managed tool environment.")
     return Path(completed.stdout.strip())
@@ -125,9 +132,13 @@ def provider_install_command(
     requested_extras = {
         PYTHON_PROVIDER_EXTRAS[item] for item in providers if item in PYTHON_PROVIDER_EXTRAS
     }
-    if not requested_extras or requested_extras.issubset(installed_extras or set()):
+    retained_extras = installed_extras or set()
+    effective_installed = (
+        set(PYTHON_PROVIDER_EXTRAS.values()) if "all" in retained_extras else retained_extras
+    )
+    if not requested_extras or requested_extras.issubset(effective_installed):
         return []
-    extras = sorted((installed_extras or set()) | requested_extras)
+    extras = sorted(retained_extras | requested_extras)
     requirement = f"flameox[{','.join(extras)}]=={__version__}"
     return [
         str(uv),
@@ -160,7 +171,7 @@ def mcp_launcher(providers: list[str]) -> tuple[str, list[str]]:
     )
 
 
-def prepare_providers(providers: list[str]) -> ProviderPreparation:
+def prepare_providers(providers: list[str], project_root: Path) -> ProviderPreparation:
     requested = list(dict.fromkeys(providers))
     _validate_providers(requested)
     managed = [item for item in requested if item in PYTHON_PROVIDER_EXTRAS]
@@ -177,7 +188,7 @@ def prepare_providers(providers: list[str]) -> ProviderPreparation:
             external,
             [],
             launcher_command,
-            launcher_args,
+            [*launcher_args, "mcp", "serve", "--project-root", str(project_root)],
         )
 
     uv_text = shutil.which("uv")
@@ -192,19 +203,24 @@ def prepare_providers(providers: list[str]) -> ProviderPreparation:
             timeout=10,
             encoding="utf-8",
         ):
-            installed_extras = managed_tool_extras(tool_directory)
+            installed_extras = installed_tool_extras(tool_directory)
             command = provider_install_command(
                 managed,
                 uv=uv,
                 installed_extras=installed_extras,
             )
             if command:
-                completed = subprocess.run(command, check=False)
+                try:
+                    completed = subprocess.run(command, check=False)
+                except OSError as error:
+                    raise SetupFailure(
+                        "uv tool install could not start the uv executable."
+                    ) from error
                 if completed.returncode != 0:
                     raise SetupFailure(
                         f"uv tool install exited with status {completed.returncode}."
                     )
-            final_extras = managed_tool_extras(tool_directory) if command else installed_extras
+            final_extras = installed_tool_extras(tool_directory) if command else installed_extras
             requested_extras = {PYTHON_PROVIDER_EXTRAS[item] for item in managed}
             missing_extras = requested_extras.difference(final_extras)
             if missing_extras:
@@ -214,9 +230,13 @@ def prepare_providers(providers: list[str]) -> ProviderPreparation:
                 )
     except portalocker.exceptions.LockException as error:
         raise SetupFailure("Timed out waiting to update the managed Flameox tool.") from error
+    except OSError as error:
+        raise SetupFailure("Cannot update the managed Flameox tool environment.") from error
 
     configured = sorted(
-        provider for provider, extra in PYTHON_PROVIDER_EXTRAS.items() if extra in final_extras
+        provider
+        for provider, extra in PYTHON_PROVIDER_EXTRAS.items()
+        if extra in final_extras or "all" in final_extras
     )
     launcher_command, launcher_args = mcp_launcher(configured)
     return ProviderPreparation(
@@ -225,5 +245,5 @@ def prepare_providers(providers: list[str]) -> ProviderPreparation:
         external,
         command,
         launcher_command,
-        launcher_args,
+        [*launcher_args, "mcp", "serve", "--project-root", str(project_root)],
     )

--- a/src/flameox/setup.py
+++ b/src/flameox/setup.py
@@ -5,7 +5,9 @@ import subprocess
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
+
+import portalocker
 
 from flameox import __version__
 
@@ -34,11 +36,34 @@ class SetupFailure(RuntimeError):
     pass
 
 
+class ProviderSelectionFailure(SetupFailure):
+    pass
+
+
 @dataclass(frozen=True, slots=True)
-class ProviderInstallation:
-    command: list[str]
-    providers: list[str]
-    changed: bool = False
+class ExternalRequirement:
+    provider_id: str
+    guidance: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPreparation:
+    requested_providers: list[str]
+    configured_managed_providers: list[str]
+    external_requirements: list[ExternalRequirement]
+    install_command: list[str]
+    launcher_command: str
+    launcher_args: list[str]
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.install_command)
+
+    @property
+    def installation_status(self) -> Literal["installed", "already_configured", "not_applicable"]:
+        if not any(item in PYTHON_PROVIDER_EXTRAS for item in self.requested_providers):
+            return "not_applicable"
+        return "installed" if self.changed else "already_configured"
 
 
 def managed_tool_extras(tool_directory: Path) -> set[str]:
@@ -82,15 +107,21 @@ def _uv_tool_directory(uv: Path) -> Path:
     return Path(completed.stdout.strip())
 
 
-def provider_install_command(
-    providers: list[str], *, uv: Path, installed_extras: set[str] | None = None
-) -> list[str]:
+def _validate_providers(providers: list[str]) -> None:
     unknown = sorted(
         set(providers).difference(PYTHON_PROVIDER_EXTRAS).difference(SYSTEM_PROVIDER_GUIDANCE)
     )
     if unknown:
         supported = ", ".join(sorted(PYTHON_PROVIDER_EXTRAS | SYSTEM_PROVIDER_GUIDANCE))
-        raise SetupFailure(f"Unknown provider {unknown[0]!r}; choose one of: {supported}")
+        raise ProviderSelectionFailure(
+            f"Unknown provider {unknown[0]!r}; choose one of: {supported}"
+        )
+
+
+def provider_install_command(
+    providers: list[str], *, uv: Path, installed_extras: set[str] | None = None
+) -> list[str]:
+    _validate_providers(providers)
     requested_extras = {
         PYTHON_PROVIDER_EXTRAS[item] for item in providers if item in PYTHON_PROVIDER_EXTRAS
     }
@@ -129,50 +160,70 @@ def mcp_launcher(providers: list[str]) -> tuple[str, list[str]]:
     )
 
 
-def install_providers(providers: list[str]) -> ProviderInstallation:
-    if not any(item in PYTHON_PROVIDER_EXTRAS for item in providers):
-        provider_install_command(providers, uv=Path("uv"))
-        return ProviderInstallation(
+def prepare_providers(providers: list[str]) -> ProviderPreparation:
+    requested = list(dict.fromkeys(providers))
+    _validate_providers(requested)
+    managed = [item for item in requested if item in PYTHON_PROVIDER_EXTRAS]
+    external = [
+        ExternalRequirement(item, SYSTEM_PROVIDER_GUIDANCE[item])
+        for item in requested
+        if item in SYSTEM_PROVIDER_GUIDANCE
+    ]
+    if not managed:
+        launcher_command, launcher_args = mcp_launcher([])
+        return ProviderPreparation(
+            requested,
             [],
-            sorted(set(providers).intersection(SYSTEM_PROVIDER_GUIDANCE)),
+            external,
+            [],
+            launcher_command,
+            launcher_args,
         )
+
     uv_text = shutil.which("uv")
     if uv_text is None:
         raise SetupFailure("Provider installation requires uv on PATH.")
     uv = Path(uv_text)
     tool_directory = _uv_tool_directory(uv)
-    installed_extras = managed_tool_extras(tool_directory)
-    command = provider_install_command(
-        providers,
-        uv=uv,
-        installed_extras=installed_extras,
-    )
-    if command:
-        completed = subprocess.run(command, check=False)
-        if completed.returncode != 0:
-            raise SetupFailure(f"uv tool install exited with status {completed.returncode}.")
-    final_extras = managed_tool_extras(tool_directory) if command else installed_extras
-    requested_extras = {
-        PYTHON_PROVIDER_EXTRAS[item] for item in providers if item in PYTHON_PROVIDER_EXTRAS
-    }
-    missing_extras = requested_extras.difference(final_extras)
-    if missing_extras:
-        raise SetupFailure(
-            "uv reported success but the managed tool receipt is missing extras: "
-            + ", ".join(sorted(missing_extras))
-        )
-    managed_providers = {
+    try:
+        with portalocker.Lock(
+            tool_directory / ".flameox-setup.lock",
+            mode="a+",
+            timeout=10,
+            encoding="utf-8",
+        ):
+            installed_extras = managed_tool_extras(tool_directory)
+            command = provider_install_command(
+                managed,
+                uv=uv,
+                installed_extras=installed_extras,
+            )
+            if command:
+                completed = subprocess.run(command, check=False)
+                if completed.returncode != 0:
+                    raise SetupFailure(
+                        f"uv tool install exited with status {completed.returncode}."
+                    )
+            final_extras = managed_tool_extras(tool_directory) if command else installed_extras
+            requested_extras = {PYTHON_PROVIDER_EXTRAS[item] for item in managed}
+            missing_extras = requested_extras.difference(final_extras)
+            if missing_extras:
+                raise SetupFailure(
+                    "uv reported success but the managed tool receipt is missing extras: "
+                    + ", ".join(sorted(missing_extras))
+                )
+    except portalocker.exceptions.LockException as error:
+        raise SetupFailure("Timed out waiting to update the managed Flameox tool.") from error
+
+    configured = sorted(
         provider for provider, extra in PYTHON_PROVIDER_EXTRAS.items() if extra in final_extras
-    }
-    selected_system = set(providers).intersection(SYSTEM_PROVIDER_GUIDANCE)
-    return ProviderInstallation(
-        command,
-        sorted(managed_providers | selected_system),
-        changed=bool(command),
     )
-
-
-def provider_guidance(providers: list[str]) -> list[str]:
-    return [
-        SYSTEM_PROVIDER_GUIDANCE[item] for item in providers if item in SYSTEM_PROVIDER_GUIDANCE
-    ]
+    launcher_command, launcher_args = mcp_launcher(configured)
+    return ProviderPreparation(
+        requested,
+        configured,
+        external,
+        command,
+        launcher_command,
+        launcher_args,
+    )

--- a/src/flameox/setup.py
+++ b/src/flameox/setup.py
@@ -38,6 +38,7 @@ class SetupFailure(RuntimeError):
 class ProviderInstallation:
     command: list[str]
     providers: list[str]
+    changed: bool = False
 
 
 def managed_tool_extras(tool_directory: Path) -> set[str]:
@@ -93,7 +94,7 @@ def provider_install_command(
     requested_extras = {
         PYTHON_PROVIDER_EXTRAS[item] for item in providers if item in PYTHON_PROVIDER_EXTRAS
     }
-    if not requested_extras:
+    if not requested_extras or requested_extras.issubset(installed_extras or set()):
         return []
     extras = sorted((installed_extras or set()) | requested_extras)
     requirement = f"flameox[{','.join(extras)}]=={__version__}"
@@ -129,11 +130,18 @@ def mcp_launcher(providers: list[str]) -> tuple[str, list[str]]:
 
 
 def install_providers(providers: list[str]) -> ProviderInstallation:
+    if not any(item in PYTHON_PROVIDER_EXTRAS for item in providers):
+        provider_install_command(providers, uv=Path("uv"))
+        return ProviderInstallation(
+            [],
+            sorted(set(providers).intersection(SYSTEM_PROVIDER_GUIDANCE)),
+        )
     uv_text = shutil.which("uv")
     if uv_text is None:
         raise SetupFailure("Provider installation requires uv on PATH.")
     uv = Path(uv_text)
-    installed_extras = managed_tool_extras(_uv_tool_directory(uv))
+    tool_directory = _uv_tool_directory(uv)
+    installed_extras = managed_tool_extras(tool_directory)
     command = provider_install_command(
         providers,
         uv=uv,
@@ -143,14 +151,25 @@ def install_providers(providers: list[str]) -> ProviderInstallation:
         completed = subprocess.run(command, check=False)
         if completed.returncode != 0:
             raise SetupFailure(f"uv tool install exited with status {completed.returncode}.")
-    final_extras = installed_extras | {
+    final_extras = managed_tool_extras(tool_directory) if command else installed_extras
+    requested_extras = {
         PYTHON_PROVIDER_EXTRAS[item] for item in providers if item in PYTHON_PROVIDER_EXTRAS
     }
+    missing_extras = requested_extras.difference(final_extras)
+    if missing_extras:
+        raise SetupFailure(
+            "uv reported success but the managed tool receipt is missing extras: "
+            + ", ".join(sorted(missing_extras))
+        )
     managed_providers = {
         provider for provider, extra in PYTHON_PROVIDER_EXTRAS.items() if extra in final_extras
     }
     selected_system = set(providers).intersection(SYSTEM_PROVIDER_GUIDANCE)
-    return ProviderInstallation(command, sorted(managed_providers | selected_system))
+    return ProviderInstallation(
+        command,
+        sorted(managed_providers | selected_system),
+        changed=bool(command),
+    )
 
 
 def provider_guidance(providers: list[str]) -> list[str]:

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 
 from flameox import __version__
 from flameox.cli import app
-from flameox.setup import ProviderInstallation
+from flameox.setup import ExternalRequirement, ProviderPreparation
 
 pytestmark = pytest.mark.integration
 
@@ -207,14 +207,29 @@ def test_setup_installs_only_explicit_python_providers_and_guides_system_tools(
 ) -> None:
     selected: list[list[str]] = []
 
-    def install(providers: list[str]) -> ProviderInstallation:
+    def prepare(providers: list[str]) -> ProviderPreparation:
         selected.append(providers)
-        return ProviderInstallation(
+        return ProviderPreparation(
+            providers,
+            ["memray", "py-spy"],
+            [
+                ExternalRequirement(
+                    "nsight-compute",
+                    "Install NVIDIA Nsight Compute with its extras/python interface.",
+                )
+            ],
             ["uv", "tool", "install", f"flameox[memory]=={__version__}"],
-            ["memray", "nsight-compute", "py-spy"],
+            "uvx",
+            [
+                "--python",
+                "3.12",
+                "--from",
+                f"flameox[cpu,memory]=={__version__}",
+                "flameox",
+            ],
         )
 
-    monkeypatch.setattr("flameox.cli.install_providers", install)
+    monkeypatch.setattr("flameox.cli.prepare_providers", prepare)
     result = CliRunner().invoke(
         app,
         [

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -207,7 +207,7 @@ def test_setup_installs_only_explicit_python_providers_and_guides_system_tools(
 ) -> None:
     selected: list[list[str]] = []
 
-    def prepare(providers: list[str]) -> ProviderPreparation:
+    def prepare(providers: list[str], project_root: Path) -> ProviderPreparation:
         selected.append(providers)
         return ProviderPreparation(
             providers,
@@ -226,6 +226,10 @@ def test_setup_installs_only_explicit_python_providers_and_guides_system_tools(
                 "--from",
                 f"flameox[cpu,memory]=={__version__}",
                 "flameox",
+                "mcp",
+                "serve",
+                "--project-root",
+                str(project_root),
             ],
         )
 

--- a/tests/test_setup_stateless.py
+++ b/tests/test_setup_stateless.py
@@ -52,6 +52,29 @@ def test_system_provider_has_guidance_but_no_python_install() -> None:
     assert provider_install_command(["nsight-compute"], uv=Path("uv")) == []
 
 
+def test_system_only_preparation_does_not_require_uv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: None)
+
+    prepared = install_providers(["nsight-compute"])
+
+    assert prepared.providers == ["nsight-compute"]
+    assert prepared.command == []
+    assert prepared.changed is False
+
+
+def test_provider_install_is_a_noop_when_requested_extra_is_already_managed() -> None:
+    assert (
+        provider_install_command(
+            ["py-spy"],
+            uv=Path("/usr/bin/uv"),
+            installed_extras={"cpu", "memory"},
+        )
+        == []
+    )
+
+
 def test_managed_tool_extras_are_read_from_uv_receipt(tmp_path: Path) -> None:
     tool = tmp_path / "flameox"
     tool.mkdir()
@@ -79,6 +102,9 @@ def test_provider_install_retains_existing_managed_providers(
         calls.append(command)
         if command[1:] == ["tool", "dir"]:
             return CompletedProcess(command, 0, f"{tmp_path / 'tools'}\n", "")
+        (tool / "uv-receipt.toml").write_text(
+            '[tool]\nrequirements = [{ name = "flameox", extras = ["cpu", "memory"] }]\n'
+        )
         return CompletedProcess(command, 0, "", "")
 
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
@@ -88,6 +114,7 @@ def test_provider_install_retains_existing_managed_providers(
 
     assert calls[-1][-1] == f"flameox[cpu,memory]=={__version__}"
     assert installed.providers == ["memray", "py-spy"]
+    assert installed.changed is True
 
 
 def test_unknown_provider_is_rejected_before_installation() -> None:

--- a/tests/test_setup_stateless.py
+++ b/tests/test_setup_stateless.py
@@ -10,7 +10,7 @@ import pytest
 from flameox import __version__
 from flameox.setup import (
     SetupFailure,
-    managed_tool_extras,
+    installed_tool_extras,
     mcp_launcher,
     prepare_providers,
     provider_install_command,
@@ -55,16 +55,17 @@ def test_system_provider_has_guidance_but_no_python_install() -> None:
 
 
 def test_system_only_preparation_does_not_require_uv(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: None)
 
-    prepared = prepare_providers(["nsight-compute"])
+    prepared = prepare_providers(["nsight-compute"], tmp_path)
 
     assert prepared.configured_managed_providers == []
     assert [item.provider_id for item in prepared.external_requirements] == ["nsight-compute"]
     assert prepared.install_command == []
     assert prepared.changed is False
+    assert prepared.restart_required is False
 
 
 def test_provider_install_is_a_noop_when_requested_extra_is_already_managed() -> None:
@@ -78,7 +79,7 @@ def test_provider_install_is_a_noop_when_requested_extra_is_already_managed() ->
     )
 
 
-def test_managed_tool_extras_are_read_from_uv_receipt(tmp_path: Path) -> None:
+def test_installed_tool_extras_are_read_from_uv_receipt(tmp_path: Path) -> None:
     tool = tmp_path / "flameox"
     tool.mkdir()
     (tool / "uv-receipt.toml").write_text(
@@ -88,7 +89,18 @@ requirements = [{ name = "flameox", extras = ["cpu", "memory"], specifier = "==0
 """
     )
 
-    assert managed_tool_extras(tmp_path) == {"cpu", "memory"}
+    assert installed_tool_extras(tmp_path) == {"cpu", "memory"}
+
+
+def test_all_extra_satisfies_and_survives_managed_provider_preparation() -> None:
+    assert (
+        provider_install_command(
+            ["memray", "py-spy"],
+            uv=Path("/usr/bin/uv"),
+            installed_extras={"all"},
+        )
+        == []
+    )
 
 
 def test_provider_install_retains_existing_managed_providers(
@@ -113,11 +125,48 @@ def test_provider_install_retains_existing_managed_providers(
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
     monkeypatch.setattr("flameox.setup.subprocess.run", run)
 
-    installed = prepare_providers(["memray"])
+    installed = prepare_providers(["memray"], tmp_path)
 
     assert calls[-1][-1] == f"flameox[cpu,memory]=={__version__}"
     assert installed.configured_managed_providers == ["memray", "py-spy"]
     assert installed.changed is True
+    assert installed.restart_required is True
+
+
+def test_satisfied_managed_provider_still_returns_a_reconnect_launcher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tool = tmp_path / "tools" / "flameox"
+    tool.mkdir(parents=True)
+    (tool / "uv-receipt.toml").write_text(
+        '[tool]\nrequirements = [{ name = "flameox", extras = ["cpu"] }]\n'
+    )
+
+    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
+        assert command[1:] == ["tool", "dir"]
+        return CompletedProcess(command, 0, f"{tmp_path / 'tools'}\n", "")
+
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
+    monkeypatch.setattr("flameox.setup.subprocess.run", run)
+
+    prepared = prepare_providers(["py-spy"], tmp_path)
+
+    assert prepared.changed is False
+    assert prepared.restart_required is True
+    assert prepared.launcher_args[-4:] == ["mcp", "serve", "--project-root", str(tmp_path)]
+
+
+def test_uv_start_failure_is_normalized_as_setup_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(*_args: object, **_kwargs: object) -> CompletedProcess[str]:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
+    monkeypatch.setattr("flameox.setup.subprocess.run", fail)
+
+    with pytest.raises(SetupFailure, match="could not start"):
+        prepare_providers(["memray"], tmp_path)
 
 
 def test_concurrent_preparation_retains_both_provider_extra_sets(
@@ -155,7 +204,13 @@ def test_concurrent_preparation_retains_both_provider_extra_sets(
     monkeypatch.setattr("flameox.setup.subprocess.run", run)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        results = list(executor.map(prepare_providers, [["memray"], ["otlp"]]))
+        results = list(
+            executor.map(
+                prepare_providers,
+                [["memray"], ["otlp"]],
+                [tmp_path, tmp_path],
+            )
+        )
 
     assert len(install_requirements) == 2
     assert any("flameox[memory,trace]" in requirement for requirement in install_requirements)

--- a/tests/test_setup_stateless.py
+++ b/tests/test_setup_stateless.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from subprocess import CompletedProcess
 
@@ -8,9 +10,9 @@ import pytest
 from flameox import __version__
 from flameox.setup import (
     SetupFailure,
-    install_providers,
     managed_tool_extras,
     mcp_launcher,
+    prepare_providers,
     provider_install_command,
 )
 
@@ -57,10 +59,11 @@ def test_system_only_preparation_does_not_require_uv(
 ) -> None:
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: None)
 
-    prepared = install_providers(["nsight-compute"])
+    prepared = prepare_providers(["nsight-compute"])
 
-    assert prepared.providers == ["nsight-compute"]
-    assert prepared.command == []
+    assert prepared.configured_managed_providers == []
+    assert [item.provider_id for item in prepared.external_requirements] == ["nsight-compute"]
+    assert prepared.install_command == []
     assert prepared.changed is False
 
 
@@ -110,11 +113,56 @@ def test_provider_install_retains_existing_managed_providers(
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
     monkeypatch.setattr("flameox.setup.subprocess.run", run)
 
-    installed = install_providers(["memray"])
+    installed = prepare_providers(["memray"])
 
     assert calls[-1][-1] == f"flameox[cpu,memory]=={__version__}"
-    assert installed.providers == ["memray", "py-spy"]
+    assert installed.configured_managed_providers == ["memray", "py-spy"]
     assert installed.changed is True
+
+
+def test_concurrent_preparation_retains_both_provider_extra_sets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tool_directory = tmp_path / "tools"
+    tool_directory.mkdir()
+    both_located = threading.Event()
+    calls_guard = threading.Lock()
+    tool_dir_calls = 0
+    install_requirements: list[str] = []
+
+    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
+        nonlocal tool_dir_calls
+        if command[1:] == ["tool", "dir"]:
+            with calls_guard:
+                tool_dir_calls += 1
+                if tool_dir_calls == 2:
+                    both_located.set()
+            return CompletedProcess(command, 0, f"{tool_directory}\n", "")
+
+        assert both_located.wait(timeout=2)
+        requirement = command[-1]
+        install_requirements.append(requirement)
+        extras = requirement.partition("[")[2].partition("]")[0].split(",")
+        receipt = tool_directory / "flameox" / "uv-receipt.toml"
+        receipt.parent.mkdir(exist_ok=True)
+        extras_toml = ", ".join(f'"{extra}"' for extra in extras)
+        receipt.write_text(
+            f'[tool]\nrequirements = [{{ name = "flameox", extras = [{extras_toml}] }}]\n'
+        )
+        return CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
+    monkeypatch.setattr("flameox.setup.subprocess.run", run)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(prepare_providers, [["memray"], ["otlp"]]))
+
+    assert len(install_requirements) == 2
+    assert any("flameox[memory,trace]" in requirement for requirement in install_requirements)
+    assert any(
+        set(result.configured_managed_providers) == {"memray", "otlp", "perfetto"}
+        for result in results
+    )
 
 
 def test_unknown_provider_is_rejected_before_installation() -> None:

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -41,7 +41,7 @@ from flameox.runtime_contracts import (
     RequestLimits,
     RuntimeFailure,
 )
-from flameox.setup import SYSTEM_PROVIDER_GUIDANCE, ProviderInstallation
+from flameox.setup import ExternalRequirement, ProviderPreparation, ProviderSelectionFailure
 from flameox.stateless import AnalysisRuntime
 
 
@@ -1807,15 +1807,31 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
 ) -> None:
     installed: list[list[str]] = []
 
-    def install(provider_ids: list[str]) -> ProviderInstallation:
+    def prepare(provider_ids: list[str]) -> ProviderPreparation:
+        if provider_ids == ["unknown-provider"]:
+            raise ProviderSelectionFailure("Unknown provider 'unknown-provider'")
         installed.append(provider_ids)
-        return ProviderInstallation(
-            ["uv", "tool", "install", f"flameox[memory]=={__version__}"],
+        return ProviderPreparation(
+            ["memray", "nsight-compute"],
             ["memray"],
-            changed=True,
+            [
+                ExternalRequirement(
+                    "nsight-compute",
+                    "Install NVIDIA Nsight Compute with its extras/python interface.",
+                )
+            ],
+            ["uv", "tool", "install", f"flameox[memory]=={__version__}"],
+            "uvx",
+            [
+                "--python",
+                "3.12",
+                "--from",
+                f"flameox[memory]=={__version__}",
+                "flameox",
+            ],
         )
 
-    monkeypatch.setattr("flameox.mcp.server.install_providers", install)
+    monkeypatch.setattr("flameox.mcp.server.prepare_providers", prepare)
 
     async def exercise() -> None:
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
@@ -1823,17 +1839,21 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
                 "prepare_capabilities",
                 {"provider_ids": ["memray", "nsight-compute", "memray"]},
             )
+            invalid = await client.call_tool(
+                "prepare_capabilities",
+                {"provider_ids": ["unknown-provider"]},
+            )
 
         assert result.is_error is False
         assert result.structured_content["requested_providers"] == [
             "memray",
             "nsight-compute",
         ]
-        assert result.structured_content["configured_providers"] == ["memray"]
+        assert result.structured_content["configured_managed_providers"] == ["memray"]
         assert result.structured_content["external_requirements"] == [
             {
                 "provider_id": "nsight-compute",
-                "guidance": SYSTEM_PROVIDER_GUIDANCE["nsight-compute"],
+                "guidance": "Install NVIDIA Nsight Compute with its extras/python interface.",
             }
         ]
         assert result.structured_content["installation"]["status"] == "installed"
@@ -1842,8 +1862,11 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
             f"flameox[memory]=={__version__}"
         )
 
+        assert invalid.is_error is True
+        assert invalid.structured_content["code"] == "INVALID_INPUT"
+
     anyio.run(exercise)
-    assert installed == [["memray"]]
+    assert installed == [["memray", "nsight-compute", "memray"]]
 
 
 @pytest.mark.process

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1789,6 +1789,7 @@ def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
         prepare = next(tool for tool in tools if tool.name == "prepare_capabilities")
         assert prepare.annotations and prepare.annotations.open_world_hint is True
         assert prepare.annotations.read_only_hint is False
+        assert prepare.annotations.destructive_hint is True
         assert all(
             tool.annotations and tool.annotations.open_world_hint is False
             for tool in tools
@@ -1807,7 +1808,7 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
 ) -> None:
     installed: list[list[str]] = []
 
-    def prepare(provider_ids: list[str]) -> ProviderPreparation:
+    def prepare(provider_ids: list[str], project_root: Path) -> ProviderPreparation:
         if provider_ids == ["unknown-provider"]:
             raise ProviderSelectionFailure("Unknown provider 'unknown-provider'")
         installed.append(provider_ids)
@@ -1828,6 +1829,10 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
                 "--from",
                 f"flameox[memory]=={__version__}",
                 "flameox",
+                "mcp",
+                "serve",
+                "--project-root",
+                str(project_root),
             ],
         )
 
@@ -1861,6 +1866,13 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
         assert result.structured_content["launcher"]["args"][3] == (
             f"flameox[memory]=={__version__}"
         )
+        assert result.structured_content["launcher"]["args"][-5:] == [
+            "flameox",
+            "mcp",
+            "serve",
+            "--project-root",
+            str(tmp_path),
+        ]
 
         assert invalid.is_error is True
         assert invalid.structured_content["code"] == "INVALID_INPUT"

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -41,6 +41,7 @@ from flameox.runtime_contracts import (
     RequestLimits,
     RuntimeFailure,
 )
+from flameox.setup import SYSTEM_PROVIDER_GUIDANCE, ProviderInstallation
 from flameox.stateless import AnalysisRuntime
 
 
@@ -1778,18 +1779,71 @@ def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
         assert [tool.name for tool in tools] == [
             "discover_capabilities",
             "inspect_capabilities",
+            "prepare_capabilities",
             "analyze",
             "capture_and_analyze",
             "preserve_evidence",
             "query_evidence",
         ]
         assert all(tool.output_schema is not None for tool in tools)
-        assert all(tool.annotations and tool.annotations.open_world_hint is False for tool in tools)
+        prepare = next(tool for tool in tools if tool.name == "prepare_capabilities")
+        assert prepare.annotations and prepare.annotations.open_world_hint is True
+        assert prepare.annotations.read_only_hint is False
+        assert all(
+            tool.annotations and tool.annotations.open_world_hint is False
+            for tool in tools
+            if tool.name != "prepare_capabilities"
+        )
         assert await server.list_resources() == []
         assert [item.uri_template for item in templates] == ["flameox://evidence/{evidence_id}"]
         assert templates[0].mime_type == AGENT_EVIDENCE_MEDIA_TYPE
 
     anyio.run(inspect)
+
+
+@pytest.mark.unit
+def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    installed: list[list[str]] = []
+
+    def install(provider_ids: list[str]) -> ProviderInstallation:
+        installed.append(provider_ids)
+        return ProviderInstallation(
+            ["uv", "tool", "install", f"flameox[memory]=={__version__}"],
+            ["memray"],
+            changed=True,
+        )
+
+    monkeypatch.setattr("flameox.mcp.server.install_providers", install)
+
+    async def exercise() -> None:
+        async with Client(create_server(tmp_path), raise_exceptions=True) as client:
+            result = await client.call_tool(
+                "prepare_capabilities",
+                {"provider_ids": ["memray", "nsight-compute", "memray"]},
+            )
+
+        assert result.is_error is False
+        assert result.structured_content["requested_providers"] == [
+            "memray",
+            "nsight-compute",
+        ]
+        assert result.structured_content["configured_providers"] == ["memray"]
+        assert result.structured_content["external_requirements"] == [
+            {
+                "provider_id": "nsight-compute",
+                "guidance": SYSTEM_PROVIDER_GUIDANCE["nsight-compute"],
+            }
+        ]
+        assert result.structured_content["installation"]["status"] == "installed"
+        assert result.structured_content["restart_required"] is True
+        assert result.structured_content["launcher"]["args"][3] == (
+            f"flameox[memory]=={__version__}"
+        )
+
+    anyio.run(exercise)
+    assert installed == [["memray"]]
 
 
 @pytest.mark.process
@@ -1826,6 +1880,7 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
         assert [tool.name for tool in tools.tools] == [
             "discover_capabilities",
             "inspect_capabilities",
+            "prepare_capabilities",
             "analyze",
             "capture_and_analyze",
             "preserve_evidence",


### PR DESCRIPTION
### Problem

Capability discovery can explain that a profiler is missing, but an MCP-only agent cannot prepare Flameox-managed providers. The stateless rewrite removed the old stateful preparation workflow along with its workspaces, plans, receipts, and jobs, leaving setup available only through the CLI.

### Change

Add one explicit `prepare_capabilities` MCP tool. It accepts a bounded provider list and delegates to the same setup operation as the CLI. That operation installs only allowlisted Flameox extras through the existing version-pinned uv path, verifies the resulting managed-tool receipt, and returns a complete `mcp serve` launcher bound to the current project root.

The preparation operation owns provider validation, managed-versus-host classification, receipt verification, status, and launcher selection. CLI and MCP are thin projections of that result. The MCP response distinguishes `configured_managed_providers` from external requirements and does not expose the internal install command.

The receipt read–modify–install sequence is protected by a cross-process lock so concurrent requests retain the union of requested extras, including an existing `all` extra. A fully satisfied request is a no-op. Managed-provider requests still require reconnect because the active MCP process may not be the persistent uv tool environment. Thread work remains request-owned during cancellation, and expected uv or receipt I/O failures use the structured setup failure envelope.

The operation truthfully advertises an open-world, destructive mutation because `uv tool install --force` replaces the managed environment. This does not restore an execution plan, durable setup state, polling, or recovery machinery. Host profilers, drivers, device permissions, and system packages remain outside Flameox's authority; they produce actionable guidance without host mutation. Capture and discovery still never install anything implicitly.

### Validation

- `uv run pytest -q` — 132 passed, 77 deselected
- `uv run pytest -q -m process` — 74 passed, 135 deselected
- `uv run ruff check src tests tools` — passed
- `uv run mypy src tests tools` — passed for 107 source files
- `uv run lint-imports` — 2 contracts kept
- `git diff --check` — passed

### Compatibility

The MCP catalog grows from six to seven tools. Existing tool contracts and the immutable evidence resource are unchanged. Hosts must reconnect after requesting a managed provider; the result and returned launcher make this explicit.