### PR TITLE
feat(mcp): expose typed capability tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,11 @@ uv sync --extra dev --extra memory --extra trace --extra cpu --extra torch
 
 ## Understand the contract you are changing
 
-Production code uses a `src/` layout. `stateless.py` owns request-local orchestration and public
-contracts, `repository.py` owns optional immutable preservation, and `execution.py` owns bounded
-subprocess work. Provider integrations live in `providers/`, reusable native-format parsing in
-`adapters/`, isolated protocols in `workers/`, and transport code in `cli.py` and `mcp/`. Tests
-mirror these semantic owners under `tests/`.
+Production code uses a `src/` layout. `runtime_contracts.py` owns public contracts and registries,
+`stateless.py` owns request-local orchestration, `repository.py` owns optional immutable
+preservation, and `execution.py` owns bounded subprocess work. Provider integrations live in
+`providers/`, reusable native-format parsing in `adapters/`, isolated protocols in `workers/`, and
+transport code in `cli.py` and `mcp/`. Tests mirror these semantic owners under `tests/`.
 
 Read the contract that owns the behavior before editing it:
 
@@ -58,7 +58,7 @@ Read the contract that owns the behavior before editing it:
 | Process model, dependencies, and package boundaries | [Architecture](docs/architecture.md) |
 | Storage, provenance, publication, and schemas | [Storage and evidence](docs/storage-and-evidence.md) |
 | Experiments, comparisons, statistics, and evidence quality | [Investigations](docs/investigations.md) |
-| Profiler integrations, compatibility, and capability probing | [Adapters](docs/adapters.md) |
+| Profiler integrations, compatibility, and adapter policy | [Adapters](docs/adapters.md) |
 | Concurrency, recovery, integrity, security, and privacy | [Runtime safety](docs/runtime-safety.md) |
 | CLI and MCP behavior and trust boundaries | [Interfaces](docs/interfaces.md) |
 | Test markers, provider requirements, and CI | [Testing](docs/testing.md) |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ paths and formats to `analyze`; old `.diagnostics` state is not migrated.
 
 ```console
 uv sync --extra dev --extra memory --extra trace --extra cpu
-uv run flameox capabilities discover --intent "CPU hotspots"
+uv run flameox mcp inspect
 uv run flameox analyze artifact.preview /absolute/path/to/artifact.json
 uv run flameox capture --provider direct -- python benchmark.py
 ```
@@ -95,9 +95,10 @@ only through explicit local manifest inspection. Native artifact bytes are
 deliberately not available as MCP resources.
 
 Direct capture accepts an argv array, a project-contained cwd, bounded environment overrides, a
-typed compatible-provider variant, capability-specific options, and limits. Shell strings are never
-accepted. Work remains owned by the live MCP request, so SDK progress and cancellation apply
-directly; there are no detached or restart-surviving tasks.
+typed compatible-provider variant, capability-specific options, an explicit single/experiment
+choice, and limits as top-level tool arguments. There is no generic request or arguments envelope.
+Shell strings are never accepted. Work remains owned by the live MCP request, so SDK progress and
+cancellation apply directly; there are no detached or restart-surviving tasks.
 
 Managed external collectors such as py-spy execute from Flameox's uvx
 environment. In-process collectors such as coverage.py and Memray are verified

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ coverage, truncation, limitations, and optional immutable preservation.
 
 The server exposes actual evidence operations for client-side tool search instead of hiding its
 capabilities behind `discover`, `inspect`, or generic `analyze(capability_id, arguments)` calls.
-There are 24 read-only analysis tools, 18 executing capture tools, and three lifecycle tools. For
+There are 24 read-only analysis tools, 17 executing capture tools, and three lifecycle tools. For
 example:
 
 ```text
 analyze_cpu_hotspots       capture_cpu_hotspots
 analyze_gpu_launches       capture_gpu_launches
-analyze_benchmark_compare  capture_benchmark_compare
+analyze_benchmark_compare  capture_benchmark_summary
 analyze_kernel_validation  capture_sanitizer_failures
 prepare_providers          preserve_evidence          query_evidence
 ```

--- a/README.md
+++ b/README.md
@@ -70,15 +70,23 @@ coverage, truncation, limitations, and optional immutable preservation.
 
 ## MCP interface
 
-The server exposes exactly seven tools:
+The server exposes actual evidence operations for client-side tool search instead of hiding its
+capabilities behind `discover`, `inspect`, or generic `analyze(capability_id, arguments)` calls.
+There are 24 read-only analysis tools, 18 executing capture tools, and three lifecycle tools. For
+example:
 
-- `discover_capabilities`
-- `inspect_capabilities`
-- `prepare_capabilities`
-- `analyze`
-- `capture_and_analyze`
-- `preserve_evidence`
-- `query_evidence`
+```text
+analyze_cpu_hotspots       capture_cpu_hotspots
+analyze_gpu_launches       capture_gpu_launches
+analyze_benchmark_compare  capture_benchmark_compare
+analyze_kernel_validation  capture_sanitizer_failures
+prepare_providers          preserve_evidence          query_evidence
+```
+
+Each tool advertises its capability-specific options and compatible providers in its input schema.
+Analysis and capture have separate names and annotations because reading an artifact and executing a
+target are materially different effects. Tool search happens in the MCP client; Flameox does not
+require an additional catalog-search call.
 
 It exposes one resource template, `flameox://evidence/{evidence_id}`, for the
 digest-bound, redacted projection of the canonical immutable manifest. Full
@@ -86,21 +94,19 @@ argv, environment values, working directories, and host paths remain available
 only through explicit local manifest inspection. Native artifact bytes are
 deliberately not available as MCP resources.
 
-Direct capture accepts an argv array, a project-contained cwd, bounded
-environment overrides, provider and analysis arguments, and limits. Shell
-strings are never accepted. Work remains owned by the live MCP request, so SDK
-progress and cancellation apply directly; there are no detached or
-restart-surviving tasks.
+Direct capture accepts an argv array, a project-contained cwd, bounded environment overrides, a
+typed compatible-provider variant, capability-specific options, and limits. Shell strings are never
+accepted. Work remains owned by the live MCP request, so SDK progress and cancellation apply
+directly; there are no detached or restart-surviving tasks.
 
 Managed external collectors such as py-spy execute from Flameox's uvx
 environment. In-process collectors such as coverage.py and Memray are verified
 in, and run with, the workload's declared Python interpreter. Flameox does not
-substitute one Python runtime for the other. When discovery reports a missing
-managed provider, `prepare_capabilities` prepares its version-pinned uvx
-environment and returns that same launcher for reconnection. The agent supplies
-the complete provider list it wants in that launcher; Flameox does not merge it
-with prior calls. Host tools, drivers, and permissions are never installed or
-changed; the same result reports their setup guidance.
+substitute one Python runtime for the other. When a capture reports a missing managed provider,
+`prepare_providers` prepares its version-pinned uvx environment and returns that same launcher for
+reconnection. The agent supplies the complete provider list it wants in that launcher; Flameox does
+not merge it with prior calls. Host tools, drivers, and permissions are never installed or changed;
+the same result reports their setup guidance.
 
 ## Evidence quality
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@ Flameox 是面向编码代理的本地、有界运行时证据层。它协调分
 包含 argv、项目内 cwd、环境覆盖、提供方参数和限制的类型化目标。
 
 ```console
-uv run flameox capabilities discover --intent "CPU 热点"
+uv run flameox mcp inspect
 uv run flameox analyze artifact.preview /absolute/path/to/artifact.json
 uv run flameox capture --provider direct -- python benchmark.py
 uv run flameox mcp serve --project-root "$PWD"
@@ -23,9 +23,10 @@ Python 扩展安装到持久的 uv 工具环境；NVIDIA 等系统或厂商工�
 `<project>/.flameox`。原生字节和证据清单按 SHA-256 寻址，并通过同一文件系统
 上的暂存、校验、fsync 和原子重命名发布。
 
-MCP 只公开六个工具：`discover_capabilities`、`inspect_capabilities`、
-`analyze`、`capture_and_analyze`、`preserve_evidence` 和
-`query_evidence`。唯一资源模板是
+MCP 公开面向任务的类型化分析和采集工具，例如 `analyze_cpu_hotspots`、
+`capture_gpu_launches` 和 `analyze_benchmark_compare`，以及
+`prepare_providers`、`preserve_evidence` 和 `query_evidence`。工具搜索由 MCP
+客户端负责。唯一资源模板是
 `flameox://evidence/{evidence_id}`，只返回不可变规范清单，不公开原生载荷。
 
 `analysis_id` 仅在当前服务进程内有效；重启后过期。`evidence_id` 是持久的内容

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -11,7 +11,7 @@ Each capability registry entry owns:
 - the capability descriptor and stable ID;
 - accepted source modes and formats;
 - a strict validation-equivalent argument model;
-- provider probes and compatibility rules;
+- compatibility rules derived from declared artifact formats;
 - capture and analysis handlers;
 - model-visible selection guidance, bounded examples, limits, overhead, and limitations.
 
@@ -20,10 +20,10 @@ roles and formats, and selection description. Generated MCP schemas, pre-executi
 checks, and capture argument validation consume that same contract so their format claims cannot
 drift.
 
-Provider probes inspect packages, executables, platform, supported version, permission, and required
-external resources without mutating the host. Capability tools remain discoverable when a provider
-is absent. Invoking an unavailable provider is a typed tool error with either an exact
-`prepare_providers` retry action or external host guidance.
+Capability tools remain discoverable when a provider is absent. Capture validates the selected
+provider's package, executable, platform, version, permission, and required external resources as
+part of the attempted operation, before workload execution. An unavailable provider returns a typed
+error with either an exact `prepare_providers` retry action or external host guidance.
 
 ## Evidence and capture support
 
@@ -42,7 +42,7 @@ Artifact analysis and typed capture are separate contracts:
 | Reliability | pytest events, observations, coverage.py | `pytest`, `observations`, `coverage` |
 | Static candidates | SARIF | — |
 | Inference exports | AIPerf, vLLM, SGLang, Mooncake | — |
-| Generic previews | JSON, JSONL, CSV, text, Parquet | — |
+| Generic previews | JSON, JSONL, CSV, text, Parquet | `direct` process output |
 
 An em dash means callers provide an explicit artifact path; it does not mean
 the format is unsupported. The offline inference readers omit prompts,

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -13,16 +13,17 @@ Each capability registry entry owns:
 - a strict validation-equivalent argument model;
 - provider probes and compatibility rules;
 - capture and analysis handlers;
-- bounded examples, limits, overhead, and limitations.
+- model-visible selection guidance, bounded examples, limits, overhead, and limitations.
 
 One immutable capture-provider contract owns each provider's argument model, declared artifact
-roles and formats, and discovery description. Inspection, pre-execution compatibility checks, and
-capture argument validation consume that same contract so their format claims cannot drift.
+roles and formats, and selection description. Generated MCP schemas, pre-execution compatibility
+checks, and capture argument validation consume that same contract so their format claims cannot
+drift.
 
-Discovery probes packages, executables, platform, supported version, permission,
-and required external resources without mutating the host. Missing dependencies
-are successful availability results with remediation outside Flameox. Invoking
-an unavailable provider is a typed tool error.
+Provider probes inspect packages, executables, platform, supported version, permission, and required
+external resources without mutating the host. Capability tools remain discoverable when a provider
+is absent. Invoking an unavailable provider is a typed tool error with either an exact
+`prepare_providers` retry action or external host guidance.
 
 ## Evidence and capture support
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,13 +51,17 @@ catalog. Flameox production code must not create or depend on SQLite state.
 
 ## Capability boundary
 
-One registry entry owns a capability descriptor, strict argument model,
-accepted formats, provider probes, and capture/analysis semantics. Discovery
-performs only bounded suffix/header sniffing. Missing packages, executables,
-permissions, versions, or platforms are successful discovery states; Flameox
-never installs remediation automatically. The separately invoked CLI setup command or MCP
-`prepare_capabilities` tool may prepare the exact version-pinned uvx environment named by an
-explicit Python provider set; neither creates project state nor owns a durable operation or provider
+One registry entry owns a capability descriptor, strict argument model, accepted formats, provider
+probes, capture/analysis semantics, and model-visible selection guidance. MCP projects each entry
+into a read-only analysis tool and, when a compatible capture provider exists, a separate executing
+capture tool. The generated callable closes over the stable capability ID; agents never pass a
+capability selector or a free-form analysis argument object.
+
+Capture-provider contracts supply the discriminated provider variants for each compatible capture
+tool. Missing packages, executables, permissions, versions, or platforms do not change the catalog;
+the attempted tool returns typed remediation. The separately invoked CLI setup command or MCP
+`prepare_providers` tool may prepare the exact version-pinned uvx environment named by an explicit
+Python provider set; neither creates project state nor owns a durable operation or provider
 inventory. Host profilers, drivers, and permissions remain external and receive guidance only.
 
 Direct capture is trusted local execution, not containment. Typed argv prevents

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,8 +36,8 @@ durable SHA-256 identity derived from the canonical manifest body.
 
 ## Package boundaries
 
-- `stateless.py` owns public models, capability discovery, bounded analysis,
-  capture orchestration, scratch, and the session cache.
+- `runtime_contracts.py` owns public models and the capability/capture-provider registries.
+- `stateless.py` owns bounded analysis, capture orchestration, scratch, and the session cache.
 - `repository.py` owns lazy repository creation, validation, publication,
   inventory queries, and immutable resource reads.
 - `execution.py` and `command_binding.py` own executable binding, subprocess
@@ -51,8 +51,8 @@ catalog. Flameox production code must not create or depend on SQLite state.
 
 ## Capability boundary
 
-One registry entry owns a capability descriptor, strict argument model, accepted formats, provider
-probes, capture/analysis semantics, and model-visible selection guidance. MCP projects each entry
+One registry entry owns a capability descriptor, strict argument model, accepted formats,
+capture/analysis semantics, and model-visible selection guidance. MCP projects each entry
 into a read-only analysis tool and, when a compatible capture provider exists, a separate executing
 capture tool. The generated callable closes over the stable capability ID; agents never pass a
 capability selector or a free-form analysis argument object.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -10,12 +10,12 @@ search/inspect protocol in front of its operations. A caller that knows the evid
 invoke its tool directly; an unfamiliar caller relies on the MCP client's ordinary tool search and
 then receives the selected tool's complete schema.
 
-There are exactly 45 tools:
+There are exactly 44 tools:
 
 | Group | Count | Examples | Effect |
 | --- | ---: | --- | --- |
 | Existing-artifact analysis | 24 | `analyze_cpu_hotspots`, `analyze_gpu_launches`, `analyze_benchmark_compare`, `analyze_kernel_validation`, `preview_artifact` | Read-only and idempotent. |
-| Capture and immediate analysis | 18 | `capture_cpu_hotspots`, `capture_gpu_launches`, `capture_benchmark_compare`, `capture_sanitizer_failures`, `capture_process_output` | Executes typed argv; not read-only or idempotent. |
+| Capture and immediate analysis | 17 | `capture_cpu_hotspots`, `capture_gpu_launches`, `capture_benchmark_summary`, `capture_sanitizer_failures`, `capture_process_output` | Executes typed argv; not read-only or idempotent. |
 | Evidence lifecycle | 3 | `prepare_providers`, `preserve_evidence`, `query_evidence` | Prepare an explicit uvx environment or manage immutable evidence. |
 
 The capability registry generates the analysis and capture tools through the Python MCP SDK 2.0
@@ -59,7 +59,8 @@ view. A missing resource is a protocol error.
 Every tool advertises a compact output schema for its stable result envelope. Provider-specific
 metrics and rows remain open JSON values. Success uses structured content directly, without an
 `ok/result/error` wrapper. Tool failures set `isError=true` and carry a stable code, message, and
-details; both success and failure shapes validate against the advertised schema.
+details. MCP SDK argument-validation errors occur before tool execution and therefore use the
+protocol error shape rather than the tool's output schema.
 
 `prepare_providers` is the only open-world tool. It resolves the exact package requirement through
 `uvx`, verifies that environment by running Flameox's version command, and returns the same

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -5,17 +5,31 @@ provider behavior, or lifecycle state.
 
 ## MCP catalog
 
-The catalog contains exactly seven tools:
+The catalog exposes task-shaped tools for client-side tool search. Flameox does not add a second
+search/inspect protocol in front of its operations. A caller that knows the evidence question can
+invoke its tool directly; an unfamiliar caller relies on the MCP client's ordinary tool search and
+then receives the selected tool's complete schema.
 
-| Tool | Behavior |
-| --- | --- |
-| `discover_capabilities` | Rank by intent and bounded source sniffing; report provider state and external remediation. |
-| `inspect_capabilities` | Inspect 1-16 IDs with source modes, strict argument schema, examples, limits, and capture semantics. |
-| `prepare_capabilities` | Prepare an exact version-pinned uvx environment for 1-16 selected managed providers and return that launcher; report host-tool guidance without changing the host. |
-| `analyze` | Analyze 1-32 explicit path/evidence sources and return bounded inline evidence plus a session `analysis_id`. |
-| `capture_and_analyze` | Run typed argv through the broker in single or bounded experiment mode, then analyze outputs. |
-| `preserve_evidence` | Idempotently publish one session analysis and return an evidence reference plus `ResourceLink`. |
-| `query_evidence` | Search a deterministic immutable manifest inventory with bounded pagination. |
+There are exactly 45 tools:
+
+| Group | Count | Examples | Effect |
+| --- | ---: | --- | --- |
+| Existing-artifact analysis | 24 | `analyze_cpu_hotspots`, `analyze_gpu_launches`, `analyze_benchmark_compare`, `analyze_kernel_validation`, `preview_artifact` | Read-only and idempotent. |
+| Capture and immediate analysis | 18 | `capture_cpu_hotspots`, `capture_gpu_launches`, `capture_benchmark_compare`, `capture_sanitizer_failures`, `capture_process_output` | Executes typed argv; not read-only or idempotent. |
+| Evidence lifecycle | 3 | `prepare_providers`, `preserve_evidence`, `query_evidence` | Prepare an explicit uvx environment or manage immutable evidence. |
+
+The capability registry generates the analysis and capture tools. A generated analysis tool accepts
+one strict `request` containing 1-32 path/evidence sources, capability-specific typed `options`,
+optional lowered limits, and an optional continuation. A generated capture tool accepts one strict
+`request` containing the direct target, a discriminated union of only compatible capture providers,
+capability-specific typed `options`, a `single` or `experiment` execution union, optional lowered
+limits, and optional preservation. There are no free-form provider or analysis argument objects.
+
+Analysis and capture remain separate tools even when they return the same evidence envelope. MCP
+annotations describe a whole tool, so combining read-only artifact analysis and target execution
+behind a mode flag would conceal a material effect change. Provider choice stays inside a capture
+tool because it is a typed implementation choice for one evidence question; incompatible providers
+cannot be represented by that tool's schema.
 
 There is one resource template:
 
@@ -33,7 +47,7 @@ metrics and rows remain open JSON values. Success uses structured content direct
 `ok/result/error` wrapper. Tool failures set `isError=true` and carry a stable code, message, and
 details; both success and failure shapes validate against the advertised schema.
 
-`prepare_capabilities` is the only open-world tool. It resolves the exact package requirement through
+`prepare_providers` is the only open-world tool. It resolves the exact package requirement through
 `uvx`, verifies that environment by running Flameox's version command, and returns the same
 requirement in a project-bound MCP launcher. The request names the complete managed provider set;
 Flameox keeps no installed-provider inventory or setup receipt. System profilers, drivers, device
@@ -72,10 +86,10 @@ They cannot raise them.
 
 ## Capture
 
-A direct target contains an argv array, project-contained cwd, at most 32
-bounded environment overrides after experiment-case overrides are merged,
-provider ID, provider capture arguments, analysis arguments, and request limits.
-Shell command strings are not accepted.
+A direct target contains an argv array, project-contained cwd, and at most 32 bounded environment
+overrides after experiment-case overrides are merged. Provider fields live in the capture tool's
+typed provider union, and analysis fields live in its capability-specific `options` model. Shell
+command strings are not accepted.
 
 Provider output formats are compared with the requested capability before scratch creation or
 execution. Statically incompatible pairs fail with the declared formats and compatible capture
@@ -99,11 +113,12 @@ cancellation.
 
 ## Stable failure codes
 
-The transport distinguishes invalid input, unknown/unavailable capability,
+The transport distinguishes invalid input, unavailable providers,
 missing or changed input, unsupported format, decode failure, execution failure,
 cancellation, limit exceeded, expired session analysis, missing evidence,
 repository I/O failure, repository corruption, and unsupported repository
-format. Provider absence during discovery is a successful state.
+format. An unavailable managed provider identifies `prepare_providers` and the exact provider list
+needed for a retry; an unavailable system provider returns external setup guidance.
 
 ## CLI
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -18,12 +18,26 @@ There are exactly 45 tools:
 | Capture and immediate analysis | 18 | `capture_cpu_hotspots`, `capture_gpu_launches`, `capture_benchmark_compare`, `capture_sanitizer_failures`, `capture_process_output` | Executes typed argv; not read-only or idempotent. |
 | Evidence lifecycle | 3 | `prepare_providers`, `preserve_evidence`, `query_evidence` | Prepare an explicit uvx environment or manage immutable evidence. |
 
-The capability registry generates the analysis and capture tools. A generated analysis tool accepts
-one strict `request` containing 1-32 path/evidence sources, capability-specific typed `options`,
-optional lowered limits, and an optional continuation. A generated capture tool accepts one strict
-`request` containing the direct target, a discriminated union of only compatible capture providers,
-capability-specific typed `options`, a `single` or `experiment` execution union, optional lowered
-limits, and optional preservation. There are no free-form provider or analysis argument objects.
+The capability registry generates the analysis and capture tools through the Python MCP SDK 2.0
+registration API. The SDK derives each top-level input schema directly from the registered callable.
+A generated analysis tool has `sources`, capability-specific typed `options`, optional lowered
+`limits`, and an optional `continuation`. A generated capture tool has `target`, a discriminated
+`provider` union containing only compatible capture providers, capability-specific typed `options`,
+an explicit `single` or `experiment` execution union, optional lowered `limits`, and optional
+`preserve`. There is no extra request envelope and there are no free-form provider or analysis
+argument objects.
+
+For example, a single Nsight Compute capture for kernel metrics has this argument shape:
+
+```json
+{
+  "target": {"argv": ["python", "kernel.py"]},
+  "provider": {"kind": "nsight-compute", "options": {"launch_count": 1}},
+  "options": {},
+  "execution": {"kind": "single"},
+  "preserve": true
+}
+```
 
 Analysis and capture remain separate tools even when they return the same evidence envelope. MCP
 annotations describe a whole tool, so combining read-only artifact analysis and target execution
@@ -127,7 +141,6 @@ The retained surface is:
 ```text
 flameox setup
 flameox mcp serve|inspect
-flameox capabilities discover|inspect
 flameox analyze [--continuation TOKEN] [--preserve]
 flameox capture [--preserve] -- <argv...>
 flameox evidence query|show

--- a/docs/investigations.md
+++ b/docs/investigations.md
@@ -40,7 +40,7 @@ optional semantic oracle. Cases are bounded and execute through the same broker 
 For GPU kernel work, the agent normally compiles and edits with its native coding tools, records
 correctness through `analyze_kernel_validation` and `analyze_kernel_compare`, checks hazards with
 `capture_sanitizer_failures`, measures representative baseline/candidate cases with
-`capture_benchmark_compare`, and profiles only the remaining uncertainty with
+`capture_benchmark_summary` in experiment mode, and profiles only the remaining uncertainty with
 `capture_gpu_launches` or `capture_gpu_kernel_metrics`. Flameox preserves the verification evidence;
 it does not generate kernels, wrap compilers, or decide which optimization to implement.
 

--- a/docs/investigations.md
+++ b/docs/investigations.md
@@ -33,10 +33,16 @@ containment must not be silently promoted to complete evidence.
 
 ## Experiments
 
-`capture_and_analyze` supports `single` and `experiment` modes. An experiment
-declares cases, blocks, seed, metric, estimand, practical threshold, and an
-optional semantic oracle. Cases are bounded and execute through the same broker
-as a single capture.
+Every `capture_*` capability tool accepts a discriminated `single` or `experiment` execution
+request. An experiment declares cases, blocks, seed, metric, estimand, practical threshold, and an
+optional semantic oracle. Cases are bounded and execute through the same broker as a single capture.
+
+For GPU kernel work, the agent normally compiles and edits with its native coding tools, records
+correctness through `analyze_kernel_validation` and `analyze_kernel_compare`, checks hazards with
+`capture_sanitizer_failures`, measures representative baseline/candidate cases with
+`capture_benchmark_compare`, and profiles only the remaining uncertainty with
+`capture_gpu_launches` or `capture_gpu_kernel_metrics`. Flameox preserves the verification evidence;
+it does not generate kernels, wrap compilers, or decide which optimization to implement.
 
 The 0.2 runtime accepts `wall_time_ns` and paired `median_difference` or
 `mean_difference`. Each non-baseline case is compared with the first declared

--- a/docs/runtime-safety.md
+++ b/docs/runtime-safety.md
@@ -34,8 +34,6 @@ capture request rather than a separate plan or preflight lifecycle.
 
 ## Input and output bounds
 
-- discovery sniffs at most 16 sources and reads only bounded headers;
-- inspection accepts 1-16 capability IDs;
 - analysis accepts 1-32 sources and at most 1,000 rows per call;
 - result JSON is capped at 256 KiB by default;
 - continuations bind request arguments, limits, formats, and input digests;

--- a/docs/storage-and-evidence.md
+++ b/docs/storage-and-evidence.md
@@ -1,8 +1,7 @@
 # Storage and evidence
 
-Storage is optional. Discovery, inspection, analysis, and unpreserved capture
-must not create `.flameox`, `.diagnostics`, SQLite files, or persistent DuckDB
-files.
+Storage is optional. Analysis and unpreserved capture must not create `.flameox`,
+`.diagnostics`, SQLite files, or persistent DuckDB files.
 
 ## Repository layout
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,9 +19,9 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly 45 MCP tools, one resource template, no concrete
-resource list, output schemas, truthful annotations, and direct structured success content without
-a universal wrapper.
+Contract tests assert exactly 45 MCP tools, one resource template, no concrete resource list,
+capability-specific top-level input schemas, compatible-provider discriminators, output schemas,
+truthful annotations, and direct structured success content without a universal wrapper.
 
 Runtime tests cover bounded streaming analysis, digest-bound continuation,
 provider states, typed capture, progress, cancellation and descendant cleanup,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly seven MCP tools, one resource template, no concrete
+Contract tests assert exactly 45 MCP tools, one resource template, no concrete
 resource list, output schemas, truthful annotations, and direct structured success content without
 a universal wrapper.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly 45 MCP tools, one resource template, no concrete resource list,
+Contract tests assert exactly 44 MCP tools, one resource template, no concrete resource list,
 capability-specific top-level input schemas, compatible-provider discriminators, output schemas,
 truthful annotations, and direct structured success content without a universal wrapper.
 

--- a/examples/semantic-matrix/README.md
+++ b/examples/semantic-matrix/README.md
@@ -4,8 +4,8 @@ This standard-library-only example shows why process success and semantic
 outcomes are different evidence. Its explicit cells cover matching behavior, a
 typed candidate mismatch, an expected rejection, and an unavailable backend.
 
-Run each case as a typed target or send the cases together through MCP
-`capture_and_analyze` in `experiment` mode. Declare the blocks, seed, metric,
+Run each case as a typed target or send the cases together through an appropriate MCP
+`capture_*` tool in `experiment` mode. Declare the blocks, seed, metric,
 estimand, practical threshold, and semantic-oracle argv in that request; no
 workspace or configuration file is required.
 

--- a/src/flameox/cli.py
+++ b/src/flameox/cli.py
@@ -27,10 +27,8 @@ app = typer.Typer(
     help="Collect and query bounded local runtime evidence.",
     no_args_is_help=True,
 )
-capabilities_app = typer.Typer(help="Discover and inspect runtime capabilities.")
 mcp_app = typer.Typer(help="Serve or inspect the local MCP adapter.")
 evidence_app = typer.Typer(help="Query or show optional preserved evidence.")
-app.add_typer(capabilities_app, name="capabilities")
 app.add_typer(mcp_app, name="mcp")
 app.add_typer(evidence_app, name="evidence")
 
@@ -125,46 +123,6 @@ def setup(
             )
             + "\n".join(guidance)
         )
-
-
-@capabilities_app.command("discover")
-def capabilities_discover(
-    intent: Annotated[str | None, typer.Option("--intent")] = None,
-    source: Annotated[list[Path] | None, typer.Option("--source")] = None,
-    include_unavailable: Annotated[bool, typer.Option("--include-unavailable")] = False,
-    limit: Annotated[int, typer.Option("--limit", min=1, max=50)] = 10,
-    project_root: Annotated[Path, typer.Option("--project-root")] = Path("."),
-) -> None:
-    """Rank capabilities for an intent and optional explicit artifact paths."""
-    runtime = _runtime(project_root)
-    try:
-        _write(
-            runtime.discover_capabilities(
-                intent,
-                [PathSource(path=str(path.resolve())) for path in source or []],
-                include_unavailable=include_unavailable,
-                limit=limit,
-            )
-        )
-    except (RuntimeFailure, ValidationError) as error:
-        _cli_failure(error)
-    finally:
-        runtime.close()
-
-
-@capabilities_app.command("inspect")
-def capabilities_inspect(
-    capability_ids: Annotated[list[str], typer.Argument()],
-    project_root: Annotated[Path, typer.Option("--project-root")] = Path("."),
-) -> None:
-    """Inspect one to sixteen capability contracts."""
-    runtime = _runtime(project_root)
-    try:
-        _write(runtime.inspect_capabilities(capability_ids))
-    except (RuntimeFailure, ValidationError) as error:
-        _cli_failure(error)
-    finally:
-        runtime.close()
 
 
 @app.command("analyze")

--- a/src/flameox/mcp/capability_tools.py
+++ b/src/flameox/mcp/capability_tools.py
@@ -1,0 +1,79 @@
+"""Generate the typed MCP request models exposed for runtime capabilities."""
+
+from __future__ import annotations
+
+from functools import reduce
+from operator import or_
+from typing import Annotated, Any, Literal
+
+from pydantic import Field, create_model
+
+from flameox.runtime_contracts import (
+    CAPTURE_PROVIDER_CONTRACTS,
+    Capability,
+    CaptureProviderContract,
+    ExperimentDesign,
+    StrictModel,
+    compatible_capture_providers,
+)
+
+
+class SingleExecution(StrictModel):
+    kind: Literal["single"] = "single"
+
+
+class ExperimentExecution(StrictModel):
+    kind: Literal["experiment"]
+    design: ExperimentDesign
+
+
+Execution = Annotated[SingleExecution | ExperimentExecution, Field(discriminator="kind")]
+
+
+def tool_stem(capability: Capability) -> str:
+    """Return the stable MCP name fragment for a capability."""
+
+    if capability.id == "artifact.preview":
+        return "artifact"
+    return capability.id.replace(".", "_")
+
+
+def analysis_tool_name(capability: Capability) -> str:
+    if capability.id == "artifact.preview":
+        return "preview_artifact"
+    return f"analyze_{tool_stem(capability)}"
+
+
+def capture_tool_name(capability: Capability) -> str:
+    if capability.id == "artifact.preview":
+        return "capture_process_output"
+    return f"capture_{tool_stem(capability)}"
+
+
+def _provider_model(contract: CaptureProviderContract) -> type[StrictModel]:
+    return create_model(
+        f"{contract.id.title().replace('-', '')}Provider",
+        __base__=StrictModel,
+        kind=(Literal[contract.id], ...),
+        options=(contract.argument_model, Field(default_factory=contract.argument_model)),
+    )
+
+
+PROVIDER_MODELS = {
+    provider_id: _provider_model(contract)
+    for provider_id, contract in CAPTURE_PROVIDER_CONTRACTS.items()
+}
+
+
+def capture_provider_type(capability: Capability) -> Any | None:
+    providers = compatible_capture_providers(capability)
+    if not providers:
+        return None
+    provider_models = tuple(PROVIDER_MODELS[contract.id] for contract in providers)
+    provider_type: Any = provider_models[0]
+    if len(provider_models) > 1:
+        provider_type = Annotated[
+            reduce(or_, provider_models),
+            Field(discriminator="kind"),
+        ]
+    return provider_type

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -277,6 +277,10 @@ def create_server(
 
         # MCP SDK 2.0 derives schemas and diagnostic names from the registered callable.
         handler.__name__ = analysis_tool_name(capability)
+        minimum_sources = 2 if capability.id.endswith(".compare") else 1
+        handler.__annotations__["sources"] = Annotated[
+            list[Source], Field(min_length=minimum_sources, max_length=32)
+        ]
         handler.__annotations__["options"] = capability.model
         return handler
 

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -21,25 +21,28 @@ from pydantic import (
     GetJsonSchemaHandler,
     JsonValue,
     RootModel,
-    ValidationError,
 )
 from pydantic.json_schema import JsonSchemaValue
 
+import flameox.setup as provider_setup
 from flameox import __version__
+from flameox.mcp.capability_tools import (
+    Execution,
+    ExperimentExecution,
+    analysis_tool_name,
+    capture_provider_type,
+    capture_tool_name,
+)
 from flameox.repository import AGENT_EVIDENCE_MEDIA_TYPE
 from flameox.runtime_contracts import (
+    CAPABILITIES,
+    Capability,
     CaptureTarget,
-    ExperimentDesign,
+    DirectTarget,
     RequestLimits,
     RuntimeFailure,
     Source,
-)
-from flameox.setup import (
-    DEFAULT_PREPARATION_TIMEOUT_SECONDS,
-    MAX_PREPARATION_TIMEOUT_SECONDS,
-    ProviderSelectionFailure,
-    SetupFailure,
-    prepare_providers,
+    compatible_capture_providers,
 )
 from flameox.stateless import AnalysisRuntime
 
@@ -92,15 +95,6 @@ class AnalysisEnvelope(_Envelope):
     continuation: str | None
 
 
-class DiscoveryEnvelope(_Envelope):
-    sniffed_sources: list[dict[str, JsonValue]]
-    capabilities: list[dict[str, JsonValue]]
-
-
-class InspectionEnvelope(_Envelope):
-    capabilities: list[dict[str, JsonValue]]
-
-
 class ExternalRequirementEnvelope(BaseModel):
     provider_id: str
     guidance: str
@@ -144,14 +138,6 @@ class _ObjectOutcome(RootModel[Any]):
         schema = handler(core_schema)
         schema["type"] = "object"
         return schema
-
-
-class DiscoveryOutcome(_ObjectOutcome):
-    root: DiscoveryEnvelope | ToolFailureEnvelope
-
-
-class InspectionOutcome(_ObjectOutcome):
-    root: InspectionEnvelope | ToolFailureEnvelope
 
 
 class PreparationOutcome(_ObjectOutcome):
@@ -221,59 +207,30 @@ def create_server(
         description="Bounded local runtime evidence without a prerequisite workspace.",
         instructions=(
             "Pass explicit artifact paths or a typed direct target. Analysis and capture are "
-            "session-local unless preserve_evidence is called. Use prepare_capabilities only when "
-            "discovery reports a missing Flameox-managed provider; reconnect with its returned "
-            "launcher after preparation. Flameox never installs host tools, searches parent "
-            "directories, accepts shell strings, or creates durable jobs."
+            "session-local unless preserve_evidence is called. If a capture reports a missing "
+            "Flameox-managed provider, call prepare_providers with the complete desired provider "
+            "set and reconnect with its returned launcher. Flameox never installs host tools, "
+            "searches parent directories, accepts shell strings, or creates durable jobs."
         ),
         lifespan=lifespan,
     )
 
-    @server.tool(annotations=READ_ONLY, structured_output=True)
-    async def discover_capabilities(
-        intent: str | None = None,
-        sources: list[Source] | None = None,
-        include_unavailable: bool = False,
-        limit: int = 10,
-    ) -> Annotated[CallToolResult, DiscoveryOutcome]:
-        """Rank capabilities by intent and bounded source sniffing; never install providers."""
-        try:
-            return _success(
-                runtime().discover_capabilities(
-                    intent, sources, include_unavailable=include_unavailable, limit=limit
-                )
-            )
-        except (RuntimeFailure, ValidationError) as error:
-            if isinstance(error, ValidationError):
-                return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
-            return _failure(error)
-
-    @server.tool(annotations=READ_ONLY, structured_output=True)
-    async def inspect_capabilities(
-        capability_ids: list[str],
-    ) -> Annotated[CallToolResult, InspectionOutcome]:
-        """Batch-inspect 1-16 capability contracts, providers, limits, and examples."""
-        try:
-            return _success(runtime().inspect_capabilities(capability_ids))
-        except RuntimeFailure as error:
-            return _failure(error)
-
     @server.tool(annotations=PREPARE, structured_output=True)
-    async def prepare_capabilities(
+    async def prepare_providers(
         provider_ids: Annotated[list[str], Field(min_length=1, max_length=16)],
         timeout_seconds: Annotated[
-            int, Field(ge=1, le=MAX_PREPARATION_TIMEOUT_SECONDS)
-        ] = DEFAULT_PREPARATION_TIMEOUT_SECONDS,
+            int, Field(ge=1, le=provider_setup.MAX_PREPARATION_TIMEOUT_SECONDS)
+        ] = provider_setup.DEFAULT_PREPARATION_TIMEOUT_SECONDS,
     ) -> Annotated[CallToolResult, PreparationOutcome]:
         """Prepare selected managed providers; report host-tool setup without changing it."""
 
         try:
             preparation = await anyio.to_thread.run_sync(
-                prepare_providers, provider_ids, root, timeout_seconds
+                provider_setup.prepare_providers, provider_ids, root, timeout_seconds
             )
-        except ProviderSelectionFailure as error:
+        except provider_setup.ProviderSelectionFailure as error:
             return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
-        except SetupFailure as error:
+        except provider_setup.SetupFailure as error:
             return _failure(RuntimeFailure("SETUP_FAILURE", str(error)))
 
         return _success(
@@ -296,87 +253,127 @@ def create_server(
             }
         )
 
-    @server.tool(annotations=READ_ONLY, structured_output=True)
-    async def analyze(
-        capability_id: str,
-        sources: list[Source],
-        arguments: dict[str, Any],
-        limits: RequestLimits | None = None,
-        continuation: str | None = None,
-    ) -> Annotated[CallToolResult, AnalysisOutcome]:
-        """Analyze 1-32 explicit path or evidence sources without durable writes."""
-        try:
-            return _success(
-                runtime().analyze(
-                    capability_id,
-                    sources,
-                    arguments,
-                    limits=limits,
-                    continuation=continuation,
-                )
-            )
-        except RuntimeFailure as error:
-            return _failure(error)
-        except ValidationError as error:
-            return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
-        except (OSError, ValueError, json.JSONDecodeError) as error:
-            return _failure(RuntimeFailure("DECODE_FAILURE", str(error)))
-
-    @server.tool(annotations=CAPTURE, structured_output=True)
-    async def capture_and_analyze(
-        target: CaptureTarget,
-        capability_id: str = "artifact.preview",
-        mode: Literal["single", "experiment"] = "single",
-        experiment: ExperimentDesign | None = None,
-        limits: RequestLimits | None = None,
-        preserve: bool = False,
-        ctx: Context[AnalysisRuntime] | None = None,
-    ) -> Annotated[CallToolResult, AnalysisOutcome]:
-        """Validate, execute, and analyze one typed target through the bounded broker."""
-
-        async def progress(current: int, total: int, message: str) -> None:
-            if ctx is not None:
-                await ctx.report_progress(float(current), float(total), message)
-
-        try:
-            value = await runtime().capture_and_analyze(
-                target,
-                capability_id,
-                mode=mode,
-                experiment=experiment,
-                limits=limits,
-                progress=progress,
-                preserve=preserve,
-            )
-            failed = [
-                item for item in value["capture"]["executions"] if item["status"] != "succeeded"
-            ]
-            if failed:
-                return _failure(
-                    RuntimeFailure(
-                        "EXECUTION_FAILURE",
-                        "One or more captured targets exited unsuccessfully.",
-                        details={"partial_evidence": value, "failed_executions": failed},
+    def analysis_handler(capability: Capability) -> Callable[..., Awaitable[CallToolResult]]:
+        async def handler(
+            sources: Annotated[list[Source], Field(min_length=1, max_length=32)],
+            options: Any,
+            limits: RequestLimits | None = None,
+            continuation: str | None = None,
+        ) -> Annotated[CallToolResult, AnalysisOutcome]:
+            try:
+                return _success(
+                    runtime().analyze(
+                        capability.id,
+                        sources,
+                        options.model_dump(),
+                        limits=limits,
+                        continuation=continuation,
                     )
                 )
-            preserved = value.get("preserved")
-            link = None
-            if isinstance(preserved, dict):
-                link = ResourceLink(
-                    type="resource_link",
-                    uri=preserved["uri"],
-                    name=f"Evidence {preserved['evidence_id']}",
-                    mime_type=AGENT_EVIDENCE_MEDIA_TYPE,
+            except RuntimeFailure as error:
+                return _failure(error)
+            except (OSError, ValueError, json.JSONDecodeError) as error:
+                return _failure(RuntimeFailure("DECODE_FAILURE", str(error)))
+
+        # MCP SDK 2.0 derives schemas and diagnostic names from the registered callable.
+        handler.__name__ = analysis_tool_name(capability)
+        handler.__annotations__["options"] = capability.model
+        return handler
+
+    def capture_handler(
+        capability: Capability,
+        provider_type: Any,
+    ) -> Callable[..., Awaitable[CallToolResult]]:
+        async def handler(
+            target: DirectTarget,
+            provider: Any,
+            options: Any,
+            execution: Execution,
+            ctx: Context[AnalysisRuntime],
+            limits: RequestLimits | None = None,
+            preserve: bool = False,
+        ) -> Annotated[CallToolResult, AnalysisOutcome]:
+            async def progress(current: int, total: int, message: str) -> None:
+                await ctx.report_progress(float(current), float(total), message)
+
+            target = CaptureTarget(
+                **target.model_dump(),
+                provider_id=provider.kind,
+                capture_arguments=provider.options.model_dump(),
+                analysis_arguments=options.model_dump(),
+            )
+            experiment = execution.design if isinstance(execution, ExperimentExecution) else None
+            try:
+                value = await runtime().capture_and_analyze(
+                    target,
+                    capability.id,
+                    mode=execution.kind,
+                    experiment=experiment,
+                    limits=limits,
+                    progress=progress,
+                    preserve=preserve,
                 )
-            return _success(value, resource=link)
-        except RuntimeFailure as error:
-            return _failure(error)
-        except ValidationError as error:
-            return _failure(RuntimeFailure("INVALID_INPUT", str(error)))
-        except asyncio.CancelledError:
-            raise
-        except Exception as error:
-            return _failure(RuntimeFailure("EXECUTION_FAILURE", str(error) or type(error).__name__))
+                failed = [
+                    item for item in value["capture"]["executions"] if item["status"] != "succeeded"
+                ]
+                if failed:
+                    return _failure(
+                        RuntimeFailure(
+                            "EXECUTION_FAILURE",
+                            "One or more captured targets exited unsuccessfully.",
+                            details={"partial_evidence": value, "failed_executions": failed},
+                        )
+                    )
+                preserved = value.get("preserved")
+                link = None
+                if isinstance(preserved, dict):
+                    link = ResourceLink(
+                        type="resource_link",
+                        uri=preserved["uri"],
+                        name=f"Evidence {preserved['evidence_id']}",
+                        mime_type=AGENT_EVIDENCE_MEDIA_TYPE,
+                    )
+                return _success(value, resource=link)
+            except RuntimeFailure as error:
+                return _failure(error)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                return _failure(
+                    RuntimeFailure("EXECUTION_FAILURE", str(error) or type(error).__name__)
+                )
+
+        handler.__name__ = capture_tool_name(capability)
+        handler.__annotations__["provider"] = provider_type
+        handler.__annotations__["options"] = capability.model
+        return handler
+
+    for capability in CAPABILITIES:
+        server.add_tool(
+            analysis_handler(capability),
+            name=analysis_tool_name(capability),
+            title=capability.summary,
+            description=(
+                f"{capability.summary} Accepts: {', '.join(capability.formats)}. "
+                f"Limitation: {capability.limitation}"
+            ),
+            annotations=READ_ONLY,
+            structured_output=True,
+        )
+        provider_type = capture_provider_type(capability)
+        if provider_type is not None:
+            providers = compatible_capture_providers(capability)
+            server.add_tool(
+                capture_handler(capability, provider_type),
+                name=capture_tool_name(capability),
+                title=f"Capture and {capability.summary.lower()}",
+                description=(
+                    f"Execute typed argv and {capability.summary.lower()} Compatible providers: "
+                    f"{', '.join(provider.id for provider in providers)}."
+                ),
+                annotations=CAPTURE,
+                structured_output=True,
+            )
 
     @server.tool(annotations=PRESERVE, structured_output=True)
     async def preserve_evidence(

--- a/src/flameox/providers/nsight_compute.py
+++ b/src/flameox/providers/nsight_compute.py
@@ -58,6 +58,10 @@ class NsightComputeProvider:
         self.harness = harness
         self.interface_path = interface_path
 
+    def resolve_interface(self, executable: Path | None = None) -> Path | None:
+        """Resolve the vendor reader used by both capture preflight and analysis."""
+        return self.interface_path or find_report_interface(executable)
+
     def analyze(
         self,
         path: Path,
@@ -68,9 +72,7 @@ class NsightComputeProvider:
         maximum_output_bytes: int,
     ) -> ProviderAnalysis:
         executable_text = shutil.which("ncu")
-        interface = self.interface_path or find_report_interface(
-            Path(executable_text) if executable_text else None
-        )
+        interface = self.resolve_interface(Path(executable_text) if executable_text else None)
         if interface is None:
             raise ProviderFailure(
                 "UNAVAILABLE_CAPABILITY",

--- a/src/flameox/runtime_contracts.py
+++ b/src/flameox/runtime_contracts.py
@@ -707,6 +707,8 @@ CAPABILITY_BY_ID = {item.id: item for item in CAPABILITIES}
 def compatible_capture_providers(capability: Capability) -> tuple[CaptureProviderContract, ...]:
     """Return capture providers whose artifacts can feed a capability."""
 
+    if capability.id.endswith(".compare"):
+        return ()
     return tuple(
         contract
         for contract in CAPTURE_PROVIDER_CONTRACTS.values()

--- a/src/flameox/runtime_contracts.py
+++ b/src/flameox/runtime_contracts.py
@@ -18,7 +18,6 @@ from flameox.environment_policy import blocked_environment_override
 MAX_INPUTS = 32
 MAX_ROWS = 1_000
 MAX_RESULT_BYTES = 256 * 1024
-MAX_SNIFF_INPUTS = 16
 
 
 class RuntimeFailure(RuntimeError):
@@ -121,13 +120,10 @@ class RequestLimits(StrictModel):
         return RequestLimits.model_validate(effective)
 
 
-class CaptureTarget(StrictModel):
+class DirectTarget(StrictModel):
     argv: list[str] = Field(min_length=1, max_length=256)
     cwd: str = "."
     environment: dict[str, str] = Field(default_factory=dict, max_length=32)
-    provider_id: str = Field(min_length=1, max_length=80)
-    capture_arguments: dict[str, Any] = Field(default_factory=dict)
-    analysis_arguments: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("argv")
     @classmethod
@@ -138,6 +134,12 @@ class CaptureTarget(StrictModel):
     @classmethod
     def valid_environment(cls, value: dict[str, str]) -> dict[str, str]:
         return _valid_environment(value)
+
+
+class CaptureTarget(DirectTarget):
+    provider_id: str = Field(min_length=1, max_length=80)
+    capture_arguments: dict[str, Any] = Field(default_factory=dict)
+    analysis_arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 class PyperfCaptureArguments(StrictModel):
@@ -293,7 +295,6 @@ class CaptureProviderContract:
     argument_model: type[StrictModel]
     artifacts: tuple[CaptureArtifactContract, ...]
     artifact_description: str
-    preview_streams: bool = False
 
 
 def _capture_provider(
@@ -301,15 +302,12 @@ def _capture_provider(
     argument_model: type[StrictModel],
     artifacts: tuple[tuple[str, str], ...],
     description: str,
-    *,
-    preview_streams: bool = False,
 ) -> CaptureProviderContract:
     return CaptureProviderContract(
         provider_id,
         argument_model,
         tuple(CaptureArtifactContract(role, format_name) for role, format_name in artifacts),
         description,
-        preview_streams,
     )
 
 
@@ -317,7 +315,10 @@ CAPTURE_PROVIDER_CONTRACTS = {
     item.id: item
     for item in (
         _capture_provider(
-            "direct", EmptyArguments, (), "stdout and stderr text", preview_streams=True
+            "direct",
+            EmptyArguments,
+            (("stdout", "text"), ("stderr", "text")),
+            "stdout and stderr text",
         ),
         _capture_provider(
             "pyperf", PyperfCaptureArguments, (("benchmark", "pyperf"),), "native pyperf JSON suite"
@@ -531,19 +532,6 @@ class AnalysisResult(StrictModel):
 
 
 @dataclass(frozen=True, slots=True)
-class ProviderProbe:
-    id: str
-    formats: tuple[str, ...]
-    module: str | None = None
-    distribution: str | None = None
-    supported_versions: str | None = None
-    executable: str | None = None
-    configured_path_environment: str | None = None
-    platforms: tuple[str, ...] = ()
-    setup_provider: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
 class Capability:
     id: str
     summary: str
@@ -575,14 +563,26 @@ CAPABILITIES = tuple(
         SummaryArguments,
     )
     + _caps(
-        ("trace.call_graph", "trace.pytorch"),
-        "Project bounded call-graph or PyTorch trace evidence.",
+        ("trace.call_graph",),
+        "Project bounded caller-callee edges from Chrome, Perfetto, or PyTorch traces.",
         ("perfetto", "chrome-trace", "pytorch"),
         SummaryArguments,
     )
     + _caps(
-        ("trace.operations", "trace.lifecycle"),
-        "Summarize bounded operation and lifecycle evidence.",
+        ("trace.pytorch",),
+        "Summarize bounded PyTorch operator and event evidence.",
+        ("perfetto", "chrome-trace", "pytorch"),
+        SummaryArguments,
+    )
+    + _caps(
+        ("trace.operations",),
+        "Summarize bounded operation timing from OTLP or Nsight Systems traces.",
+        ("otlp", "nsys-rep", "nsys-parquet"),
+        SummaryArguments,
+    )
+    + _caps(
+        ("trace.lifecycle",),
+        "Summarize bounded execution lifecycle events from OTLP or Nsight Systems traces.",
         ("otlp", "nsys-rep", "nsys-parquet"),
         SummaryArguments,
     )
@@ -599,14 +599,26 @@ CAPABILITIES = tuple(
         SummaryArguments,
     )
     + _caps(
-        ("memory.hotspots", "memory.retained"),
-        "Rank bounded allocation evidence.",
+        ("memory.hotspots",),
+        "Rank bounded allocation hotspots from a Memray capture.",
         ("memray",),
         SummaryArguments,
     )
     + _caps(
-        ("benchmark.summary", "benchmark.scaling"),
-        "Summarize benchmark measurements.",
+        ("memory.retained",),
+        "Rank bounded retained-memory evidence from a Memray capture.",
+        ("memray",),
+        SummaryArguments,
+    )
+    + _caps(
+        ("benchmark.summary",),
+        "Summarize bounded benchmark latency measurements.",
+        ("pyperf", "samples", "nvbench"),
+        SummaryArguments,
+    )
+    + _caps(
+        ("benchmark.scaling",),
+        "Summarize how benchmark measurements scale across declared parameters.",
         ("pyperf", "samples", "nvbench"),
         SummaryArguments,
     )
@@ -690,139 +702,13 @@ CAPABILITIES = tuple(
     )
 )
 CAPABILITY_BY_ID = {item.id: item for item in CAPABILITIES}
-FORMAT_PROBES = (
-    ProviderProbe("flameox-preview", ("json", "jsonl", "csv", "text", "parquet")),
-    ProviderProbe("v8-cpu-profile", ("cpuprofile",)),
-    ProviderProbe("py-spy-speedscope", ("py-spy",)),
-    ProviderProbe("perf-collapsed", ("perf",)),
-    ProviderProbe("perf-data", ("perf-data",), executable="perf", platforms=("linux",)),
-    ProviderProbe(
-        "memray",
-        ("memray",),
-        module="memray",
-        distribution="memray",
-        supported_versions=">=1.17",
-        setup_provider="memray",
-    ),
-    ProviderProbe(
-        "pyperf",
-        ("pyperf",),
-        module="pyperf",
-        distribution="pyperf",
-        supported_versions=">=2.10,<2.11",
-    ),
-    ProviderProbe("benchmark-samples", ("samples",)),
-    ProviderProbe(
-        "aiperf",
-        ("aiperf",),
-        module="aiperf",
-        distribution="aiperf",
-        supported_versions=">=0.12,<0.13",
-        setup_provider="aiperf",
-    ),
-    ProviderProbe("vllm-benchmark", ("vllm-benchmark",)),
-    ProviderProbe("sglang-benchmark", ("sglang-benchmark",)),
-    ProviderProbe("mooncake-trace", ("mooncake-trace",)),
-    ProviderProbe("nvbench-jsonbin", ("nvbench",)),
-    ProviderProbe(
-        "perfetto",
-        ("perfetto", "chrome-trace", "pytorch", "rocprof-pftrace"),
-        module="perfetto.trace_processor",
-        distribution="perfetto",
-        supported_versions=">=0.57,<0.58",
-        executable="trace_processor_shell",
-        configured_path_environment="FLAMEOX_TRACE_PROCESSOR",
-        setup_provider="perfetto",
-    ),
-    ProviderProbe(
-        "otlp",
-        ("otlp",),
-        module="opentelemetry.proto",
-        distribution="opentelemetry-proto",
-        supported_versions=">=1.44,<1.45",
-        setup_provider="otlp",
-    ),
-    ProviderProbe(
-        "nsight-systems",
-        ("nsys-rep",),
-        executable="nsys",
-        platforms=("linux", "win32"),
-    ),
-    ProviderProbe(
-        "nsight-systems-parquetdir",
-        ("nsys-parquet",),
-        module="pyarrow",
-        distribution="pyarrow",
-        supported_versions=">=20,<26",
-    ),
-    ProviderProbe(
-        "nsight-compute",
-        ("nsight-compute",),
-        executable="ncu",
-        platforms=("linux", "win32"),
-    ),
-    ProviderProbe("xctrace", ("xctrace",), executable="xcrun", platforms=("darwin",)),
-    ProviderProbe("compute-sanitizer-xml", ("compute-sanitizer",)),
-    ProviderProbe("triton-autotune-jsonl", ("triton",)),
-    ProviderProbe("kernel-validation", ("kernel-validation",)),
-    ProviderProbe("pytest", ("pytest",)),
-    ProviderProbe(
-        "coverage.py",
-        ("coverage",),
-        module="coverage",
-        distribution="coverage",
-        supported_versions=">=7.14,<8",
-    ),
-    ProviderProbe("flameox-observations", ("observations",)),
-    ProviderProbe("sarif", ("sarif",)),
-)
 
-CAPTURE_PROBES = {
-    "direct": ProviderProbe("direct", ()),
-    "pyperf": ProviderProbe(
-        "pyperf",
-        (),
-        module="pyperf",
-        distribution="pyperf",
-        supported_versions=">=2.10,<2.11",
-    ),
-    "py-spy": ProviderProbe("py-spy", (), executable="py-spy", setup_provider="py-spy"),
-    "perf": ProviderProbe("perf", (), executable="perf", platforms=("linux",)),
-    "node-cpu-profile": ProviderProbe("node-cpu-profile", ()),
-    "memray": ProviderProbe(
-        "memray",
-        (),
-        module="memray",
-        distribution="memray",
-        supported_versions=">=1.17",
-        setup_provider="memray",
-    ),
-    "torch-profiler": ProviderProbe(
-        "torch-profiler", (), module="torch", distribution="torch", setup_provider="torch"
-    ),
-    "nvbench": ProviderProbe("nvbench", (), platforms=("linux", "win32")),
-    "compute-sanitizer": ProviderProbe(
-        "compute-sanitizer",
-        (),
-        executable="compute-sanitizer",
-        platforms=("linux", "win32"),
-    ),
-    "nsight-systems": ProviderProbe(
-        "nsight-systems", (), executable="nsys", platforms=("linux", "win32")
-    ),
-    "nsight-compute": ProviderProbe(
-        "nsight-compute", (), executable="ncu", platforms=("linux", "win32")
-    ),
-    "rocprofv3": ProviderProbe("rocprofv3", (), executable="rocprofv3", platforms=("linux",)),
-    "xctrace": ProviderProbe("xctrace", (), executable="xcrun", platforms=("darwin",)),
-    "coverage": ProviderProbe(
-        "coverage",
-        (),
-        module="coverage",
-        distribution="coverage",
-        supported_versions=">=7.14,<8",
-    ),
-    "benchmark-samples": ProviderProbe("benchmark-samples", ()),
-    "observations": ProviderProbe("observations", ()),
-    "pytest": ProviderProbe("pytest", ()),
-}
+
+def compatible_capture_providers(capability: Capability) -> tuple[CaptureProviderContract, ...]:
+    """Return capture providers whose artifacts can feed a capability."""
+
+    return tuple(
+        contract
+        for contract in CAPTURE_PROVIDER_CONTRACTS.values()
+        if set(capability.formats).intersection(artifact.format for artifact in contract.artifacts)
+    )

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -47,7 +47,7 @@ from flameox.providers.cpu import CpuProfileProvider
 from flameox.providers.inference_exports import InferenceExportProvider
 from flameox.providers.kernel_evidence import KernelEvidenceProvider
 from flameox.providers.memray import MemrayProvider
-from flameox.providers.nsight_compute import NsightComputeProvider
+from flameox.providers.nsight_compute import NsightComputeProvider, find_report_interface
 from flameox.providers.nsight_systems import NsightSystemsParquetProvider
 from flameox.providers.nvbench import NvbenchProvider
 from flameox.providers.otlp import OtlpProvider
@@ -95,6 +95,7 @@ from flameox.runtime_contracts import (
     compatible_capture_providers,
 )
 from flameox.runtime_errors import DomainError, ErrorCode
+from flameox.setup import SYSTEM_PROVIDER_GUIDANCE
 from flameox.workers.harness import IsolatedWorkerHarness, WorkerRuntimeConfig
 
 
@@ -380,6 +381,19 @@ class AnalysisRuntime:
                 },
             )
         cases = experiment.cases if experiment else [ExperimentCase(name="single")]
+        source_count = (
+            len(cases)
+            * (experiment.blocks if experiment else 1)
+            * len(CAPTURE_PROVIDER_CONTRACTS[target.provider_id].artifacts)
+        )
+        if source_count > MAX_INPUTS:
+            raise RuntimeFailure(
+                "LIMIT_EXCEEDED",
+                (
+                    f"Capture would produce {source_count} analysis sources; "
+                    f"the limit is {MAX_INPUTS}."
+                ),
+            )
         return ValidatedCaptureRequest(
             capability=capability,
             capture_arguments=capture_arguments,
@@ -434,9 +448,24 @@ class AnalysisRuntime:
                 target.provider_id, argv, environment, capture_arguments, directory
             )
             self._require_workload_python_provider(target.provider_id, argv, environment, cwd=cwd)
-            self._require_host_tool(
-                invocation.argv[0], cwd=cwd, environment={**os.environ, **invocation.environment}
+            binding = self._require_host_tool(
+                invocation.argv[0],
+                cwd=cwd,
+                environment={**os.environ, **invocation.environment},
+                provider_id=target.provider_id,
             )
+            if (
+                target.provider_id == "nsight-compute"
+                and find_report_interface(binding.invocation_path) is None
+            ):
+                raise RuntimeFailure(
+                    "UNAVAILABLE_CAPABILITY",
+                    "The official Nsight Compute ncu_report.py interface is missing.",
+                    details={
+                        "provider_id": target.provider_id,
+                        "external_setup_guidance": SYSTEM_PROVIDER_GUIDANCE[target.provider_id],
+                    },
+                )
             if experiment is not None and experiment.semantic_oracle is not None:
                 self._require_host_tool(
                     experiment.semantic_oracle[0],
@@ -878,7 +907,11 @@ class AnalysisRuntime:
 
     @staticmethod
     def _require_host_tool(
-        executable: str, *, cwd: Path, environment: Mapping[str, str]
+        executable: str,
+        *,
+        cwd: Path,
+        environment: Mapping[str, str],
+        provider_id: str | None = None,
     ) -> ResolvedExecutable:
         try:
             return ExecutableResolver().require_host_tool(
@@ -890,7 +923,13 @@ class AnalysisRuntime:
                 if error.code is ErrorCode.UNAVAILABLE_CAPABILITY
                 else "EXECUTION_FAILURE"
             )
-            raise RuntimeFailure(code, error.message) from error
+            details = {}
+            if provider_id in SYSTEM_PROVIDER_GUIDANCE:
+                details = {
+                    "provider_id": provider_id,
+                    "external_setup_guidance": SYSTEM_PROVIDER_GUIDANCE[provider_id],
+                }
+            raise RuntimeFailure(code, error.message, details=details) from error
 
     @staticmethod
     def _managed_executable(name: str) -> str | None:

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -6,15 +6,12 @@ import base64
 import csv
 import errno
 import hashlib
-import importlib.metadata
-import importlib.util
 import json
 import os
 import random
 import secrets
 import shutil
 import statistics
-import subprocess
 import sys
 import tempfile
 from collections.abc import Iterator, Mapping, Sequence
@@ -50,7 +47,7 @@ from flameox.providers.cpu import CpuProfileProvider
 from flameox.providers.inference_exports import InferenceExportProvider
 from flameox.providers.kernel_evidence import KernelEvidenceProvider
 from flameox.providers.memray import MemrayProvider
-from flameox.providers.nsight_compute import NsightComputeProvider, find_report_interface
+from flameox.providers.nsight_compute import NsightComputeProvider
 from flameox.providers.nsight_systems import NsightSystemsParquetProvider
 from flameox.providers.nvbench import NvbenchProvider
 from flameox.providers.otlp import OtlpProvider
@@ -66,14 +63,10 @@ from flameox.repository import (
     sha256_file,
 )
 from flameox.runtime_contracts import (
-    CAPABILITIES,
     CAPABILITY_BY_ID,
-    CAPTURE_PROBES,
     CAPTURE_PROVIDER_CONTRACTS,
-    FORMAT_PROBES,
     MAX_INPUTS,
     MAX_ROWS,
-    MAX_SNIFF_INPUTS,
     AnalysisResult,
     BenchmarkSamplesCaptureArguments,
     Capability,
@@ -91,7 +84,6 @@ from flameox.runtime_contracts import (
     PathSource,
     PerfCaptureArguments,
     PreviewArguments,
-    ProviderProbe,
     PyperfCaptureArguments,
     PySpyCaptureArguments,
     RequestLimits,
@@ -100,6 +92,7 @@ from flameox.runtime_contracts import (
     Source,
     TorchProfilerCaptureArguments,
     XctraceCaptureArguments,
+    compatible_capture_providers,
 )
 from flameox.runtime_errors import DomainError, ErrorCode
 from flameox.workers.harness import IsolatedWorkerHarness, WorkerRuntimeConfig
@@ -147,37 +140,6 @@ class ValidatedCaptureRequest:
     limits: RequestLimits
     cases: list[ExperimentCase]
     blocks: int
-
-
-def _perf_permission_limited(executable_path: str) -> bool:
-    try:
-        probe = subprocess.run(
-            [executable_path, "stat", "-e", "task-clock", "--", "true"],
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            timeout=2,
-            check=False,
-            text=True,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    diagnostic = probe.stderr.casefold()
-    return probe.returncode != 0 and any(
-        marker in diagnostic for marker in ("permission", "not permitted", "perf_event_paranoid")
-    )
-
-
-def _permission_guidance(provider_id: str, executable_path: str) -> tuple[str, str]:
-    if provider_id == "perf" and os.access(executable_path, os.X_OK):
-        return (
-            "perf events are blocked by the host permission policy.",
-            "Grant CAP_PERFMON or adjust kernel.perf_event_paranoid outside Flameox, then retry.",
-        )
-    return (
-        f"Required executable is not executable: {executable_path}",
-        "Grant execute permission outside Flameox, then retry.",
-    )
 
 
 class AnalysisRuntime:
@@ -229,128 +191,6 @@ class AnalysisRuntime:
 
     def close(self) -> None:
         self._temporary.cleanup()
-
-    def discover_capabilities(
-        self,
-        intent: str | None = None,
-        sources: Sequence[Source] | None = None,
-        *,
-        include_unavailable: bool = False,
-        limit: int = 10,
-    ) -> dict[str, Any]:
-        if not 1 <= limit <= 50:
-            raise RuntimeFailure("INVALID_INPUT", "limit must be between 1 and 50")
-        supplied = sources or []
-        if len(supplied) > MAX_SNIFF_INPUTS:
-            raise RuntimeFailure("INVALID_INPUT", "discovery accepts at most 16 sources")
-        sniffed = [self._sniff_source(item) for item in supplied]
-        formats = {str(item["format"]) for item in sniffed}
-        terms = set((intent or "").lower().replace("_", " ").replace(".", " ").split())
-        ranked: list[tuple[int, Capability, dict[str, Any]]] = []
-        for capability in CAPABILITIES:
-            state = self._availability(capability, formats)
-            score = 3 * len(terms.intersection(capability.id.replace(".", " ").split())) + 5 * len(
-                formats.intersection(capability.formats)
-            )
-            if not terms and not formats:
-                score = 1
-            if state["available"] or include_unavailable:
-                ranked.append((score, capability, state))
-        ranked.sort(key=lambda item: (-item[0], item[1].id))
-        return {
-            "sniffed_sources": sniffed,
-            "capabilities": [
-                {
-                    "id": cap.id,
-                    "summary": cap.summary,
-                    "accepted_formats": list(cap.formats),
-                    "providers": state["providers"],
-                    "available": state["available"],
-                    "overhead": "Bounded local analysis; capture overhead is provider-specific.",
-                    "limitations": state["limitations"],
-                    "remediation": state["remediation"],
-                }
-                for _, cap, state in ranked[:limit]
-            ],
-        }
-
-    def inspect_capabilities(self, capability_ids: list[str]) -> dict[str, Any]:
-        if not 1 <= len(capability_ids) <= 16:
-            raise RuntimeFailure("INVALID_INPUT", "capability_ids must contain 1 to 16 entries")
-        if unknown := [item for item in capability_ids if item not in CAPABILITY_BY_ID]:
-            raise RuntimeFailure("UNKNOWN_CAPABILITY", f"Unknown capability: {unknown[0]}")
-        return {
-            "capabilities": [
-                {
-                    "id": cap.id,
-                    "summary": cap.summary,
-                    "source_modes": ["path", "evidence"],
-                    "accepted_formats": list(cap.formats),
-                    "providers": self._availability(cap, set())["providers"],
-                    "capture_providers": self._capture_provider_details(cap),
-                    "argument_schema": cap.model.model_json_schema(mode="validation"),
-                    "example": {
-                        "capability_id": cap.id,
-                        "sources": [{"kind": "path", "path": "/absolute/path/to/artifact"}],
-                        "arguments": {},
-                    },
-                    "limits": self.limits.model_dump(mode="json"),
-                    "capture_semantics": (
-                        "Typed argv is executed through the bounded subprocess broker."
-                    ),
-                    "limitations": [cap.limitation],
-                }
-                for cap in (CAPABILITY_BY_ID[item] for item in capability_ids)
-            ]
-        }
-
-    def _capture_provider_details(self, capability: Capability) -> list[dict[str, Any]]:
-        providers = [
-            contract
-            for contract in CAPTURE_PROVIDER_CONTRACTS.values()
-            if (
-                (capability.id == "artifact.preview" and contract.preview_streams)
-                or set(capability.formats).intersection(
-                    artifact.format for artifact in contract.artifacts
-                )
-            )
-        ]
-        return [
-            {
-                "id": contract.id,
-                "capture_argument_schema": contract.argument_model.model_json_schema(
-                    mode="validation"
-                ),
-                "artifact": contract.artifact_description,
-                "availability": self._capture_provider_availability(contract.id),
-            }
-            for contract in providers
-        ]
-
-    def _capture_provider_availability(self, provider_id: str) -> dict[str, Any]:
-        availability = self._probe_provider(CAPTURE_PROBES[provider_id])
-        if provider_id not in {"coverage", "memray"}:
-            return availability
-        distribution, supported_versions = {
-            "coverage": ("coverage", ">=7.14,<8"),
-            "memray": ("memray", ">=1.17"),
-        }[provider_id]
-        return {
-            **availability,
-            "available": None,
-            "status": "target_dependent",
-            "environment_scope": "workload_interpreter",
-            "version": None,
-            "limitations": [
-                (
-                    f"Capture requires {distribution} {supported_versions} in the declared "
-                    "workload interpreter; Flameox validates it before execution."
-                )
-            ],
-            "remediation": [
-                f"Install {distribution} {supported_versions} into the workload interpreter."
-            ],
-        }
 
     def analyze(
         self,
@@ -521,17 +361,10 @@ class AnalysisRuntime:
                 "INVALID_INPUT", "experiment mode and design must be supplied together"
             )
         output_formats = set(self._capture_output_formats(target.provider_id))
-        compatible = (
-            capability_id == "artifact.preview" and target.provider_id == "direct"
-        ) or bool(output_formats.intersection(capability.formats))
-        if not compatible:
-            compatible_providers = [
-                contract.id
-                for contract in CAPTURE_PROVIDER_CONTRACTS.values()
-                if set(capability.formats).intersection(
-                    artifact.format for artifact in contract.artifacts
-                )
-            ]
+        compatible_provider_ids = [
+            contract.id for contract in compatible_capture_providers(capability)
+        ]
+        if target.provider_id not in compatible_provider_ids:
             raise RuntimeFailure(
                 "UNSUPPORTED_FORMAT",
                 (
@@ -543,7 +376,7 @@ class AnalysisRuntime:
                     "output_formats": sorted(output_formats),
                     "capability_id": capability_id,
                     "accepted_formats": list(capability.formats),
-                    "compatible_capture_providers": compatible_providers,
+                    "compatible_capture_providers": compatible_provider_ids,
                 },
             )
         cases = experiment.cases if experiment else [ExperimentCase(name="single")]
@@ -1067,12 +900,21 @@ class AnalysisRuntime:
         return None
 
     @staticmethod
-    def _require_managed_executable(name: str) -> str:
+    def _require_managed_executable(provider_id: str, name: str) -> str:
         executable = AnalysisRuntime._managed_executable(name)
         if executable is None:
             raise RuntimeFailure(
                 "UNAVAILABLE_CAPABILITY",
-                f"Managed provider executable is unavailable: {name}. Run flameox setup.",
+                (
+                    f"Managed provider executable is unavailable: {name}. Call "
+                    f"prepare_providers with provider_ids=[{provider_id!r}], reconnect with "
+                    "the returned launcher, then retry."
+                ),
+                details={
+                    "provider_id": provider_id,
+                    "preparation_tool": "prepare_providers",
+                    "provider_ids": [provider_id],
+                },
             )
         return executable
 
@@ -1286,7 +1128,7 @@ class AnalysisRuntime:
                 pyspy_options.append("--native")
             return CaptureInvocation(
                 (
-                    AnalysisRuntime._require_managed_executable("py-spy"),
+                    AnalysisRuntime._require_managed_executable("py-spy", "py-spy"),
                     "record",
                     "--format",
                     "speedscope",
@@ -1876,6 +1718,41 @@ class AnalysisRuntime:
                 )
             )
         return result
+
+    @staticmethod
+    def _sniff(path: Path) -> str:
+        known = {
+            ".json": "json",
+            ".jsonl": "jsonl",
+            ".csv": "csv",
+            ".parquet": "parquet",
+            ".cpuprofile": "cpuprofile",
+            ".pftrace": "perfetto",
+            ".perfetto-trace": "perfetto",
+            ".trace": "xctrace",
+            ".bin": "memray",
+            ".nsys-rep": "nsys-rep",
+            ".ncu-rep": "nsight-compute",
+            ".ncu-repz": "nsight-compute",
+            ".sarif": "sarif",
+            ".pstats": "pstats",
+        }
+        if path.suffix.lower() in known:
+            return known[path.suffix.lower()]
+        if path.is_dir():
+            return "directory"
+        try:
+            with path.open("rb") as stream:
+                header = stream.read(16).lstrip()
+        except OSError:
+            return "unknown"
+        if path.name == ".coverage" and header.startswith(b"SQLite format 3"):
+            return "coverage"
+        if header.startswith(b"PAR1"):
+            return "parquet"
+        if header.startswith((b"{", b"[")):
+            return "json"
+        return "text"
 
     def _resolve_evidence_source(self, source: EvidenceSource) -> ResolvedSource:
         manifest = self.read_evidence(source.evidence_id)
@@ -2682,214 +2559,6 @@ class AnalysisRuntime:
             raise RuntimeFailure(
                 "INVALID_INPUT", "Continuation does not match this request and its inputs"
             ) from exc
-
-    def _sniff_source(self, source: Source) -> dict[str, Any]:
-        if isinstance(source, EvidenceSource):
-            manifest = self.read_evidence(source.evidence_id)
-            artifacts = manifest["body"].get("artifacts", [])
-            if not isinstance(artifacts, list):
-                raise RuntimeFailure("REPOSITORY_CORRUPTION", "Evidence artifacts are invalid")
-            role = source.artifact_role or self._default_evidence_role(artifacts)
-            selected = [
-                item
-                for item in artifacts
-                if isinstance(item, dict)
-                and (item.get("role") == role or str(item.get("role", "")).startswith(role + ":"))
-            ]
-            formats = {str(item.get("format")) for item in selected}
-            if len(formats) != 1:
-                raise RuntimeFailure(
-                    "REPOSITORY_CORRUPTION",
-                    "Evidence bundle metadata is inconsistent",
-                )
-            return {"kind": "evidence", "evidence_id": source.evidence_id, "format": formats.pop()}
-        return {
-            "kind": "path",
-            "path": source.path,
-            "format": source.format or self._sniff(Path(source.path)),
-        }
-
-    @staticmethod
-    def _sniff(path: Path) -> str:
-        known = {
-            ".json": "json",
-            ".jsonl": "jsonl",
-            ".csv": "csv",
-            ".parquet": "parquet",
-            ".cpuprofile": "cpuprofile",
-            ".pftrace": "perfetto",
-            ".perfetto-trace": "perfetto",
-            ".trace": "xctrace",
-            ".bin": "memray",
-            ".nsys-rep": "nsys-rep",
-            ".ncu-rep": "nsight-compute",
-            ".ncu-repz": "nsight-compute",
-            ".sarif": "sarif",
-            ".pstats": "pstats",
-        }
-        if path.suffix.lower() in known:
-            return known[path.suffix.lower()]
-        if path.is_dir():
-            return "directory"
-        try:
-            with path.open("rb") as stream:
-                header = stream.read(16).lstrip()
-        except OSError:
-            return "unknown"
-        return (
-            "coverage"
-            if path.name == ".coverage" and header.startswith(b"SQLite format 3")
-            else "parquet"
-            if header.startswith(b"PAR1")
-            else "json"
-            if header.startswith((b"{", b"["))
-            else "text"
-        )
-
-    def _availability(self, capability: Capability, formats: set[str]) -> dict[str, Any]:
-        source_issues: list[str] = []
-        if formats and not formats.intersection(capability.formats):
-            source_issues.append("No supplied artifact matches a declared format.")
-        selected_formats = (
-            formats.intersection(capability.formats) if formats else set(capability.formats)
-        )
-        probes = [probe for probe in FORMAT_PROBES if selected_formats.intersection(probe.formats)]
-        providers = [self._probe_provider(probe) for probe in probes]
-        provider_issues = [
-            limitation
-            for provider in providers
-            if not provider["available"]
-            for limitation in provider["limitations"]
-        ]
-        remediation = list(
-            dict.fromkeys(item for provider in providers for item in provider["remediation"])
-        )
-        return {
-            "available": not source_issues and any(provider["available"] for provider in providers),
-            "providers": providers,
-            "limitations": source_issues + provider_issues or [capability.limitation],
-            "remediation": remediation,
-        }
-
-    @staticmethod
-    def _probe_provider(probe: ProviderProbe) -> dict[str, Any]:
-        limitations: list[str] = []
-        remediation: list[str] = []
-        wrong_platform = bool(probe.platforms and sys.platform not in probe.platforms)
-        if wrong_platform:
-            limitations.append(f"Provider is not supported on {sys.platform}.")
-
-        missing_package: str | None = None
-        version: str | None = None
-        unsupported_version = False
-        if probe.module is not None:
-            try:
-                installed = importlib.util.find_spec(probe.module) is not None
-            except (ImportError, ModuleNotFoundError, ValueError):
-                installed = False
-            if not installed:
-                missing_package = probe.distribution or probe.module
-                limitations.append(f"Optional package is not installed: {missing_package}")
-                if probe.setup_provider is not None:
-                    remediation.append(
-                        f"Run flameox setup --provider {probe.setup_provider}, then restart "
-                        "the server."
-                    )
-                else:
-                    remediation.append(
-                        f"Install {missing_package} outside Flameox, then restart the server."
-                    )
-            elif probe.distribution is not None:
-                try:
-                    version = importlib.metadata.version(probe.distribution)
-                except importlib.metadata.PackageNotFoundError:
-                    missing_package = probe.distribution
-                    limitations.append(f"Package metadata is unavailable for: {probe.distribution}")
-                if version is not None and probe.supported_versions is not None:
-                    try:
-                        unsupported_version = Version(version) not in SpecifierSet(
-                            probe.supported_versions
-                        )
-                    except InvalidVersion:
-                        unsupported_version = True
-                    if unsupported_version:
-                        limitations.append(
-                            f"Provider version {version} is outside {probe.supported_versions}."
-                        )
-
-        executable_path = AnalysisRuntime._probe_executable(probe)
-        missing_executable = (
-            probe.executable if probe.executable is not None and executable_path is None else None
-        )
-        permission_limited = bool(
-            executable_path is not None and not os.access(executable_path, os.X_OK)
-        )
-        if probe.id == "perf" and executable_path is not None and not permission_limited:
-            permission_limited = _perf_permission_limited(executable_path)
-        if missing_executable is not None:
-            limitations.append(f"Required executable is not on PATH: {missing_executable}")
-            remediation.append(
-                f"Install {missing_executable} with the system/vendor package manager, "
-                "then restart Flameox."
-            )
-        if permission_limited:
-            assert executable_path is not None
-            limitation, repair = _permission_guidance(probe.id, executable_path)
-            limitations.append(limitation)
-            remediation.append(repair)
-
-        missing_resource: str | None = None
-        if (
-            probe.id == "nsight-compute"
-            and not wrong_platform
-            and executable_path is not None
-            and find_report_interface(Path(executable_path)) is None
-        ):
-            missing_resource = "ncu_report.py"
-            limitations.append("The official Nsight Compute ncu_report.py interface is missing.")
-            remediation.append(
-                "Install Nsight Compute with its extras/python interface outside Flameox, "
-                "then restart the server."
-            )
-
-        unavailable = bool(
-            wrong_platform
-            or missing_package
-            or unsupported_version
-            or missing_executable
-            or permission_limited
-            or missing_resource
-        )
-        return {
-            "id": probe.id,
-            "available": not unavailable,
-            "version": version
-            or (__version__ if probe.module is None and probe.executable is None else None),
-            "formats": list(probe.formats),
-            "platforms": list(probe.platforms),
-            "missing_package": missing_package,
-            "missing_executable": missing_executable,
-            "executable": executable_path,
-            "missing_resource": missing_resource,
-            "permission_limited": permission_limited,
-            "unsupported_version": unsupported_version,
-            "limitations": limitations,
-            "remediation": remediation,
-        }
-
-    @staticmethod
-    def _probe_executable(probe: ProviderProbe) -> str | None:
-        executable_path: str | None = None
-        if probe.configured_path_environment is not None:
-            configured = os.environ.get(probe.configured_path_environment)
-            if configured and Path(configured).is_file():
-                executable_path = configured
-        if executable_path is None and probe.executable is not None:
-            if probe.setup_provider is not None:
-                executable_path = AnalysisRuntime._managed_executable(probe.executable)
-            else:
-                executable_path = shutil.which(probe.executable)
-        return executable_path
 
     def _resolve_project_cwd(self, value: str) -> Path:
         candidate = Path(value)

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -47,7 +47,7 @@ from flameox.providers.cpu import CpuProfileProvider
 from flameox.providers.inference_exports import InferenceExportProvider
 from flameox.providers.kernel_evidence import KernelEvidenceProvider
 from flameox.providers.memray import MemrayProvider
-from flameox.providers.nsight_compute import NsightComputeProvider, find_report_interface
+from flameox.providers.nsight_compute import NsightComputeProvider
 from flameox.providers.nsight_systems import NsightSystemsParquetProvider
 from flameox.providers.nvbench import NvbenchProvider
 from flameox.providers.otlp import OtlpProvider
@@ -456,7 +456,7 @@ class AnalysisRuntime:
             )
             if (
                 target.provider_id == "nsight-compute"
-                and find_report_interface(binding.invocation_path) is None
+                and self.nsight_compute.resolve_interface(binding.invocation_path) is None
             ):
                 raise RuntimeFailure(
                     "UNAVAILABLE_CAPABILITY",

--- a/tests/providers/test_nsight_compute.py
+++ b/tests/providers/test_nsight_compute.py
@@ -45,6 +45,42 @@ def test_vendor_interface_is_resolved_from_explicit_ncu_install(tmp_path: Path) 
     assert find_report_interface(executable) == interface
 
 
+def test_capture_rejects_missing_vendor_interface_before_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = tmp_path / "executed"
+    executable = tmp_path / "bin" / "ncu"
+    executable.parent.mkdir()
+    executable.write_text(
+        f"#!{sys.executable}\nfrom pathlib import Path\nPath({str(marker)!r}).touch()\n"
+    )
+    executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(executable.parent))
+    monkeypatch.setattr(
+        "flameox.providers.nsight_compute.find_report_interface", lambda _executable: None
+    )
+
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(tmp_path)
+        try:
+            with pytest.raises(RuntimeFailure) as failure:
+                await runtime.capture_and_analyze(
+                    CaptureTarget(
+                        argv=[sys.executable, "-c", "pass"],
+                        provider_id="nsight-compute",
+                    ),
+                    "gpu.kernel_metrics",
+                )
+        finally:
+            runtime.close()
+
+        assert failure.value.code == "UNAVAILABLE_CAPABILITY"
+        assert failure.value.details["provider_id"] == "nsight-compute"
+
+    anyio.run(exercise)
+    assert not marker.exists()
+
+
 @pytest.mark.process
 def test_nsight_compute_capture_uses_typed_bounded_options(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/providers/test_nsight_compute.py
+++ b/tests/providers/test_nsight_compute.py
@@ -14,6 +14,12 @@ from flameox.runtime_contracts import CaptureTarget, PathSource, RuntimeFailure
 from flameox.stateless import AnalysisRuntime
 
 
+def _write_fake_report_interface(executable: Path) -> None:
+    interface = executable.parent.parent / "extras" / "python" / "ncu_report.py"
+    interface.parent.mkdir(parents=True)
+    interface.touch()
+
+
 def test_explicit_report_fails_as_unavailable_without_vendor_interface(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -97,6 +103,7 @@ def test_nsight_compute_capture_uses_typed_bounded_options(
         "output.write_bytes(b'native-report')\n"
     )
     executable.chmod(0o755)
+    _write_fake_report_interface(executable)
     monkeypatch.setenv("PATH", str(executable.parent) + os.pathsep + os.environ["PATH"])
 
     async def exercise() -> dict[str, Any]:
@@ -156,6 +163,7 @@ def test_preserved_native_capture_survives_analysis_failure(
         "output.write_bytes(b'authoritative-native-report')\n"
     )
     executable.chmod(0o755)
+    _write_fake_report_interface(executable)
     monkeypatch.setenv("PATH", str(executable.parent) + os.pathsep + os.environ["PATH"])
 
     async def exercise() -> tuple[str, dict[str, Any]]:

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -24,7 +24,6 @@ def test_help_exposes_only_stateless_command_families() -> None:
             "setup",
             "analyze",
             "capture",
-            "capabilities",
             "mcp",
             "evidence",
         )

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -129,6 +129,38 @@ def test_capture_rejects_declared_provider_capability_mismatch_before_execution(
     assert not marker.exists()
 
 
+@pytest.mark.unit
+def test_capture_rejects_experiments_that_exceed_analysis_source_limit(tmp_path: Path) -> None:
+    marker = tmp_path / "executed"
+
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(tmp_path)
+        try:
+            with pytest.raises(RuntimeFailure) as failure:
+                await runtime.capture_and_analyze(
+                    CaptureTarget(
+                        argv=[sys.executable, "-c", f"open({str(marker)!r}, 'w').close()"],
+                        provider_id="direct",
+                    ),
+                    "artifact.preview",
+                    mode="experiment",
+                    experiment=ExperimentDesign(
+                        cases=[ExperimentCase(name="a"), ExperimentCase(name="b")],
+                        blocks=9,
+                        seed=1,
+                        metric="wall_time_ns",
+                        estimand="median_difference",
+                        practical_threshold=0,
+                    ),
+                )
+        finally:
+            runtime.close()
+        assert failure.value.code == "LIMIT_EXCEEDED"
+
+    anyio.run(exercise)
+    assert not marker.exists()
+
+
 def test_special_file_sources_are_rejected_before_decoding(tmp_path: Path) -> None:
     fifo = tmp_path / "input.fifo"
     os.mkfifo(fifo)
@@ -1533,7 +1565,7 @@ def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
                 expected.append(capture_tool_name(capability))
         expected.extend(["preserve_evidence", "query_evidence"])
         assert [tool.name for tool in tools] == expected
-        assert len(tools) == 45
+        assert len(tools) == 44
         assert all(tool.output_schema is not None for tool in tools)
         assert not {
             "discover_capabilities",
@@ -1565,6 +1597,11 @@ def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
             "py-spy": "#/$defs/PySpyProvider",
         }
         assert capture_schema["required"] == ["target", "provider", "options", "execution"]
+        assert (
+            by_name["analyze_benchmark_compare"].input_schema["properties"]["sources"]["minItems"]
+            == 2
+        )
+        assert "capture_benchmark_compare" not in by_name
         analysis_annotations = by_name["analyze_cpu_hotspots"].annotations
         capture_annotations = by_name["capture_cpu_hotspots"].annotations
         assert analysis_annotations and analysis_annotations.read_only_hint is True
@@ -1710,7 +1747,7 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
             await session.validate_tool_result("capture_process_output", captured)
 
         assert initialized.server_info.version == __version__
-        assert len(tools.tools) == 45
+        assert len(tools.tools) == 44
         assert "preview_artifact" in [tool.name for tool in tools.tools]
         assert "capture_gpu_kernel_metrics" in [tool.name for tool in tools.tools]
         assert all(tool.output_schema is not None for tool in tools.tools)

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1707,7 +1707,6 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
                 },
             )
             await session.validate_tool_result("preview_artifact", inspected)
-            await session.validate_tool_result("preview_artifact", invalid)
             await session.validate_tool_result("capture_process_output", captured)
 
         assert initialized.server_info.version == __version__

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import importlib.machinery
-import importlib.util
 import json
 import os
-import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -29,9 +26,14 @@ from pydantic import ValidationError
 from flameox import __version__
 from flameox.canonical import canonical_bytes
 from flameox.mcp import create_server
+from flameox.mcp.capability_tools import (
+    analysis_tool_name,
+    capture_tool_name,
+)
 from flameox.providers.contracts import ProviderAnalysis
 from flameox.repository import AGENT_EVIDENCE_MEDIA_TYPE, EvidenceRepository
 from flameox.runtime_contracts import (
+    CAPABILITIES,
     MAX_ROWS,
     CaptureTarget,
     EvidenceSource,
@@ -40,6 +42,7 @@ from flameox.runtime_contracts import (
     PathSource,
     RequestLimits,
     RuntimeFailure,
+    compatible_capture_providers,
 )
 from flameox.setup import ExternalRequirement, ProviderPreparation, ProviderSelectionFailure
 from flameox.stateless import AnalysisRuntime
@@ -1471,114 +1474,6 @@ def test_aiperf_export_is_projected_without_prompts_or_repository(tmp_path: Path
     assert not (tmp_path / ".flameox").exists()
 
 
-@pytest.mark.unit
-def test_inspection_exposes_strict_validation_schema(tmp_path: Path) -> None:
-    runtime = AnalysisRuntime(tmp_path)
-    details = runtime.inspect_capabilities(["trace.window", "benchmark.summary"])["capabilities"]
-    runtime.close()
-    detail = details[0]
-    schema = detail["argument_schema"]
-
-    assert schema["additionalProperties"] is False
-    assert schema["required"] == ["start_ns", "end_ns"]
-    assert detail["source_modes"] == ["path", "evidence"]
-    pyperf_capture = details[1]["capture_providers"][0]
-    assert pyperf_capture["id"] == "pyperf"
-    assert pyperf_capture["capture_argument_schema"]["additionalProperties"] is False
-    assert "processes" in pyperf_capture["capture_argument_schema"]["properties"]
-
-
-@pytest.mark.unit
-def test_discovery_reports_external_remediation_without_setup_action(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr("flameox.stateless.shutil.which", lambda _name: None)
-    runtime = AnalysisRuntime(Path.cwd())
-    result = runtime.discover_capabilities(
-        "gpu launches",
-        [PathSource(path="/artifact.nsys-rep", format="nsys-rep")],
-        include_unavailable=True,
-    )
-    runtime.close()
-    match = next(item for item in result["capabilities"] if item["id"] == "gpu.launches")
-
-    assert match["available"] is False
-    assert match["providers"][0]["missing_executable"] == "nsys"
-    assert "system/vendor package manager" in match["remediation"][0]
-    assert "setup" not in json.dumps(match).lower()
-
-
-@pytest.mark.integration
-def test_discovery_uses_the_selected_evidence_artifact_format(tmp_path: Path) -> None:
-    artifact = tmp_path / "samples.json"
-    artifact.write_text('[{"value": 1}]')
-    runtime = AnalysisRuntime(tmp_path)
-    try:
-        analysis = runtime.analyze("artifact.preview", [PathSource(path=str(artifact))], {})
-        preserved = runtime.preserve_evidence(analysis["analysis_id"])
-        discovered = runtime.discover_capabilities(
-            sources=[EvidenceSource(kind="evidence", evidence_id=preserved["evidence_id"])],
-        )
-    finally:
-        runtime.close()
-
-    preview = next(item for item in discovered["capabilities"] if item["id"] == "artifact.preview")
-    assert discovered["sniffed_sources"][0]["format"] == "json"
-    assert preview["available"] is True
-
-
-@pytest.mark.unit
-def test_discovery_separates_builtin_readers_from_capture_dependencies(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr("flameox.stateless.shutil.which", lambda _name: None)
-    runtime = AnalysisRuntime(tmp_path)
-    monkeypatch.setattr("flameox.stateless.sys.executable", str(tmp_path / "python"))
-    discovered = runtime.discover_capabilities(
-        sources=[PathSource(path="/profile.json", format="py-spy")],
-        include_unavailable=True,
-    )
-    inspected = runtime.inspect_capabilities(["cpu.hotspots"])
-    runtime.close()
-
-    cpu = next(item for item in discovered["capabilities"] if item["id"] == "cpu.hotspots")
-    assert cpu["available"] is True
-    assert cpu["providers"][0]["id"] == "py-spy-speedscope"
-    pyspy_capture = next(
-        item for item in inspected["capabilities"][0]["capture_providers"] if item["id"] == "py-spy"
-    )
-    assert pyspy_capture["availability"]["available"] is False
-    assert pyspy_capture["availability"]["missing_executable"] == "py-spy"
-
-
-@pytest.mark.unit
-def test_py_spy_capture_discovers_executable_in_managed_tool_environment(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    managed_bin = tmp_path / "managed" / "bin"
-    managed_bin.mkdir(parents=True)
-    managed_python = managed_bin / "python"
-    managed_python.write_text("#!/bin/sh\nexit 0\n")
-    managed_python.chmod(0o755)
-    managed_pyspy = managed_bin / "py-spy"
-    managed_pyspy.write_text("#!/bin/sh\nexit 0\n")
-    managed_pyspy.chmod(0o755)
-    monkeypatch.setattr("flameox.stateless.sys.executable", str(managed_python))
-    monkeypatch.setattr("flameox.stateless.shutil.which", lambda _name: None)
-
-    runtime = AnalysisRuntime(tmp_path)
-    try:
-        inspected = runtime.inspect_capabilities(["cpu.hotspots"])
-    finally:
-        runtime.close()
-
-    capture = next(
-        item for item in inspected["capabilities"][0]["capture_providers"] if item["id"] == "py-spy"
-    )
-    assert capture["availability"]["available"] is True
-    assert capture["availability"]["executable"] == str(managed_pyspy)
-
-
 @pytest.mark.process
 def test_py_spy_capture_executes_managed_tool_when_request_path_is_empty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1625,175 +1520,63 @@ def test_py_spy_capture_executes_managed_tool_when_request_path_is_empty(
 
 
 @pytest.mark.unit
-def test_discovery_reports_missing_and_unsupported_python_providers(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    original_find_spec = importlib.util.find_spec
-
-    def missing_memray(name: str) -> Any:
-        return None if name == "memray" else original_find_spec(name)
-
-    monkeypatch.setattr("flameox.stateless.importlib.util.find_spec", missing_memray)
-    runtime = AnalysisRuntime(tmp_path)
-    missing = runtime.discover_capabilities(
-        sources=[PathSource(path="/artifact.bin", format="memray")],
-        include_unavailable=True,
-    )
-    runtime.close()
-    memory = next(item for item in missing["capabilities"] if item["id"] == "memory.hotspots")
-    assert memory["available"] is False
-    assert memory["providers"][0]["missing_package"] == "memray"
-    assert "flameox setup --provider memray" in memory["remediation"][0]
-
-    def installed_memray(name: str) -> Any:
-        if name == "memray":
-            return importlib.machinery.ModuleSpec(name, loader=None)
-        return original_find_spec(name)
-
-    monkeypatch.setattr("flameox.stateless.importlib.util.find_spec", installed_memray)
-    monkeypatch.setattr("flameox.stateless.importlib.metadata.version", lambda _name: "1.0")
-    runtime = AnalysisRuntime(tmp_path)
-    unsupported = runtime.discover_capabilities(
-        sources=[PathSource(path="/artifact.bin", format="memray")],
-        include_unavailable=True,
-    )
-    runtime.close()
-    memory = next(item for item in unsupported["capabilities"] if item["id"] == "memory.hotspots")
-    assert memory["available"] is False
-    assert memory["providers"][0]["unsupported_version"] is True
-
-
-@pytest.mark.unit
-def test_in_process_capture_availability_is_workload_interpreter_dependent(
-    tmp_path: Path,
-) -> None:
-    runtime = AnalysisRuntime(tmp_path)
-    try:
-        inspected = runtime.inspect_capabilities(["coverage.summary", "memory.hotspots"])
-    finally:
-        runtime.close()
-
-    for capability in inspected["capabilities"]:
-        capture = capability["capture_providers"][0]
-        assert capture["availability"]["available"] is None
-        assert capture["availability"]["status"] == "target_dependent"
-        assert capture["availability"]["environment_scope"] == "workload_interpreter"
-
-
-@pytest.mark.unit
-def test_discovery_reports_wrong_platform_and_executable_permission(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    host_platform = sys.platform
-    monkeypatch.setattr("flameox.stateless.sys.platform", "darwin")
-    monkeypatch.setattr("flameox.stateless.shutil.which", lambda _name: "/usr/bin/nsys")
-    runtime = AnalysisRuntime(tmp_path)
-    wrong_platform = runtime.discover_capabilities(
-        sources=[PathSource(path="/artifact.nsys-rep", format="nsys-rep")],
-        include_unavailable=True,
-    )
-    runtime.close()
-    launches = next(item for item in wrong_platform["capabilities"] if item["id"] == "gpu.launches")
-    assert launches["available"] is False
-    assert "not supported on darwin" in launches["limitations"][0]
-
-    processor = tmp_path / "trace_processor_shell"
-    processor.write_text("binary")
-    monkeypatch.setenv("FLAMEOX_TRACE_PROCESSOR", str(processor))
-    monkeypatch.setattr("flameox.stateless.sys.platform", host_platform)
-    runtime = AnalysisRuntime(tmp_path)
-    monkeypatch.setattr("flameox.stateless.os.access", lambda _path, _mode: False)
-    permission = runtime.discover_capabilities(
-        sources=[PathSource(path="/artifact.pftrace", format="perfetto")],
-        include_unavailable=True,
-    )
-    runtime.close()
-    trace = next(item for item in permission["capabilities"] if item["id"] == "trace.summary")
-    assert trace["available"] is False
-    assert trace["providers"][0]["permission_limited"] is True
-
-
-@pytest.mark.unit
-def test_discovery_actively_reports_perf_event_permission_policy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr("flameox.stateless.shutil.which", lambda name: "/usr/bin/perf")
-    monkeypatch.setattr(
-        "flameox.stateless.subprocess.run",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            [], 255, stderr="Access denied by perf_event_paranoid"
-        ),
-    )
-    runtime = AnalysisRuntime(tmp_path)
-    try:
-        inspected = runtime.inspect_capabilities(["cpu.hotspots"])
-    finally:
-        runtime.close()
-
-    perf = next(
-        provider
-        for provider in inspected["capabilities"][0]["capture_providers"]
-        if provider["id"] == "perf"
-    )
-    assert perf["availability"]["available"] is False
-    assert perf["availability"]["permission_limited"] is True
-    assert "CAP_PERFMON" in perf["availability"]["remediation"][0]
-
-
-@pytest.mark.unit
-def test_discovery_requires_nsight_compute_official_reader(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    executable = tmp_path / "ncu"
-    executable.write_text("binary")
-    executable.chmod(0o755)
-    monkeypatch.setattr(
-        "flameox.stateless.shutil.which",
-        lambda name: str(executable) if name == "ncu" else None,
-    )
-    monkeypatch.setattr("flameox.stateless.find_report_interface", lambda _path: None)
-    runtime = AnalysisRuntime(tmp_path)
-    try:
-        discovered = runtime.discover_capabilities(
-            sources=[PathSource(path="/artifact.ncu-rep", format="nsight-compute")],
-            include_unavailable=True,
-        )
-    finally:
-        runtime.close()
-
-    metrics = next(
-        item for item in discovered["capabilities"] if item["id"] == "gpu.kernel_metrics"
-    )
-    assert metrics["available"] is False
-    assert metrics["providers"][0]["missing_resource"] == "ncu_report.py"
-    assert "extras/python interface" in metrics["remediation"][0]
-
-
-@pytest.mark.unit
 def test_mcp_catalog_is_exact_typed_and_has_one_resource_template() -> None:
     async def inspect() -> None:
         server = create_server()
         tools = await server.list_tools()
         templates = await server.list_resource_templates()
 
-        assert [tool.name for tool in tools] == [
+        expected = ["prepare_providers"]
+        for capability in CAPABILITIES:
+            expected.append(analysis_tool_name(capability))
+            if compatible_capture_providers(capability):
+                expected.append(capture_tool_name(capability))
+        expected.extend(["preserve_evidence", "query_evidence"])
+        assert [tool.name for tool in tools] == expected
+        assert len(tools) == 45
+        assert all(tool.output_schema is not None for tool in tools)
+        assert not {
             "discover_capabilities",
             "inspect_capabilities",
-            "prepare_capabilities",
             "analyze",
             "capture_and_analyze",
-            "preserve_evidence",
-            "query_evidence",
-        ]
-        assert all(tool.output_schema is not None for tool in tools)
-        prepare = next(tool for tool in tools if tool.name == "prepare_capabilities")
+        }.intersection(expected)
+        by_name = {tool.name: tool for tool in tools}
+        analysis_schema = by_name["analyze_cpu_hotspots"].input_schema
+        assert set(analysis_schema["properties"]) == {
+            "sources",
+            "options",
+            "limits",
+            "continuation",
+        }
+        assert analysis_schema["required"] == ["sources", "options"]
+        capture_schema = by_name["capture_cpu_hotspots"].input_schema
+        assert set(capture_schema["properties"]) == {
+            "target",
+            "provider",
+            "options",
+            "execution",
+            "limits",
+            "preserve",
+        }
+        assert capture_schema["properties"]["provider"]["discriminator"]["mapping"] == {
+            "node-cpu-profile": "#/$defs/NodeCpuProfileProvider",
+            "perf": "#/$defs/PerfProvider",
+            "py-spy": "#/$defs/PySpyProvider",
+        }
+        assert capture_schema["required"] == ["target", "provider", "options", "execution"]
+        analysis_annotations = by_name["analyze_cpu_hotspots"].annotations
+        capture_annotations = by_name["capture_cpu_hotspots"].annotations
+        assert analysis_annotations and analysis_annotations.read_only_hint is True
+        assert capture_annotations and capture_annotations.destructive_hint is True
+        prepare = next(tool for tool in tools if tool.name == "prepare_providers")
         assert prepare.annotations and prepare.annotations.open_world_hint is True
         assert prepare.annotations.read_only_hint is False
         assert prepare.annotations.destructive_hint is False
         assert all(
             tool.annotations and tool.annotations.open_world_hint is False
             for tool in tools
-            if tool.name != "prepare_capabilities"
+            if tool.name != "prepare_providers"
         )
         assert await server.list_resources() == []
         assert [item.uri_template for item in templates] == ["flameox://evidence/{evidence_id}"]
@@ -1839,16 +1622,16 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
             ],
         )
 
-    monkeypatch.setattr("flameox.mcp.server.prepare_providers", prepare)
+    monkeypatch.setattr("flameox.mcp.server.provider_setup.prepare_providers", prepare)
 
     async def exercise() -> None:
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             result = await client.call_tool(
-                "prepare_capabilities",
+                "prepare_providers",
                 {"provider_ids": ["memray", "nsight-compute", "memray"]},
             )
             invalid = await client.call_tool(
-                "prepare_capabilities",
+                "prepare_providers",
                 {"provider_ids": ["unknown-provider"]},
             )
 
@@ -1905,27 +1688,35 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
             tools = await session.list_tools()
             resources = await session.list_resources()
             templates = await session.list_resource_templates()
+            artifact = tmp_path / "sample.json"
+            artifact.write_text('[{"value":1}]')
             inspected = await session.call_tool(
-                "inspect_capabilities", {"capability_ids": ["cpu.hotspots"]}
+                "preview_artifact",
+                {"sources": [{"kind": "path", "path": str(artifact)}], "options": {}},
             )
             invalid = await session.call_tool(
-                "inspect_capabilities", {"capability_ids": ["unknown.capability"]}
+                "preview_artifact", {"sources": [], "options": {}, "unexpected": True}
             )
-            await session.validate_tool_result("inspect_capabilities", inspected)
-            await session.validate_tool_result("inspect_capabilities", invalid)
+            captured = await session.call_tool(
+                "capture_process_output",
+                {
+                    "target": {"argv": [sys.executable, "-c", "print('stdio capture')"]},
+                    "provider": {"kind": "direct"},
+                    "options": {},
+                    "execution": {"kind": "single"},
+                },
+            )
+            await session.validate_tool_result("preview_artifact", inspected)
+            await session.validate_tool_result("preview_artifact", invalid)
+            await session.validate_tool_result("capture_process_output", captured)
 
         assert initialized.server_info.version == __version__
-        assert [tool.name for tool in tools.tools] == [
-            "discover_capabilities",
-            "inspect_capabilities",
-            "prepare_capabilities",
-            "analyze",
-            "capture_and_analyze",
-            "preserve_evidence",
-            "query_evidence",
-        ]
+        assert len(tools.tools) == 45
+        assert "preview_artifact" in [tool.name for tool in tools.tools]
+        assert "capture_gpu_kernel_metrics" in [tool.name for tool in tools.tools]
         assert all(tool.output_schema is not None for tool in tools.tools)
         assert invalid.is_error is True
+        assert captured.structured_content["blocks"][1]["rows"][0]["text"] == "stdio capture"
         assert resources.resources == []
         assert [item.uri_template for item in templates.resource_templates] == [
             "flameox://evidence/{evidence_id}"
@@ -1942,11 +1733,10 @@ def test_analysis_preservation_query_resource_and_restart(tmp_path: Path) -> Non
     async def exercise() -> None:
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             analyzed = await client.call_tool(
-                "analyze",
+                "preview_artifact",
                 {
-                    "capability_id": "artifact.preview",
                     "sources": [{"kind": "path", "path": str(artifact)}],
-                    "arguments": {},
+                    "options": {},
                 },
             )
             assert analyzed.is_error is False
@@ -1962,9 +1752,8 @@ def test_analysis_preservation_query_resource_and_restart(tmp_path: Path) -> Non
 
         async with Client(create_server(tmp_path), raise_exceptions=True) as restarted:
             reanalyzed = await restarted.call_tool(
-                "analyze",
+                "preview_artifact",
                 {
-                    "capability_id": "artifact.preview",
                     "sources": [
                         {
                             "kind": "evidence",
@@ -1972,7 +1761,7 @@ def test_analysis_preservation_query_resource_and_restart(tmp_path: Path) -> Non
                             "artifact_role": "input",
                         }
                     ],
-                    "arguments": {},
+                    "options": {},
                 },
             )
             assert reanalyzed.is_error is False
@@ -1999,15 +1788,16 @@ def test_mcp_evidence_resource_redacts_capture_provenance(tmp_path: Path) -> Non
     async def exercise() -> None:
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             captured = await client.call_tool(
-                "capture_and_analyze",
+                "capture_process_output",
                 {
                     "target": {
                         "argv": [sys.executable, "-c", "print('ok')", secret_argument],
                         "cwd": ".",
                         "environment": {"FLAMEOX_TEST_MARKER": secret_environment},
-                        "provider_id": "direct",
                     },
-                    "capability_id": "artifact.preview",
+                    "provider": {"kind": "direct"},
+                    "options": {},
+                    "execution": {"kind": "single"},
                 },
             )
             assert captured.is_error is False
@@ -2042,7 +1832,7 @@ def test_mcp_evidence_resource_redacts_capture_provenance(tmp_path: Path) -> Non
 
 
 @pytest.mark.integration
-def test_mcp_validation_unknown_capability_and_failed_execution_are_typed(
+def test_mcp_validation_unavailable_provider_and_failed_execution_are_typed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     artifact = tmp_path / "samples.json"
@@ -2051,26 +1841,15 @@ def test_mcp_validation_unknown_capability_and_failed_execution_are_typed(
     async def exercise() -> None:
         async with Client(create_server(tmp_path), raise_exceptions=True) as client:
             invalid = await client.call_tool(
-                "analyze",
+                "preview_artifact",
                 {
-                    "capability_id": "artifact.preview",
                     "sources": [{"kind": "path", "path": str(artifact)}],
-                    "arguments": {"unexpected": True},
+                    "options": {"unexpected": True},
                 },
             )
             assert invalid.is_error is True
-            assert invalid.structured_content["code"] == "INVALID_INPUT"
-
-            unknown = await client.call_tool(
-                "analyze",
-                {
-                    "capability_id": "unknown.capability",
-                    "sources": [{"kind": "path", "path": str(artifact)}],
-                    "arguments": {},
-                },
-            )
-            assert unknown.is_error is True
-            assert unknown.structured_content["code"] == "UNKNOWN_CAPABILITY"
+            # MCP SDK 2.0 rejects schema-invalid input before invoking the tool.
+            assert invalid.structured_content is None
 
             empty_path = tmp_path / "empty-bin"
             empty_path.mkdir()
@@ -2078,26 +1857,34 @@ def test_mcp_validation_unknown_capability_and_failed_execution_are_typed(
             unmanaged_python.symlink_to(sys.executable)
             monkeypatch.setattr("flameox.stateless.sys.executable", str(unmanaged_python))
             unavailable = await client.call_tool(
-                "capture_and_analyze",
+                "capture_cpu_hotspots",
                 {
                     "target": {
                         "argv": [sys.executable, "-c", "pass"],
                         "environment": {"PATH": str(empty_path)},
-                        "provider_id": "py-spy",
                     },
-                    "capability_id": "cpu.hotspots",
+                    "provider": {"kind": "py-spy"},
+                    "options": {},
+                    "execution": {"kind": "single"},
                 },
             )
             assert unavailable.is_error is True
             assert unavailable.structured_content["code"] == "UNAVAILABLE_CAPABILITY"
+            assert unavailable.structured_content["details"] == {
+                "provider_id": "py-spy",
+                "preparation_tool": "prepare_providers",
+                "provider_ids": ["py-spy"],
+            }
 
             failed = await client.call_tool(
-                "capture_and_analyze",
+                "capture_process_output",
                 {
                     "target": {
                         "argv": [sys.executable, "-c", "raise SystemExit(7)"],
-                        "provider_id": "direct",
-                    }
+                    },
+                    "provider": {"kind": "direct"},
+                    "options": {},
+                    "execution": {"kind": "single"},
                 },
             )
             assert failed.is_error is True
@@ -2531,8 +2318,6 @@ def test_unpreserved_operations_create_no_durable_state(tmp_path: Path) -> None:
     artifact.write_text("[]")
     runtime = AnalysisRuntime(tmp_path)
     try:
-        runtime.discover_capabilities(sources=[PathSource(path=str(artifact))])
-        runtime.inspect_capabilities(["artifact.preview"])
         runtime.analyze("artifact.preview", [PathSource(path=str(artifact))], {})
     finally:
         runtime.close()


### PR DESCRIPTION
### Problem

Flameox exposed 24 evidence capabilities behind generic `discover_capabilities`, `inspect_capabilities`, `analyze(capability_id, arguments)`, and `capture_and_analyze(...)` tools. Agents had to learn a Flameox-specific search/inspection protocol and manually construct untyped argument objects even when the MCP client already provides tool search and lazy loading.

The parallel discovery path also maintained its own provider probes, compatibility logic, CLI commands, and tests. That catalog could drift from the validation performed by an actual capture.

### Change

- Generate 24 read-only analysis tools and 17 executing capture tools from the capability registry, plus `prepare_providers`, `preserve_evidence`, and `query_evidence`.
- Give every capability tool top-level typed arguments, capability-specific options, output schemas, truthful effect annotations, and capture-provider discriminators containing only compatible providers.
- Keep analysis and capture separate so a read-only annotation never conceals process execution.
- Derive generated schemas and callable diagnostics through the pinned Python MCP SDK 2.0 registration API.
- Make capture compatibility use one artifact-format contract shared by schema generation and pre-execution validation.
- Remove the superseded MCP discovery/inspection tools, CLI capability catalog, provider-probe registry, and associated compatibility code. The shared `AnalysisRuntime.analyze` and `capture_and_analyze` engine remains the transport-independent implementation.
- Return an exact `prepare_providers` retry from missing managed-provider captures. Host tools, drivers, permissions, and workload-interpreter packages remain external setup boundaries.

Representative catalog output:

```text
44 tools, 257394 catalog bytes
analyze_cpu_hotspots: sources, options, limits, continuation
capture_cpu_hotspots: target, provider, options, execution, limits, preserve
```

The larger one-time `tools/list` payload is the intentional tradeoff for actual typed operations. Clients with tool search/lazy loading do not place the complete catalog in model context.

### Compatibility

This intentionally removes the seven-tool generic MCP surface and the `flameox capabilities discover|inspect` CLI commands. Existing artifact formats, capture providers, evidence manifests, and the transport-independent runtime analysis/capture methods are unchanged.

### Validation

- `uv run pytest -q` — 123 passed, 77 deselected
- `uv run pytest tests/test_stateless.py -q` — 50 passed, 28 deselected
- `uv run pytest -o addopts='' -ra -q -m 'not optional and not performance and process' tests` — 73 passed, 127 deselected
- `uv run ruff check src tests tools` — passed
- `uv run ruff format --check src tests tools` — passed
- `uv run mypy src tests tools` — passed
- `uv run lint-imports` — 2 contracts kept
- `uv run vulture src/flameox --min-confidence 80` — passed
- `uv run python -m flameox mcp inspect` — emitted the 44-tool catalog

The stdio process test initializes MCP, lists the complete catalog, observes SDK-standard rejection of schema-invalid input, and validates successful artifact analysis and direct-capture outputs against the advertised schemas.

### Suggested review order

1. `docs/interfaces.md` for the public contract and compatibility decision.
2. `src/flameox/mcp/capability_tools.py` and `src/flameox/mcp/server.py` for SDK 2.0 schema generation and handler registration.
3. `src/flameox/runtime_contracts.py` and `src/flameox/stateless.py` for shared compatibility ownership and legacy removal.
4. MCP contract and stdio coverage in `tests/test_stateless.py`.