### PR TITLE
refactor(setup): prepare the returned uvx environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ uv run flameox mcp serve --project-root "$PWD"
 3.12 and the exact running Flameox release. It does not change an MCP client
 registration; apply the printed command through the client's supported MCP
 management interface. Explicit
-`--provider` selections add the matching Python extras to a persistent uv tool
-environment without removing its existing provider extras. System and vendor
-tools are diagnosed with external install guidance. Setup never initializes the
-project or creates `.flameox`.
+`--provider` selections prepare the exact version-pinned `uvx` environment in
+the printed launcher. Each invocation declares the complete managed provider
+set for that launcher. System and vendor tools are diagnosed with external
+install guidance. Setup never initializes the project or creates `.flameox`.
 
 ## Authority model
 
@@ -89,12 +89,12 @@ strings are never accepted. Work remains owned by the live MCP request, so SDK
 progress and cancellation apply directly; there are no detached or
 restart-surviving tasks.
 
-Managed external collectors such as py-spy execute from Flameox's uv tool
+Managed external collectors such as py-spy execute from Flameox's uvx
 environment. In-process collectors such as coverage.py and Memray are verified
 in, and run with, the workload's declared Python interpreter. Flameox does not
 substitute one Python runtime for the other. When discovery reports a missing
-managed provider, `prepare_capabilities` explicitly installs its version-pinned
-extra and returns the launcher to use after reconnecting. Host tools, drivers,
+managed provider, `prepare_capabilities` prepares its version-pinned uvx
+environment and returns that same launcher for reconnection. Host tools, drivers,
 and permissions are never installed or changed; the same result reports their
 setup guidance.
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -91,14 +91,14 @@ session-local in-memory DuckDB; it does not create a temporary SQLite database.
 
 ## Provider setup boundary
 
-An explicit `flameox setup --provider ...` invocation adds the selected Python
-extras to the persistent uv tool environment while retaining extras from its
-existing uv receipt. The result reports the complete managed provider set.
+An explicit `flameox setup --provider ...` invocation prepares the exact
+version-pinned uvx environment returned in its launcher. The invocation's
+provider list is complete; Flameox retains no provider inventory or setup receipt.
 System and vendor packages remain externally installed. Setup creates no
 project state and is not a prerequisite for explicit-path analysis.
 
 Provider ownership is explicit during capture. External collectors installed
-with Flameox, such as py-spy, execute from the managed tool environment rather
+with Flameox, such as py-spy, execute from the launched uvx environment rather
 than ambient request `PATH`. In-process collectors, including coverage.py and
 Memray, must be installed in the declared workload interpreter; capture probes
 that interpreter before execution and never substitutes Flameox's interpreter.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,9 +56,9 @@ accepted formats, provider probes, and capture/analysis semantics. Discovery
 performs only bounded suffix/header sniffing. Missing packages, executables,
 permissions, versions, or platforms are successful discovery states; Flameox
 never installs remediation automatically. The separately invoked CLI setup command or MCP
-`prepare_capabilities` tool may install an explicitly selected Python provider-extra set into a uv
-tool environment; neither creates project state nor owns a durable operation. Host profilers,
-drivers, and permissions remain external and receive guidance only.
+`prepare_capabilities` tool may prepare the exact version-pinned uvx environment named by an
+explicit Python provider set; neither creates project state nor owns a durable operation or provider
+inventory. Host profilers, drivers, and permissions remain external and receive guidance only.
 
 Direct capture is trusted local execution, not containment. Typed argv prevents
 shell interpretation, while the broker provides process-group cleanup, bounded

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -11,7 +11,7 @@ The catalog contains exactly seven tools:
 | --- | --- |
 | `discover_capabilities` | Rank by intent and bounded source sniffing; report provider state and external remediation. |
 | `inspect_capabilities` | Inspect 1-16 IDs with source modes, strict argument schema, examples, limits, and capture semantics. |
-| `prepare_capabilities` | Explicitly install 1-16 selected Flameox-managed providers and return a reconnect launcher; report host-tool guidance without changing the host. |
+| `prepare_capabilities` | Prepare an exact version-pinned uvx environment for 1-16 selected managed providers and return that launcher; report host-tool guidance without changing the host. |
 | `analyze` | Analyze 1-32 explicit path/evidence sources and return bounded inline evidence plus a session `analysis_id`. |
 | `capture_and_analyze` | Run typed argv through the broker in single or bounded experiment mode, then analyze outputs. |
 | `preserve_evidence` | Idempotently publish one session analysis and return an evidence reference plus `ResourceLink`. |
@@ -33,14 +33,14 @@ metrics and rows remain open JSON values. Success uses structured content direct
 `ok/result/error` wrapper. Tool failures set `isError=true` and carry a stable code, message, and
 details; both success and failure shapes validate against the advertised schema.
 
-`prepare_capabilities` is the only open-world tool. It may resolve packages through `uv`, retains
-already configured Flameox extras, verifies the resulting managed-tool receipt, and reports whether
-the MCP client must reconnect. Repeating a fully satisfied request is a no-op. System profilers,
-drivers, device access, and OS permissions remain external requirements; Flameox returns guidance
-for them but does not invoke a system package manager or elevate privileges. Preparation creates no
-project state, durable job, plan, or setup receipt of its own. The result distinguishes configured
-managed providers from external requirements; a provider such as Perfetto may appear in both when
-its Python support is configured but its host Trace Processor still needs setup.
+`prepare_capabilities` is the only open-world tool. It resolves the exact package requirement through
+`uvx`, verifies that environment by running Flameox's version command, and returns the same
+requirement in a project-bound MCP launcher. The request names the complete managed provider set;
+Flameox keeps no installed-provider inventory or setup receipt. System profilers, drivers, device
+access, and OS permissions remain external requirements; Flameox returns guidance for them but does
+not invoke a system package manager or elevate privileges. Preparation creates no project state,
+durable job, or plan. A provider such as Perfetto may be both prepared Python support and an external
+host Trace Processor requirement.
 
 ## Sources and limits
 
@@ -120,9 +120,8 @@ flameox evidence query|show
 `setup` prints stdio configuration that launches the exact running Flameox
 release through `uvx` on Python 3.12. It reports that no MCP client registration
 was changed; client-owned management interfaces apply the returned command.
-Repeated `--provider` options add Python
-provider extras to a persistent uv tool environment without removing its
-existing extras, and the result reports the complete managed provider set.
+Repeated `--provider` options declare the complete Python provider set for the
+exact version-pinned uvx environment used by the returned launcher.
 System and vendor providers receive external installation guidance. Setup does
 not create a project repository, durable operation, or MCP setup endpoint.
 Other CLI commands construct the same runtime and project-root rules used by

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -40,7 +40,8 @@ Flameox keeps no installed-provider inventory or setup receipt. System profilers
 access, and OS permissions remain external requirements; Flameox returns guidance for them but does
 not invoke a system package manager or elevate privileges. Preparation creates no project state,
 durable job, or plan. A provider such as Perfetto may be both prepared Python support and an external
-host Trace Processor requirement.
+host Trace Processor requirement. Preparation waits up to 1,800 seconds by default; callers may set
+`timeout_seconds` from 1 through 3,600. A uvx failure returns its complete stderr in `SETUP_FAILURE`.
 
 ## Sources and limits
 

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -14,7 +14,12 @@ from pydantic import ValidationError
 from flameox import __version__
 from flameox.mcp import create_server, run_server
 from flameox.runtime_contracts import CaptureTarget, PathSource, RuntimeFailure
-from flameox.setup import SetupFailure, prepare_providers
+from flameox.setup import (
+    DEFAULT_PREPARATION_TIMEOUT_SECONDS,
+    MAX_PREPARATION_TIMEOUT_SECONDS,
+    SetupFailure,
+    prepare_providers,
+)
 from flameox.stateless import AnalysisRuntime
 
 app = typer.Typer(
@@ -78,12 +83,16 @@ def setup(
     project_root: Annotated[Path, typer.Option("--project-root")] = Path("."),
     provider: Annotated[list[str] | None, typer.Option("--provider")] = None,
     json_output: Annotated[bool, typer.Option("--json")] = False,
+    timeout_seconds: Annotated[
+        int,
+        typer.Option("--timeout-seconds", min=1, max=MAX_PREPARATION_TIMEOUT_SECONDS),
+    ] = DEFAULT_PREPARATION_TIMEOUT_SECONDS,
 ) -> None:
     """Print version-bound MCP config and optionally prepare selected provider extras."""
     root = project_root.resolve(strict=True)
     selected = provider or []
     try:
-        preparation = prepare_providers(selected, root)
+        preparation = prepare_providers(selected, root, timeout_seconds)
     except SetupFailure as error:
         raise typer.BadParameter(str(error), param_hint="--provider") from error
     prepared_providers = preparation.prepared_managed_providers

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -79,14 +79,14 @@ def setup(
     provider: Annotated[list[str] | None, typer.Option("--provider")] = None,
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
-    """Print version-bound MCP config and optionally install selected provider extras."""
+    """Print version-bound MCP config and optionally prepare selected provider extras."""
     root = project_root.resolve(strict=True)
     selected = provider or []
     try:
         preparation = prepare_providers(selected, root)
     except SetupFailure as error:
         raise typer.BadParameter(str(error), param_hint="--provider") from error
-    configured_providers = preparation.configured_managed_providers
+    prepared_providers = preparation.prepared_managed_providers
     external_providers = [item.provider_id for item in preparation.external_requirements]
     guidance = [item.guidance for item in preparation.external_requirements]
     launcher, launcher_args = preparation.launcher_command, preparation.launcher_args
@@ -99,8 +99,8 @@ def setup(
         "project_root": str(root),
         "durable_repository": str(root / ".flameox"),
         "repository_created": False,
-        "providers": sorted(set(configured_providers) | set(external_providers)),
-        "install_command": preparation.install_command,
+        "providers": sorted(set(prepared_providers) | set(external_providers)),
+        "preparation_command": preparation.preparation_command,
         "external_guidance": guidance,
     }
     if json_output:
@@ -110,10 +110,9 @@ def setup(
             "No MCP client registration was changed. Configure your client to run:\n"
             f"  {shlex.join([launcher, *args])}\n\n"
             + (
-                "Installed the selected Python provider extras into the persistent Flameox "
-                "uv tool environment.\n"
-                if preparation.changed
-                else "No Python provider packages were installed.\n"
+                "Prepared the exact version-pinned uvx provider environment.\n"
+                if preparation.preparation_command
+                else "No managed provider environment needed preparation.\n"
             )
             + "\n".join(guidance)
         )

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -35,6 +35,8 @@ from flameox.runtime_contracts import (
     Source,
 )
 from flameox.setup import (
+    DEFAULT_PREPARATION_TIMEOUT_SECONDS,
+    MAX_PREPARATION_TIMEOUT_SECONDS,
     ProviderSelectionFailure,
     SetupFailure,
     prepare_providers,
@@ -259,11 +261,16 @@ def create_server(
     @server.tool(annotations=PREPARE, structured_output=True)
     async def prepare_capabilities(
         provider_ids: Annotated[list[str], Field(min_length=1, max_length=16)],
+        timeout_seconds: Annotated[
+            int, Field(ge=1, le=MAX_PREPARATION_TIMEOUT_SECONDS)
+        ] = DEFAULT_PREPARATION_TIMEOUT_SECONDS,
     ) -> Annotated[CallToolResult, PreparationOutcome]:
-        """Install selected managed providers; report host-tool setup without changing it."""
+        """Prepare selected managed providers; report host-tool setup without changing it."""
 
         try:
-            preparation = await anyio.to_thread.run_sync(prepare_providers, provider_ids, root)
+            preparation = await anyio.to_thread.run_sync(
+                prepare_providers, provider_ids, root, timeout_seconds
+            )
         except ProviderSelectionFailure as error:
             return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
         except SetupFailure as error:

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -56,7 +56,7 @@ PRESERVE = ToolAnnotations(
 )
 PREPARE = ToolAnnotations(
     read_only_hint=False,
-    destructive_hint=True,
+    destructive_hint=False,
     idempotent_hint=True,
     open_world_hint=True,
 )
@@ -104,8 +104,8 @@ class ExternalRequirementEnvelope(BaseModel):
     guidance: str
 
 
-class InstallationEnvelope(BaseModel):
-    status: Literal["installed", "already_configured", "not_applicable"]
+class PreparationStatusEnvelope(BaseModel):
+    status: Literal["prepared", "not_applicable"]
 
 
 class LauncherEnvelope(BaseModel):
@@ -115,9 +115,9 @@ class LauncherEnvelope(BaseModel):
 
 class PreparationEnvelope(_Envelope):
     requested_providers: list[str]
-    configured_managed_providers: list[str]
+    prepared_managed_providers: list[str]
     external_requirements: list[ExternalRequirementEnvelope]
-    installation: InstallationEnvelope
+    preparation: PreparationStatusEnvelope
     launcher: LauncherEnvelope
     restart_required: bool
 
@@ -221,7 +221,7 @@ def create_server(
             "Pass explicit artifact paths or a typed direct target. Analysis and capture are "
             "session-local unless preserve_evidence is called. Use prepare_capabilities only when "
             "discovery reports a missing Flameox-managed provider; reconnect with its returned "
-            "launcher after installation. Flameox never installs host tools, searches parent "
+            "launcher after preparation. Flameox never installs host tools, searches parent "
             "directories, accepts shell strings, or creates durable jobs."
         ),
         lifespan=lifespan,
@@ -272,7 +272,7 @@ def create_server(
         return _success(
             {
                 "requested_providers": preparation.requested_providers,
-                "configured_managed_providers": preparation.configured_managed_providers,
+                "prepared_managed_providers": preparation.prepared_managed_providers,
                 "external_requirements": [
                     {
                         "provider_id": requirement.provider_id,
@@ -280,7 +280,7 @@ def create_server(
                     }
                     for requirement in preparation.external_requirements
                 ],
-                "installation": {"status": preparation.installation_status},
+                "preparation": {"status": preparation.preparation_status},
                 "launcher": {
                     "command": preparation.launcher_command,
                     "args": preparation.launcher_args,

--- a/src/flameox/setup.py
+++ b/src/flameox/setup.py
@@ -2,12 +2,9 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
-
-import portalocker
+from typing import Literal
 
 from flameox import __version__
 
@@ -49,69 +46,19 @@ class ExternalRequirement:
 @dataclass(frozen=True, slots=True)
 class ProviderPreparation:
     requested_providers: list[str]
-    configured_managed_providers: list[str]
+    prepared_managed_providers: list[str]
     external_requirements: list[ExternalRequirement]
-    install_command: list[str]
+    preparation_command: list[str]
     launcher_command: str
     launcher_args: list[str]
 
     @property
-    def changed(self) -> bool:
-        return bool(self.install_command)
-
-    @property
-    def installation_status(self) -> Literal["installed", "already_configured", "not_applicable"]:
-        if not any(item in PYTHON_PROVIDER_EXTRAS for item in self.requested_providers):
-            return "not_applicable"
-        return "installed" if self.changed else "already_configured"
+    def preparation_status(self) -> Literal["prepared", "not_applicable"]:
+        return "prepared" if self.prepared_managed_providers else "not_applicable"
 
     @property
     def restart_required(self) -> bool:
-        return any(item in PYTHON_PROVIDER_EXTRAS for item in self.requested_providers)
-
-
-def installed_tool_extras(tool_directory: Path) -> set[str]:
-    """Read the optional extras uv will replace when reinstalling the Flameox tool."""
-
-    receipt = tool_directory / "flameox" / "uv-receipt.toml"
-    if not receipt.is_file():
-        return set()
-    try:
-        document: Any = tomllib.loads(receipt.read_text())
-        requirements = document["tool"]["requirements"]
-        flameox = next(
-            item
-            for item in requirements
-            if isinstance(item, dict) and item.get("name") == "flameox"
-        )
-        extras = flameox.get("extras", [])
-    except (
-        OSError,
-        KeyError,
-        StopIteration,
-        TypeError,
-        UnicodeError,
-        tomllib.TOMLDecodeError,
-    ) as exc:
-        raise SetupFailure(f"Cannot read the existing uv tool receipt: {receipt}") from exc
-    if not isinstance(extras, list) or not all(isinstance(item, str) for item in extras):
-        raise SetupFailure(f"The existing uv tool receipt has invalid extras: {receipt}")
-    return set(extras)
-
-
-def _uv_tool_directory(uv: Path) -> Path:
-    try:
-        completed = subprocess.run(
-            [str(uv), "tool", "dir"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-    except OSError as error:
-        raise SetupFailure("uv tool dir could not start the uv executable.") from error
-    if completed.returncode != 0 or not completed.stdout.strip():
-        raise SetupFailure("uv tool dir could not locate the managed tool environment.")
-    return Path(completed.stdout.strip())
+        return bool(self.prepared_managed_providers)
 
 
 def _validate_providers(providers: list[str]) -> None:
@@ -123,34 +70,6 @@ def _validate_providers(providers: list[str]) -> None:
         raise ProviderSelectionFailure(
             f"Unknown provider {unknown[0]!r}; choose one of: {supported}"
         )
-
-
-def provider_install_command(
-    providers: list[str], *, uv: Path, installed_extras: set[str] | None = None
-) -> list[str]:
-    _validate_providers(providers)
-    requested_extras = {
-        PYTHON_PROVIDER_EXTRAS[item] for item in providers if item in PYTHON_PROVIDER_EXTRAS
-    }
-    retained_extras = installed_extras or set()
-    effective_installed = (
-        set(PYTHON_PROVIDER_EXTRAS.values()) if "all" in retained_extras else retained_extras
-    )
-    if not requested_extras or requested_extras.issubset(effective_installed):
-        return []
-    extras = sorted(retained_extras | requested_extras)
-    requirement = f"flameox[{','.join(extras)}]=={__version__}"
-    return [
-        str(uv),
-        "tool",
-        "install",
-        "--force",
-        "--python",
-        "3.12",
-        "--prerelease",
-        "allow",
-        requirement,
-    ]
 
 
 def mcp_launcher(providers: list[str]) -> tuple[str, list[str]]:
@@ -180,70 +99,37 @@ def prepare_providers(providers: list[str], project_root: Path) -> ProviderPrepa
         for item in requested
         if item in SYSTEM_PROVIDER_GUIDANCE
     ]
-    if not managed:
-        launcher_command, launcher_args = mcp_launcher([])
-        return ProviderPreparation(
-            requested,
-            [],
-            external,
-            [],
-            launcher_command,
-            [*launcher_args, "mcp", "serve", "--project-root", str(project_root)],
-        )
+    launcher_command, launcher_args = mcp_launcher(managed)
+    server_args = [*launcher_args, "mcp", "serve", "--project-root", str(project_root)]
+    preparation_command: list[str] = []
 
-    uv_text = shutil.which("uv")
-    if uv_text is None:
-        raise SetupFailure("Provider installation requires uv on PATH.")
-    uv = Path(uv_text)
-    tool_directory = _uv_tool_directory(uv)
-    try:
-        with portalocker.Lock(
-            tool_directory / ".flameox-setup.lock",
-            mode="a+",
-            timeout=10,
-            encoding="utf-8",
-        ):
-            installed_extras = installed_tool_extras(tool_directory)
-            command = provider_install_command(
-                managed,
-                uv=uv,
-                installed_extras=installed_extras,
+    if managed:
+        uvx = shutil.which(launcher_command)
+        if uvx is None:
+            raise SetupFailure("Provider preparation requires uvx on PATH.")
+        preparation_command = [uvx, *launcher_args, "--version"]
+        try:
+            completed = subprocess.run(
+                preparation_command,
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=300,
             )
-            if command:
-                try:
-                    completed = subprocess.run(command, check=False)
-                except OSError as error:
-                    raise SetupFailure(
-                        "uv tool install could not start the uv executable."
-                    ) from error
-                if completed.returncode != 0:
-                    raise SetupFailure(
-                        f"uv tool install exited with status {completed.returncode}."
-                    )
-            final_extras = installed_tool_extras(tool_directory) if command else installed_extras
-            requested_extras = {PYTHON_PROVIDER_EXTRAS[item] for item in managed}
-            missing_extras = requested_extras.difference(final_extras)
-            if missing_extras:
-                raise SetupFailure(
-                    "uv reported success but the managed tool receipt is missing extras: "
-                    + ", ".join(sorted(missing_extras))
-                )
-    except portalocker.exceptions.LockException as error:
-        raise SetupFailure("Timed out waiting to update the managed Flameox tool.") from error
-    except OSError as error:
-        raise SetupFailure("Cannot update the managed Flameox tool environment.") from error
+        except OSError as error:
+            raise SetupFailure("uvx could not prepare the provider environment.") from error
+        except subprocess.TimeoutExpired as error:
+            raise SetupFailure("uvx provider preparation exceeded 300 seconds.") from error
+        if completed.returncode != 0:
+            raise SetupFailure(
+                f"uvx provider preparation exited with status {completed.returncode}."
+            )
 
-    configured = sorted(
-        provider
-        for provider, extra in PYTHON_PROVIDER_EXTRAS.items()
-        if extra in final_extras or "all" in final_extras
-    )
-    launcher_command, launcher_args = mcp_launcher(configured)
     return ProviderPreparation(
         requested,
-        configured,
+        managed,
         external,
-        command,
+        preparation_command,
         launcher_command,
-        [*launcher_args, "mcp", "serve", "--project-root", str(project_root)],
+        server_args,
     )

--- a/src/flameox/setup.py
+++ b/src/flameox/setup.py
@@ -28,6 +28,9 @@ SYSTEM_PROVIDER_GUIDANCE = {
     "triton": "Install Triton in the target Python environment and verify device access.",
 }
 
+DEFAULT_PREPARATION_TIMEOUT_SECONDS = 1_800
+MAX_PREPARATION_TIMEOUT_SECONDS = 3_600
+
 
 class SetupFailure(RuntimeError):
     pass
@@ -90,7 +93,26 @@ def mcp_launcher(providers: list[str]) -> tuple[str, list[str]]:
     )
 
 
-def prepare_providers(providers: list[str], project_root: Path) -> ProviderPreparation:
+def _decode_stderr(stderr: bytes | str | None) -> str:
+    if not stderr:
+        return ""
+    return stderr.strip() if isinstance(stderr, str) else stderr.decode(errors="replace").strip()
+
+
+def _failure_message(message: str, stderr: bytes | str | None) -> str:
+    diagnostic = _decode_stderr(stderr)
+    return f"{message}\n\nuvx stderr:\n{diagnostic}" if diagnostic else message
+
+
+def prepare_providers(
+    providers: list[str],
+    project_root: Path,
+    timeout_seconds: int = DEFAULT_PREPARATION_TIMEOUT_SECONDS,
+) -> ProviderPreparation:
+    if not 1 <= timeout_seconds <= MAX_PREPARATION_TIMEOUT_SECONDS:
+        raise SetupFailure(
+            f"timeout_seconds must be between 1 and {MAX_PREPARATION_TIMEOUT_SECONDS}"
+        )
     requested = list(dict.fromkeys(providers))
     _validate_providers(requested)
     managed = [item for item in requested if item in PYTHON_PROVIDER_EXTRAS]
@@ -113,16 +135,23 @@ def prepare_providers(providers: list[str], project_root: Path) -> ProviderPrepa
                 preparation_command,
                 check=False,
                 stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=300,
+                stderr=subprocess.PIPE,
+                timeout=timeout_seconds,
             )
         except OSError as error:
             raise SetupFailure("uvx could not prepare the provider environment.") from error
         except subprocess.TimeoutExpired as error:
-            raise SetupFailure("uvx provider preparation exceeded 300 seconds.") from error
+            raise SetupFailure(
+                _failure_message(
+                    f"uvx provider preparation exceeded {timeout_seconds} seconds.", error.stderr
+                )
+            ) from error
         if completed.returncode != 0:
             raise SetupFailure(
-                f"uvx provider preparation exited with status {completed.returncode}."
+                _failure_message(
+                    f"uvx provider preparation exited with status {completed.returncode}.",
+                    completed.stderr,
+                )
             )
 
     return ProviderPreparation(

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -207,7 +207,10 @@ def test_setup_prepares_exact_python_providers_and_guides_system_tools(
 ) -> None:
     selected: list[list[str]] = []
 
-    def prepare(providers: list[str], project_root: Path) -> ProviderPreparation:
+    def prepare(
+        providers: list[str], project_root: Path, timeout_seconds: int
+    ) -> ProviderPreparation:
+        assert timeout_seconds == 1_800
         selected.append(providers)
         return ProviderPreparation(
             providers,

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -202,7 +202,7 @@ def test_setup_prints_configuration_without_creating_repository(tmp_path: Path) 
     assert not (tmp_path / ".flameox").exists()
 
 
-def test_setup_installs_only_explicit_python_providers_and_guides_system_tools(
+def test_setup_prepares_exact_python_providers_and_guides_system_tools(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     selected: list[list[str]] = []
@@ -211,14 +211,14 @@ def test_setup_installs_only_explicit_python_providers_and_guides_system_tools(
         selected.append(providers)
         return ProviderPreparation(
             providers,
-            ["memray", "py-spy"],
+            ["memray"],
             [
                 ExternalRequirement(
                     "nsight-compute",
                     "Install NVIDIA Nsight Compute with its extras/python interface.",
                 )
             ],
-            ["uv", "tool", "install", f"flameox[memory]=={__version__}"],
+            ["/usr/bin/uvx", "--from", f"flameox[memory]=={__version__}", "--version"],
             "uvx",
             [
                 "--python",
@@ -251,7 +251,8 @@ def test_setup_installs_only_explicit_python_providers_and_guides_system_tools(
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert selected == [["memray", "nsight-compute"]]
-    assert payload["providers"] == ["memray", "nsight-compute", "py-spy"]
+    assert payload["providers"] == ["memray", "nsight-compute"]
+    assert payload["preparation_command"][0] == "/usr/bin/uvx"
     assert f"flameox[cpu,memory]=={__version__}" in payload["args"]
     assert "extras/python" in payload["external_guidance"][0]
     assert not (tmp_path / ".flameox").exists()

--- a/tests/test_setup_stateless.py
+++ b/tests/test_setup_stateless.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from subprocess import CompletedProcess
 
 import pytest
 
 from flameox import __version__
-from flameox.setup import SetupFailure, mcp_launcher, prepare_providers
+from flameox.setup import (
+    DEFAULT_PREPARATION_TIMEOUT_SECONDS,
+    SetupFailure,
+    mcp_launcher,
+    prepare_providers,
+)
 
 
 def test_mcp_launcher_pins_python_release_and_provider_extras() -> None:
@@ -26,10 +32,12 @@ def test_preparation_runs_and_returns_the_same_exact_uvx_environment(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     calls: list[list[str]] = []
+    options: list[dict[str, object]] = []
 
-    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
+    def run(command: list[str], **kwargs: object) -> CompletedProcess[bytes]:
         calls.append(command)
-        return CompletedProcess(command, 0)
+        options.append(kwargs)
+        return CompletedProcess(command, 0, stderr=b"")
 
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
     monkeypatch.setattr("flameox.setup.subprocess.run", run)
@@ -51,6 +59,14 @@ def test_preparation_runs_and_returns_the_same_exact_uvx_environment(
             "flameox",
             "--version",
         ]
+    ]
+    assert options == [
+        {
+            "check": False,
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.PIPE,
+            "timeout": DEFAULT_PREPARATION_TIMEOUT_SECONDS,
+        }
     ]
     assert prepared.launcher_command == "uvx"
     assert prepared.launcher_args == [
@@ -95,11 +111,57 @@ def test_uvx_failure_is_normalized_as_setup_failure(
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
     monkeypatch.setattr(
         "flameox.setup.subprocess.run",
-        lambda command, **_kwargs: CompletedProcess(command, 2),
+        lambda command, **_kwargs: CompletedProcess(
+            command,
+            2,
+            stderr=b"No solution found: dependency conflict.\xff",
+        ),
     )
 
-    with pytest.raises(SetupFailure, match="status 2"):
+    with pytest.raises(SetupFailure) as raised:
         prepare_providers(["memray"], tmp_path)
+
+    assert "status 2" in str(raised.value)
+    assert "No solution found: dependency conflict.\ufffd" in str(raised.value)
+
+
+def test_preparation_timeout_is_configurable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed: dict[str, object] = {}
+
+    def run(command: list[str], **kwargs: object) -> CompletedProcess[bytes]:
+        observed.update(kwargs)
+        return CompletedProcess(command, 0, stderr=b"")
+
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
+    monkeypatch.setattr("flameox.setup.subprocess.run", run)
+
+    prepare_providers(["torch"], tmp_path, timeout_seconds=2_400)
+
+    assert observed["timeout"] == 2_400
+
+
+def test_preparation_timeout_preserves_uvx_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def run(*_args: object, **_kwargs: object) -> CompletedProcess[bytes]:
+        raise subprocess.TimeoutExpired("uvx", 2_400, stderr=b"download stalled\xff")
+
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
+    monkeypatch.setattr("flameox.setup.subprocess.run", run)
+
+    with pytest.raises(SetupFailure) as raised:
+        prepare_providers(["torch"], tmp_path, timeout_seconds=2_400)
+
+    assert "exceeded 2400 seconds" in str(raised.value)
+    assert "download stalled\ufffd" in str(raised.value)
+
+
+@pytest.mark.parametrize("timeout_seconds", [0, 3_601])
+def test_preparation_timeout_is_bounded(timeout_seconds: int, tmp_path: Path) -> None:
+    with pytest.raises(SetupFailure, match="between 1 and 3600"):
+        prepare_providers(["torch"], tmp_path, timeout_seconds=timeout_seconds)
 
 
 def test_uvx_start_failure_is_normalized_as_setup_failure(

--- a/tests/test_setup_stateless.py
+++ b/tests/test_setup_stateless.py
@@ -1,27 +1,19 @@
 from __future__ import annotations
 
-import threading
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from subprocess import CompletedProcess
 
 import pytest
 
 from flameox import __version__
-from flameox.setup import (
-    SetupFailure,
-    installed_tool_extras,
-    mcp_launcher,
-    prepare_providers,
-    provider_install_command,
-)
+from flameox.setup import SetupFailure, mcp_launcher, prepare_providers
 
 
 def test_mcp_launcher_pins_python_release_and_provider_extras() -> None:
     command, args = mcp_launcher(["memray", "nsight-compute", "py-spy"])
 
     assert command == "uvx"
-    assert args[:5] == [
+    assert args == [
         "--python",
         "3.12",
         "--from",
@@ -30,196 +22,99 @@ def test_mcp_launcher_pins_python_release_and_provider_extras() -> None:
     ]
 
 
-def test_provider_install_command_adds_declared_extras_to_managed_tool() -> None:
-    command = provider_install_command(
-        ["perfetto", "memray", "otlp"],
-        uv=Path("/usr/bin/uv"),
-        installed_extras={"cpu"},
-    )
+def test_preparation_runs_and_returns_the_same_exact_uvx_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
 
-    assert command == [
-        "/usr/bin/uv",
-        "tool",
-        "install",
-        "--force",
+    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
+        calls.append(command)
+        return CompletedProcess(command, 0)
+
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
+    monkeypatch.setattr("flameox.setup.subprocess.run", run)
+
+    prepared = prepare_providers(["memray", "py-spy", "memray"], tmp_path)
+
+    requirement = f"flameox[cpu,memory]=={__version__}"
+    assert prepared.requested_providers == ["memray", "py-spy"]
+    assert prepared.prepared_managed_providers == ["memray", "py-spy"]
+    assert prepared.preparation_status == "prepared"
+    assert prepared.restart_required is True
+    assert calls == [
+        [
+            "/usr/bin/uvx",
+            "--python",
+            "3.12",
+            "--from",
+            requirement,
+            "flameox",
+            "--version",
+        ]
+    ]
+    assert prepared.launcher_command == "uvx"
+    assert prepared.launcher_args == [
         "--python",
         "3.12",
-        "--prerelease",
-        "allow",
-        f"flameox[cpu,memory,trace]=={__version__}",
+        "--from",
+        requirement,
+        "flameox",
+        "mcp",
+        "serve",
+        "--project-root",
+        str(tmp_path),
     ]
 
 
-def test_system_provider_has_guidance_but_no_python_install() -> None:
-    assert provider_install_command(["nsight-compute"], uv=Path("uv")) == []
-
-
-def test_system_only_preparation_does_not_require_uv(
+def test_host_only_preparation_returns_guidance_without_requiring_uvx(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: None)
 
     prepared = prepare_providers(["nsight-compute"], tmp_path)
 
-    assert prepared.configured_managed_providers == []
+    assert prepared.prepared_managed_providers == []
     assert [item.provider_id for item in prepared.external_requirements] == ["nsight-compute"]
-    assert prepared.install_command == []
-    assert prepared.changed is False
+    assert prepared.preparation_command == []
+    assert prepared.preparation_status == "not_applicable"
     assert prepared.restart_required is False
 
 
-def test_provider_install_is_a_noop_when_requested_extra_is_already_managed() -> None:
-    assert (
-        provider_install_command(
-            ["py-spy"],
-            uv=Path("/usr/bin/uv"),
-            installed_extras={"cpu", "memory"},
-        )
-        == []
-    )
-
-
-def test_installed_tool_extras_are_read_from_uv_receipt(tmp_path: Path) -> None:
-    tool = tmp_path / "flameox"
-    tool.mkdir()
-    (tool / "uv-receipt.toml").write_text(
-        """
-[tool]
-requirements = [{ name = "flameox", extras = ["cpu", "memory"], specifier = "==0.2.1" }]
-"""
-    )
-
-    assert installed_tool_extras(tmp_path) == {"cpu", "memory"}
-
-
-def test_all_extra_satisfies_and_survives_managed_provider_preparation() -> None:
-    assert (
-        provider_install_command(
-            ["memray", "py-spy"],
-            uv=Path("/usr/bin/uv"),
-            installed_extras={"all"},
-        )
-        == []
-    )
-
-
-def test_provider_install_retains_existing_managed_providers(
+def test_uvx_is_required_before_managed_preparation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    tool = tmp_path / "tools" / "flameox"
-    tool.mkdir(parents=True)
-    (tool / "uv-receipt.toml").write_text(
-        '[tool]\nrequirements = [{ name = "flameox", extras = ["cpu"] }]\n'
-    )
-    calls: list[list[str]] = []
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: None)
 
-    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
-        calls.append(command)
-        if command[1:] == ["tool", "dir"]:
-            return CompletedProcess(command, 0, f"{tmp_path / 'tools'}\n", "")
-        (tool / "uv-receipt.toml").write_text(
-            '[tool]\nrequirements = [{ name = "flameox", extras = ["cpu", "memory"] }]\n'
-        )
-        return CompletedProcess(command, 0, "", "")
-
-    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
-    monkeypatch.setattr("flameox.setup.subprocess.run", run)
-
-    installed = prepare_providers(["memray"], tmp_path)
-
-    assert calls[-1][-1] == f"flameox[cpu,memory]=={__version__}"
-    assert installed.configured_managed_providers == ["memray", "py-spy"]
-    assert installed.changed is True
-    assert installed.restart_required is True
+    with pytest.raises(SetupFailure, match="requires uvx"):
+        prepare_providers(["memray"], tmp_path)
 
 
-def test_satisfied_managed_provider_still_returns_a_reconnect_launcher(
+def test_uvx_failure_is_normalized_as_setup_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    tool = tmp_path / "tools" / "flameox"
-    tool.mkdir(parents=True)
-    (tool / "uv-receipt.toml").write_text(
-        '[tool]\nrequirements = [{ name = "flameox", extras = ["cpu"] }]\n'
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
+    monkeypatch.setattr(
+        "flameox.setup.subprocess.run",
+        lambda command, **_kwargs: CompletedProcess(command, 2),
     )
 
-    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
-        assert command[1:] == ["tool", "dir"]
-        return CompletedProcess(command, 0, f"{tmp_path / 'tools'}\n", "")
-
-    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
-    monkeypatch.setattr("flameox.setup.subprocess.run", run)
-
-    prepared = prepare_providers(["py-spy"], tmp_path)
-
-    assert prepared.changed is False
-    assert prepared.restart_required is True
-    assert prepared.launcher_args[-4:] == ["mcp", "serve", "--project-root", str(tmp_path)]
+    with pytest.raises(SetupFailure, match="status 2"):
+        prepare_providers(["memray"], tmp_path)
 
 
-def test_uv_start_failure_is_normalized_as_setup_failure(
+def test_uvx_start_failure_is_normalized_as_setup_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     def fail(*_args: object, **_kwargs: object) -> CompletedProcess[str]:
         raise PermissionError("denied")
 
-    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
+    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uvx")
     monkeypatch.setattr("flameox.setup.subprocess.run", fail)
 
-    with pytest.raises(SetupFailure, match="could not start"):
+    with pytest.raises(SetupFailure, match="could not prepare"):
         prepare_providers(["memray"], tmp_path)
 
 
-def test_concurrent_preparation_retains_both_provider_extra_sets(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    tool_directory = tmp_path / "tools"
-    tool_directory.mkdir()
-    both_located = threading.Event()
-    calls_guard = threading.Lock()
-    tool_dir_calls = 0
-    install_requirements: list[str] = []
-
-    def run(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
-        nonlocal tool_dir_calls
-        if command[1:] == ["tool", "dir"]:
-            with calls_guard:
-                tool_dir_calls += 1
-                if tool_dir_calls == 2:
-                    both_located.set()
-            return CompletedProcess(command, 0, f"{tool_directory}\n", "")
-
-        assert both_located.wait(timeout=2)
-        requirement = command[-1]
-        install_requirements.append(requirement)
-        extras = requirement.partition("[")[2].partition("]")[0].split(",")
-        receipt = tool_directory / "flameox" / "uv-receipt.toml"
-        receipt.parent.mkdir(exist_ok=True)
-        extras_toml = ", ".join(f'"{extra}"' for extra in extras)
-        receipt.write_text(
-            f'[tool]\nrequirements = [{{ name = "flameox", extras = [{extras_toml}] }}]\n'
-        )
-        return CompletedProcess(command, 0, "", "")
-
-    monkeypatch.setattr("flameox.setup.shutil.which", lambda _name: "/usr/bin/uv")
-    monkeypatch.setattr("flameox.setup.subprocess.run", run)
-
-    with ThreadPoolExecutor(max_workers=2) as executor:
-        results = list(
-            executor.map(
-                prepare_providers,
-                [["memray"], ["otlp"]],
-                [tmp_path, tmp_path],
-            )
-        )
-
-    assert len(install_requirements) == 2
-    assert any("flameox[memory,trace]" in requirement for requirement in install_requirements)
-    assert any(
-        set(result.configured_managed_providers) == {"memray", "otlp", "perfetto"}
-        for result in results
-    )
-
-
-def test_unknown_provider_is_rejected_before_installation() -> None:
+def test_unknown_provider_is_rejected_before_preparation(tmp_path: Path) -> None:
     with pytest.raises(SetupFailure, match="Unknown provider"):
-        provider_install_command(["mystery"], uv=Path("uv"))
+        prepare_providers(["mystery"], tmp_path)

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1789,7 +1789,7 @@ def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
         prepare = next(tool for tool in tools if tool.name == "prepare_capabilities")
         assert prepare.annotations and prepare.annotations.open_world_hint is True
         assert prepare.annotations.read_only_hint is False
-        assert prepare.annotations.destructive_hint is True
+        assert prepare.annotations.destructive_hint is False
         assert all(
             tool.annotations and tool.annotations.open_world_hint is False
             for tool in tools
@@ -1806,12 +1806,12 @@ def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
 def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    installed: list[list[str]] = []
+    preparation_calls: list[list[str]] = []
 
     def prepare(provider_ids: list[str], project_root: Path) -> ProviderPreparation:
         if provider_ids == ["unknown-provider"]:
             raise ProviderSelectionFailure("Unknown provider 'unknown-provider'")
-        installed.append(provider_ids)
+        preparation_calls.append(provider_ids)
         return ProviderPreparation(
             ["memray", "nsight-compute"],
             ["memray"],
@@ -1821,7 +1821,7 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
                     "Install NVIDIA Nsight Compute with its extras/python interface.",
                 )
             ],
-            ["uv", "tool", "install", f"flameox[memory]=={__version__}"],
+            ["/usr/bin/uvx", "--from", f"flameox[memory]=={__version__}", "--version"],
             "uvx",
             [
                 "--python",
@@ -1854,14 +1854,14 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
             "memray",
             "nsight-compute",
         ]
-        assert result.structured_content["configured_managed_providers"] == ["memray"]
+        assert result.structured_content["prepared_managed_providers"] == ["memray"]
         assert result.structured_content["external_requirements"] == [
             {
                 "provider_id": "nsight-compute",
                 "guidance": "Install NVIDIA Nsight Compute with its extras/python interface.",
             }
         ]
-        assert result.structured_content["installation"]["status"] == "installed"
+        assert result.structured_content["preparation"]["status"] == "prepared"
         assert result.structured_content["restart_required"] is True
         assert result.structured_content["launcher"]["args"][3] == (
             f"flameox[memory]=={__version__}"
@@ -1878,7 +1878,7 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
         assert invalid.structured_content["code"] == "INVALID_INPUT"
 
     anyio.run(exercise)
-    assert installed == [["memray", "nsight-compute", "memray"]]
+    assert preparation_calls == [["memray", "nsight-compute", "memray"]]
 
 
 @pytest.mark.process

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1808,7 +1808,10 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
 ) -> None:
     preparation_calls: list[list[str]] = []
 
-    def prepare(provider_ids: list[str], project_root: Path) -> ProviderPreparation:
+    def prepare(
+        provider_ids: list[str], project_root: Path, timeout_seconds: int
+    ) -> ProviderPreparation:
+        assert timeout_seconds == 1_800
         if provider_ids == ["unknown-provider"]:
             raise ProviderSelectionFailure("Unknown provider 'unknown-provider'")
         preparation_calls.append(provider_ids)


### PR DESCRIPTION
### Problem

`prepare_capabilities` installed provider extras into a persistent `uv tool` environment but returned a version-pinned `uvx` launcher. Those are different environments, so the operation prepared one runtime and told the agent to reconnect through another.

That mismatch also required Flameox to maintain an installed-extra inventory, parse uv receipts, merge extras, and lock receipt updates even though the returned uvx requirement already described the environment the agent would use.

### Change

Prepare the exact uvx requirement returned to the caller. For managed providers, setup now runs the version-pinned environment once with `flameox --version`, then returns the same requirement with `flameox mcp serve --project-root ...`.

Each request names the complete managed-provider set for its launcher. Flameox keeps no setup receipt or provider inventory. Host and vendor tools remain external requirements and receive guidance without invoking uvx.

The MCP result now reports `prepared_managed_providers` and a `preparation.status` of `prepared` or `not_applicable`. The operation remains idempotent and open-world, but is no longer marked destructive because it only populates uvx cache rather than replacing a persistent tool environment.

Preparation captures complete uvx stderr in `SETUP_FAILURE`, decoding invalid UTF-8 with replacement so resolver and download failures remain actionable. Its previous fixed five-minute deadline is now a configurable `timeout_seconds` bound: 1,800 seconds by default and 3,600 seconds maximum, exposed consistently through MCP and CLI.

This removes the receipt parser, installed-extra union, persistent-tool replacement, and cross-process setup lock.

### Validation

- `uv run pytest -q` — 131 passed, 77 deselected
- `uv run pytest -q -m process` — 74 passed, 134 deselected
- `uv run ruff check src tests tools` — passed
- `uv run mypy src tests tools` — passed for 107 source files
- `uv run lint-imports` — 2 contracts kept
- `git diff --check` — passed

### Compatibility

The preparation result field names change from installation/configuration terminology to preparation terminology. Callers must provide the complete managed-provider list they want in the returned launcher; provider selections are no longer merged with a persistent Flameox inventory.

`prepare_capabilities` and `flameox setup` gain an optional bounded timeout; their default increases from five to thirty minutes. System profilers, drivers, permissions, and workload-interpreter packages remain outside this operation.