### PR TITLE
feat(evidence): complete typed investigation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ coverage, truncation, limitations, and optional immutable preservation.
 
 The server exposes actual evidence operations for client-side tool search instead of hiding its
 capabilities behind `discover`, `inspect`, or generic `analyze(capability_id, arguments)` calls.
-There are 24 read-only analysis tools, 17 executing capture tools, and three lifecycle tools. For
+There are 26 read-only analysis tools, 18 executing capture tools, and three lifecycle tools. For
 example:
 
 ```text
 analyze_cpu_hotspots       capture_cpu_hotspots
+analyze_cpu_callers
 analyze_gpu_launches       capture_gpu_launches
 analyze_benchmark_compare  capture_benchmark_summary
 analyze_kernel_validation  capture_sanitizer_failures

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,4 +70,6 @@ inventory. Host profilers, drivers, and permissions remain external and receive 
 
 Direct capture is trusted local execution, not containment. Typed argv prevents
 shell interpretation, while the broker provides process-group cleanup, bounded
-output, timeouts, resource observation, and exact executable identity.
+output, timeouts, resource observation, and exact executable identity. Those bounds do not provide
+a network sandbox or neutralize the target program's own external side effects. MCP effect
+annotations are discovery and confirmation hints, not authorization controls.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -10,12 +10,12 @@ search/inspect protocol in front of its operations. A caller that knows the evid
 invoke its tool directly; an unfamiliar caller relies on the MCP client's ordinary tool search and
 then receives the selected tool's complete schema.
 
-There are exactly 44 tools:
+There are exactly 47 tools:
 
 | Group | Count | Examples | Effect |
 | --- | ---: | --- | --- |
-| Existing-artifact analysis | 24 | `analyze_cpu_hotspots`, `analyze_gpu_launches`, `analyze_benchmark_compare`, `analyze_kernel_validation`, `preview_artifact` | Read-only and idempotent. |
-| Capture and immediate analysis | 17 | `capture_cpu_hotspots`, `capture_gpu_launches`, `capture_benchmark_summary`, `capture_sanitizer_failures`, `capture_process_output` | Executes typed argv; not read-only or idempotent. |
+| Existing-artifact analysis | 26 | `analyze_cpu_hotspots`, `analyze_cpu_callers`, `analyze_gpu_launches`, `analyze_benchmark_compare`, `analyze_pytest_fixtures`, `preview_artifact` | Read-only and idempotent. |
+| Capture and immediate analysis | 18 | `capture_cpu_hotspots`, `capture_gpu_launches`, `capture_benchmark_summary`, `capture_pytest_fixtures`, `capture_process_output` | Executes typed argv; not read-only or idempotent. |
 | Evidence lifecycle | 3 | `prepare_providers`, `preserve_evidence`, `query_evidence` | Prepare an explicit uvx environment or manage immutable evidence. |
 
 The capability registry generates the analysis and capture tools through the Python MCP SDK 2.0
@@ -23,14 +23,32 @@ registration API. The SDK derives each top-level input schema directly from the 
 A generated analysis tool has `sources`, capability-specific typed `options`, optional lowered
 `limits`, and an optional `continuation`. A generated capture tool has `target`, a discriminated
 `provider` union containing only compatible capture providers, capability-specific typed `options`,
-an explicit `single` or `experiment` execution union, optional lowered `limits`, and optional
-`preserve`. There is no extra request envelope and there are no free-form provider or analysis
-argument objects.
+an explicit execution model, optional lowered `limits`, and optional `preserve`. Capabilities that
+can analyze the multiple artifacts produced by paired cases expose the `single` or `experiment`
+union; single-artifact analyses expose only `single`. There is no extra request envelope and there
+are no free-form provider or analysis argument objects.
 
 Field descriptions are part of the public MCP contract. Shared source, target, limit, provider,
 and experiment descriptions are declared on their owning Pydantic models so CLI validation,
 runtime validation, and every generated capability tool use the same semantics. Transport-only
 fields such as continuations and preservation handles are described at the MCP boundary.
+
+Successful calls keep the complete validated result in `structuredContent`. Their text block is a
+short compatibility summary with the capability, completion or truncation state, session handle,
+and next action; it does not serialize the evidence tables a second time. Content-only clients can
+still identify the outcome and recovery path, while structured clients retain the authoritative
+bounded evidence. Preserved results also return a resource link.
+
+Each capability declaration also owns its accepted source cardinality. MCP encodes that range in
+the generated `sources` schema, and the runtime checks the same range before resolving paths or
+starting capture. Single-artifact summaries require exactly one source, comparison operations
+require at least two, and only intentional aggregations accept a larger bounded collection.
+
+`options` is optional when the capability model can be constructed entirely from documented
+defaults, including operations whose option model is empty. It remains required when omission
+would leave the request incomplete, such as the start and end bounds for `trace.window`. Unknown
+fields are rejected rather than ignored, and pstats CPU metrics use a closed vocabulary in the
+generated schema.
 
 For example, a single Nsight Compute capture for kernel metrics has this argument shape:
 
@@ -70,9 +88,11 @@ metrics and rows remain open JSON values. Success uses structured content direct
 details. MCP SDK argument-validation errors occur before tool execution and therefore use the
 protocol error shape rather than the tool's output schema.
 
-`prepare_providers` is the only open-world tool. It resolves the exact package requirement through
-`uvx`, verifies that environment by running Flameox's version command, and returns the same
-requirement in a global, version-pinned MCP launcher. The request names the complete managed
+`prepare_providers` and the capture tools are open-world. Preparation resolves the exact package
+requirement through `uvx`, verifies that environment by running Flameox's version command, and
+returns the same requirement in a global, version-pinned MCP launcher. Capture tools execute an
+explicit caller-supplied target that may itself access external services. The request names the
+complete managed
 provider set; Flameox keeps no installed-provider inventory or setup receipt. System profilers,
 drivers, device access, and OS permissions remain external requirements. Flameox returns guidance
 for them but does not invoke a system package manager or elevate privileges. Preparation creates no

--- a/docs/investigations.md
+++ b/docs/investigations.md
@@ -33,10 +33,13 @@ containment must not be silently promoted to complete evidence.
 
 ## Experiments
 
-Every MCP `capture_*` capability tool accepts a discriminated `single` or `experiment` execution
-request. The CLI accepts the same `ExperimentDesign` object through `capture --experiment JSON`.
-An experiment declares cases, blocks, seed, metric, estimand, practical threshold, and an optional
-semantic oracle. Cases are bounded and execute through the same broker as a single capture.
+MCP capture tools accept `single` execution. Capabilities whose analysis intentionally composes
+multiple artifacts also accept a discriminated `experiment` request. Single-artifact analyses do
+not advertise experiment mode and reject it during runtime preflight before a target starts. The
+CLI accepts the same `ExperimentDesign` object through `capture --experiment JSON` when the chosen
+capability supports it. An experiment declares cases, blocks, seed, metric, estimand, practical
+threshold, and an optional semantic oracle. Cases are bounded and execute through the same broker
+as a single capture.
 
 For GPU kernel work, the agent normally compiles and edits with its native coding tools, records
 correctness through `analyze_kernel_validation` and `analyze_kernel_compare`, checks hazards with
@@ -57,6 +60,27 @@ and candidate summaries independently, preserve them if they must survive the se
 both sources to the matching `analyze_*_compare` tool. There is no `capture_*_compare` shortcut:
 comparison requires explicit artifact identity, while experiment mode owns randomized case order
 and repeated measurements within one request.
+
+## Scaling
+
+`benchmark.scaling` is distinct from both workflows. The caller names a declared numeric benchmark
+dimension such as `elements`; Flameox groups positive measurements for each compatible benchmark
+series, averages repeated samples at each input value, and fits
+`measurement = coefficient * input ** exponent` in log space. The result reports the observed
+input range, point count, exponent, and goodness of fit. A series with fewer than two distinct
+positive input values is explicitly inconclusive rather than falling back to a generic benchmark
+summary. The fit describes the measured range; it does not establish asymptotic complexity or a
+causal performance change.
+
+## Pytest fixture work
+
+`pytest.fixtures` records fixture setup and finalizer phases without serializing fixture values.
+Each invocation retains its fixture name, scope, test identity, worker, phase outcome, and measured
+duration. Session-scoped fixtures therefore appear once per xdist worker, rather than being
+mistaken for one global invocation. Aggregate work is summed evidence and can overlap across
+workers; Flameox reports the maximum accumulated worker work separately and does not label either
+quantity as wall-clock critical-path duration. Interrupted runs preserve incomplete invocations
+instead of assigning missing finalizers a zero duration.
 
 Randomization and blocking reduce ordering and environmental bias; they do not
 make an unrepresentative workload representative. Failed and partial trials are

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ use `-o addopts='' -m performance`.
 
 ## Required behavioral proof
 
-Contract tests assert exactly 44 MCP tools, one resource template, no concrete resource list,
+Contract tests assert exactly 47 MCP tools, one resource template, no concrete resource list,
 capability-specific top-level input schemas, compatible-provider discriminators, output schemas,
 truthful annotations, and direct structured success content without a universal wrapper.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "mypy>=1.15",
     "pip-audit>=2.9",
     "pytest>=8.3",
+    "pytest-xdist>=3.8,<4",
     "pytest-cov>=6.1",
     "pyarrow-stubs>=20.0.0.20260625",
     "ruff>=0.11",

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
@@ -29,6 +30,7 @@ from flameox import __version__
 from flameox.mcp.capability_tools import (
     Execution,
     ExperimentExecution,
+    SingleExecution,
     analysis_tool_name,
     capture_provider_type,
     capture_tool_name,
@@ -53,7 +55,7 @@ CAPTURE = ToolAnnotations(
     read_only_hint=False,
     destructive_hint=True,
     idempotent_hint=False,
-    open_world_hint=False,
+    open_world_hint=True,
 )
 PRESERVE = ToolAnnotations(
     read_only_hint=False,
@@ -185,9 +187,54 @@ class QueryOutcome(_ObjectOutcome):
     root: QueryEnvelope | ToolFailureEnvelope
 
 
+def _success_summary(value: dict[str, Any], *, resource: ResourceLink | None) -> str:
+    capability_id = value.get("capability_id")
+    if isinstance(capability_id, str):
+        coverage = value.get("coverage")
+        complete = isinstance(coverage, dict) and coverage.get("complete") is True
+        state = "complete" if complete else "bounded or incomplete"
+        continuation = value.get("continuation")
+        preserved = value.get("preserved")
+        next_action = (
+            "follow the returned evidence resource"
+            if resource is not None or isinstance(preserved, dict)
+            else "request the continuation page"
+            if isinstance(continuation, str)
+            else "preserve the session analysis if durable evidence is needed"
+        )
+        return (
+            f"{capability_id}: analysis {state}; analysis_id={value.get('analysis_id')}; "
+            f"next: {next_action}. Full bounded evidence is in structuredContent."
+        )
+    evidence_id = value.get("evidence_id")
+    if isinstance(evidence_id, str):
+        return (
+            f"Evidence {evidence_id} preserved with {value.get('artifact_count', 0)} artifact(s); "
+            "next: follow the returned evidence resource. Full details are in structuredContent."
+        )
+    if "requested_providers" in value:
+        preparation_action = value.get("next_action")
+        action = (
+            "reconnect using the returned launcher" if preparation_action else "continue capture"
+        )
+        return (
+            f"Provider preparation completed; next: {action}. "
+            "Full details are in structuredContent."
+        )
+    if "evidence" in value:
+        evidence = value.get("evidence")
+        count = len(evidence) if isinstance(evidence, list) else 0
+        action = "request the continuation page" if value.get("continuation") else "query complete"
+        return (
+            f"Found {count} evidence record(s); next: {action}. "
+            "Full details are in structuredContent."
+        )
+    return "Operation completed. Full details are in structuredContent."
+
+
 def _success(value: dict[str, Any], *, resource: ResourceLink | None = None) -> CallToolResult:
     content: list[ContentBlock] = [
-        TextContent(type="text", text=json.dumps(value, sort_keys=True, separators=(",", ":")))
+        TextContent(type="text", text=_success_summary(value, resource=resource))
     ]
     if resource is not None:
         content.append(resource)
@@ -231,8 +278,13 @@ def create_server(
             "Pass explicit artifact paths or a typed direct target. Analysis and capture are "
             "session-local unless preserve_evidence is called. If a capture reports a missing "
             "Flameox-managed provider, call prepare_providers with the complete desired provider "
-            "set and reconnect with its returned launcher. Flameox never installs host tools, "
-            "searches parent directories, accepts shell strings, or creates durable jobs."
+            "set and reconnect with its returned launcher. Profiles are exploratory: use "
+            "capture_* with execution.kind=experiment for baseline/candidate cases measured in "
+            "randomized paired blocks with a wall-clock effect and semantic oracle. Use "
+            "benchmark.scaling for measurements across a declared numeric input axis, and "
+            "analyze_*_compare for compatible native artifacts captured separately. Flameox "
+            "never installs host tools, searches parent directories, accepts shell strings, or "
+            "creates durable jobs."
         ),
         lifespan=lifespan,
     )
@@ -306,8 +358,8 @@ def create_server(
                     max_length=32,
                 ),
             ],
-            options: Any,
             ctx: Context[AnalysisRuntime],
+            options: Any = None,
             limits: Annotated[
                 RequestLimits | None,
                 Field(description="Optional bounds that may only lower the server limits."),
@@ -322,6 +374,8 @@ def create_server(
                 ),
             ] = None,
         ) -> Annotated[CallToolResult, AnalysisOutcome]:
+            if options is None:
+                options = capability.model.model_validate({})
             try:
                 return _success(
                     runtime(ctx).analyze(
@@ -339,19 +393,28 @@ def create_server(
 
         # MCP SDK 2.0 derives schemas and diagnostic names from the registered callable.
         handler.__name__ = analysis_tool_name(capability)
-        minimum_sources = 2 if capability.id.endswith(".compare") else 1
         handler.__annotations__["sources"] = Annotated[
             list[Source],
             Field(
                 description="Native paths or preserved evidence artifacts to analyze.",
-                min_length=minimum_sources,
-                max_length=32,
+                min_length=capability.minimum_sources,
+                max_length=capability.maximum_sources,
             ),
         ]
         handler.__annotations__["options"] = Annotated[
             capability.model,
             Field(description=f"Options for {capability.summary.lower()}"),
         ]
+        if any(field.is_required() for field in capability.model.model_fields.values()):
+            signature = inspect.signature(handler, eval_str=True)
+            parameters = list(signature.parameters.values())
+            option_index = next(
+                index for index, parameter in enumerate(parameters) if parameter.name == "options"
+            )
+            parameters[option_index] = parameters[option_index].replace(
+                default=inspect.Parameter.empty
+            )
+            handler.__signature__ = signature.replace(parameters=parameters)  # type: ignore[attr-defined]
         return handler
 
     def capture_handler(
@@ -363,11 +426,11 @@ def create_server(
                 DirectTarget, Field(description="Process target to execute and capture.")
             ],
             provider: Any,
-            options: Any,
             execution: Annotated[
                 Execution, Field(description="Run once or execute a randomized paired experiment.")
             ],
             ctx: Context[AnalysisRuntime],
+            options: Any = None,
             limits: Annotated[
                 RequestLimits | None,
                 Field(description="Optional bounds that may only lower the server limits."),
@@ -382,6 +445,9 @@ def create_server(
                 ),
             ] = False,
         ) -> Annotated[CallToolResult, AnalysisOutcome]:
+            if options is None:
+                options = capability.model.model_validate({})
+
             async def progress(current: int, total: int, message: str) -> None:
                 await ctx.report_progress(float(current), float(total), message)
 
@@ -440,16 +506,43 @@ def create_server(
             capability.model,
             Field(description=f"Options for {capability.summary.lower()}"),
         ]
+        execution_type = Execution if capability.maximum_sources > 1 else SingleExecution
+        handler.__annotations__["execution"] = Annotated[
+            execution_type,
+            Field(
+                description=(
+                    "Run once or execute a randomized paired experiment."
+                    if capability.maximum_sources > 1
+                    else "Run once; this analysis accepts exactly one captured artifact."
+                )
+            ),
+        ]
+        if any(field.is_required() for field in capability.model.model_fields.values()):
+            signature = inspect.signature(handler, eval_str=True)
+            parameters = list(signature.parameters.values())
+            option_index = next(
+                index for index, parameter in enumerate(parameters) if parameter.name == "options"
+            )
+            parameters[option_index] = parameters[option_index].replace(
+                default=inspect.Parameter.empty
+            )
+            handler.__signature__ = signature.replace(parameters=parameters)  # type: ignore[attr-defined]
         return handler
 
     for capability in CAPABILITIES:
+        analysis_routing = (
+            " Use this for compatible native artifacts already captured separately, not for "
+            "paired baseline/candidate execution."
+            if capability.id.endswith(".compare")
+            else ""
+        )
         server.add_tool(
             analysis_handler(capability),
             name=analysis_tool_name(capability),
             title=capability.summary,
             description=(
                 f"{capability.summary} Accepts: {', '.join(capability.formats)}. "
-                f"Limitation: {capability.limitation}"
+                f"Limitation: {capability.limitation}{analysis_routing}"
             ),
             annotations=READ_ONLY,
             structured_output=True,
@@ -457,13 +550,22 @@ def create_server(
         provider_type = capture_provider_type(capability)
         if provider_type is not None:
             providers = compatible_capture_providers(capability)
+            experiment_routing = (
+                " Set execution.kind=experiment for baseline/candidate cases in randomized "
+                "paired blocks; the experiment effect is wall_time_ns and the semantic oracle "
+                "checks successful captures."
+                if capability.maximum_sources > 1
+                else ""
+            )
             server.add_tool(
                 capture_handler(capability, provider_type),
                 name=capture_tool_name(capability),
                 title=f"Capture and {capability.summary.lower()}",
                 description=(
                     f"Execute typed argv and {capability.summary.lower()} Compatible providers: "
-                    f"{', '.join(provider.id for provider in providers)}."
+                    f"{', '.join(provider.id for provider in providers)}. Flameox bounds and "
+                    "records the process but does not prevent the target's external side effects."
+                    f"{experiment_routing}"
                 ),
                 annotations=CAPTURE,
                 structured_output=True,

--- a/src/flameox/providers/benchmark_scaling.py
+++ b/src/flameox/providers/benchmark_scaling.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from statistics import fmean
+from typing import Any
+
+from flameox.providers.contracts import ProviderAnalysis
+
+
+def scaling_projection(
+    rows: Sequence[Mapping[str, Any]],
+    arguments: Mapping[str, Any],
+    *,
+    provider_id: str,
+    provider_version: str,
+    max_rows: int,
+) -> ProviderAnalysis:
+    """Fit bounded log-log scaling estimates for declared benchmark dimensions."""
+
+    input_dimension = str(arguments["input_dimension"])
+    requested_metric = arguments.get("metric")
+    series: dict[tuple[str, str], dict[float, list[float]]] = defaultdict(lambda: defaultdict(list))
+    identities: set[tuple[str, str]] = set()
+    omitted_measurements = 0
+    for row in rows:
+        if row.get("is_warmup") is True:
+            continue
+        benchmark = row.get("benchmark")
+        unit = row.get("unit")
+        if not isinstance(benchmark, str) or not isinstance(unit, str):
+            continue
+        if requested_metric is not None and benchmark != requested_metric:
+            continue
+        identity = (benchmark, unit)
+        identities.add(identity)
+        dimensions = row.get("dimensions")
+        raw_input = dimensions.get(input_dimension) if isinstance(dimensions, Mapping) else None
+        value = row.get("value_int")
+        if value is None:
+            value = row.get("value_float")
+        if (
+            not isinstance(raw_input, str | int | float)
+            or isinstance(raw_input, bool)
+            or not isinstance(value, str | int | float)
+            or isinstance(value, bool)
+        ):
+            omitted_measurements += 1
+            continue
+        try:
+            input_value = float(raw_input)
+            measurement = float(value)
+        except ValueError:
+            omitted_measurements += 1
+            continue
+        if (
+            not math.isfinite(input_value)
+            or not math.isfinite(measurement)
+            or input_value <= 0
+            or measurement <= 0
+        ):
+            omitted_measurements += 1
+            continue
+        series[identity][input_value].append(measurement)
+
+    output: list[dict[str, Any]] = []
+    estimated = 0
+    for benchmark, unit in sorted(identities):
+        points = sorted(
+            (input_value, fmean(values))
+            for input_value, values in series[(benchmark, unit)].items()
+        )
+        if len(points) < 2:
+            output.append(
+                {
+                    "benchmark": benchmark,
+                    "unit": unit,
+                    "status": "inconclusive",
+                    "input_dimension": input_dimension,
+                    "point_count": len(points),
+                    "exponent": None,
+                    "coefficient": None,
+                    "r_squared": None,
+                    "input_min": points[0][0] if points else None,
+                    "input_max": points[-1][0] if points else None,
+                    "reason": "fewer than two distinct positive input values",
+                }
+            )
+            continue
+        log_inputs = [math.log(point[0]) for point in points]
+        log_measurements = [math.log(point[1]) for point in points]
+        mean_input = fmean(log_inputs)
+        mean_measurement = fmean(log_measurements)
+        input_variance = sum((value - mean_input) ** 2 for value in log_inputs)
+        exponent = (
+            sum(
+                (input_value - mean_input) * (measurement - mean_measurement)
+                for input_value, measurement in zip(log_inputs, log_measurements, strict=True)
+            )
+            / input_variance
+        )
+        intercept = mean_measurement - exponent * mean_input
+        residual_sum = sum(
+            (measurement - (intercept + exponent * input_value)) ** 2
+            for input_value, measurement in zip(log_inputs, log_measurements, strict=True)
+        )
+        total_sum = sum((measurement - mean_measurement) ** 2 for measurement in log_measurements)
+        r_squared = 1.0 if total_sum == 0 else max(0.0, 1.0 - residual_sum / total_sum)
+        output.append(
+            {
+                "benchmark": benchmark,
+                "unit": unit,
+                "status": "estimated",
+                "input_dimension": input_dimension,
+                "point_count": len(points),
+                "exponent": exponent,
+                "coefficient": math.exp(intercept),
+                "r_squared": r_squared,
+                "input_min": points[0][0],
+                "input_max": points[-1][0],
+                "reason": None,
+            }
+        )
+        estimated += 1
+
+    limitations = [
+        "The log-log power-law fit describes observed benchmark means and does not prove "
+        "asymptotic complexity or causality."
+    ]
+    if omitted_measurements:
+        limitations.append(
+            f"{omitted_measurements} measurement(s) lacked positive numeric "
+            f"{input_dimension!r} and value pairs."
+        )
+    if estimated == 0:
+        limitations.append(
+            f"No benchmark series had two distinct positive numeric {input_dimension!r} values."
+        )
+    return ProviderAnalysis(
+        provider_id=provider_id,
+        provider_version=provider_version,
+        blocks=[
+            {
+                "type": "metrics",
+                "values": {
+                    "scaling_status": "estimated" if estimated else "inconclusive",
+                    "input_dimension": input_dimension,
+                    "series_count": len(identities),
+                    "estimated_series_count": estimated,
+                    "inconclusive_series_count": len(identities) - estimated,
+                },
+            },
+            {"type": "table", "rows": output[:max_rows]},
+        ],
+        rows_observed=len(output),
+        complete=len(output) <= max_rows,
+        limitations=limitations,
+    )

--- a/src/flameox/providers/benchmark_scaling.py
+++ b/src/flameox/providers/benchmark_scaling.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import math
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
@@ -21,8 +22,10 @@ def scaling_projection(
 
     input_dimension = str(arguments["input_dimension"])
     requested_metric = arguments.get("metric")
-    series: dict[tuple[str, str], dict[float, list[float]]] = defaultdict(lambda: defaultdict(list))
-    identities: set[tuple[str, str]] = set()
+    series: dict[tuple[str, str, str], dict[float, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    identity_dimensions: dict[tuple[str, str, str], dict[str, Any]] = {}
     omitted_measurements = 0
     for row in rows:
         if row.get("is_warmup") is True:
@@ -33,10 +36,18 @@ def scaling_projection(
             continue
         if requested_metric is not None and benchmark != requested_metric:
             continue
-        identity = (benchmark, unit)
-        identities.add(identity)
         dimensions = row.get("dimensions")
         raw_input = dimensions.get(input_dimension) if isinstance(dimensions, Mapping) else None
+        non_axis_dimensions = (
+            {str(key): value for key, value in dimensions.items() if key != input_dimension}
+            if isinstance(dimensions, Mapping)
+            else {}
+        )
+        dimension_identity = json.dumps(
+            non_axis_dimensions, sort_keys=True, separators=(",", ":"), default=str
+        )
+        identity = (benchmark, unit, dimension_identity)
+        identity_dimensions[identity] = non_axis_dimensions
         value = row.get("value_int")
         if value is None:
             value = row.get("value_float")
@@ -66,16 +77,18 @@ def scaling_projection(
 
     output: list[dict[str, Any]] = []
     estimated = 0
-    for benchmark, unit in sorted(identities):
+    for identity in sorted(identity_dimensions):
+        benchmark, unit, _dimension_identity = identity
+        dimensions = identity_dimensions[identity]
         points = sorted(
-            (input_value, fmean(values))
-            for input_value, values in series[(benchmark, unit)].items()
+            (input_value, fmean(values)) for input_value, values in series[identity].items()
         )
         if len(points) < 2:
             output.append(
                 {
                     "benchmark": benchmark,
                     "unit": unit,
+                    "dimensions": dimensions,
                     "status": "inconclusive",
                     "input_dimension": input_dimension,
                     "point_count": len(points),
@@ -111,6 +124,7 @@ def scaling_projection(
             {
                 "benchmark": benchmark,
                 "unit": unit,
+                "dimensions": dimensions,
                 "status": "estimated",
                 "input_dimension": input_dimension,
                 "point_count": len(points),
@@ -146,9 +160,9 @@ def scaling_projection(
                 "values": {
                     "scaling_status": "estimated" if estimated else "inconclusive",
                     "input_dimension": input_dimension,
-                    "series_count": len(identities),
+                    "series_count": len(identity_dimensions),
                     "estimated_series_count": estimated,
-                    "inconclusive_series_count": len(identities) - estimated,
+                    "inconclusive_series_count": len(identity_dimensions) - estimated,
                 },
             },
             {"type": "table", "rows": output[:max_rows]},

--- a/src/flameox/providers/benchmarks.py
+++ b/src/flameox/providers/benchmarks.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from statistics import fmean
 from typing import Any
 
+from flameox.providers.benchmark_scaling import scaling_projection
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 from flameox.workers.benchmark_samples_contract import (
     BENCHMARK_SAMPLES_WORKER,
@@ -40,6 +41,7 @@ class BenchmarkProvider:
             return self._structured_samples(
                 paths,
                 compare_arguments=arguments if capability_id == "benchmark.compare" else None,
+                scaling_arguments=arguments if capability_id == "benchmark.scaling" else None,
                 max_rows=max_rows,
                 timeout_seconds=timeout_seconds,
                 maximum_rss_bytes=maximum_rss_bytes,
@@ -59,6 +61,19 @@ class BenchmarkProvider:
         ]
         if capability_id == "benchmark.compare":
             return self._compare(parsed, arguments, max_rows=max_rows)
+        if capability_id == "benchmark.scaling":
+            if any(result.truncated for result in parsed):
+                raise ProviderFailure(
+                    "LIMIT_EXCEEDED",
+                    "benchmark.scaling requires complete samples; raise the startup row limit",
+                )
+            return scaling_projection(
+                [dict(row) for result in parsed for row in result.rows],
+                arguments,
+                provider_id="pyperf",
+                provider_version=parsed[0].reader_version,
+                max_rows=max_rows,
+            )
         rows: list[dict[str, Any]] = []
         observed = 0
         limitations: list[str] = []
@@ -95,6 +110,7 @@ class BenchmarkProvider:
         paths: Sequence[Path],
         *,
         compare_arguments: Mapping[str, Any] | None,
+        scaling_arguments: Mapping[str, Any] | None,
         max_rows: int,
         timeout_seconds: float,
         maximum_rss_bytes: int,
@@ -122,6 +138,19 @@ class BenchmarkProvider:
                 max_rows=max_rows,
                 provider_id="benchmark-samples",
                 provider_version="flameox.benchmark-samples.v1",
+            )
+        if scaling_arguments is not None:
+            if any(item.truncated for item in parsed):
+                raise ProviderFailure(
+                    "LIMIT_EXCEEDED",
+                    "benchmark.scaling requires complete samples; raise the startup row limit",
+                )
+            return scaling_projection(
+                [dict(row) for result in parsed for row in result.rows],
+                scaling_arguments,
+                provider_id="benchmark-samples",
+                provider_version="flameox.benchmark-samples.v1",
+                max_rows=max_rows,
             )
         rows: list[dict[str, Any]] = []
         limitations: list[str] = []

--- a/src/flameox/providers/capture.py
+++ b/src/flameox/providers/capture.py
@@ -101,6 +101,8 @@ def _py_spy(request: CaptureBuildRequest, managed: ManagedExecutable) -> Capture
         options.append("--gil")
     if arguments.native:
         options.append("--native")
+    if arguments.subprocesses:
+        options.append("--subprocesses")
     argv = (
         managed("py-spy", "py-spy"),
         "record",

--- a/src/flameox/providers/nsight_systems.py
+++ b/src/flameox/providers/nsight_systems.py
@@ -11,6 +11,7 @@ from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 _OPERATION_TABLE_PREFIXES = (
     "CUDA_API",
     "NVTX",
+    "OSRT",
     "OS_RUNTIME",
     "OPENACC",
     "OPENMP",

--- a/src/flameox/providers/nsight_systems.py
+++ b/src/flameox/providers/nsight_systems.py
@@ -8,6 +8,24 @@ import pyarrow.parquet as pq
 
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 
+_OPERATION_TABLE_PREFIXES = (
+    "CUDA_API",
+    "NVTX",
+    "OS_RUNTIME",
+    "OPENACC",
+    "OPENMP",
+    "MPI",
+    "VULKAN",
+    "DX12",
+)
+_LIFECYCLE_TABLE_PREFIXES = (
+    "PROCESS",
+    "THREAD",
+    "SESSION",
+    "TARGET",
+    "CONTEXT_SWITCH",
+)
+
 
 class NsightSystemsParquetProvider:
     """Bounded reads over an explicit Nsight Systems ``parquetdir`` export."""
@@ -31,6 +49,14 @@ class NsightSystemsParquetProvider:
             )
         if capability_id == "gpu.launches":
             files = [file for file in files if file.stem.upper().startswith(("CUDA_", "CUPTI_"))]
+        elif capability_id == "trace.operations":
+            files = [
+                file for file in files if file.stem.upper().startswith(_OPERATION_TABLE_PREFIXES)
+            ]
+        elif capability_id == "trace.lifecycle":
+            files = [
+                file for file in files if file.stem.upper().startswith(_LIFECYCLE_TABLE_PREFIXES)
+            ]
         rows: list[dict[str, Any]] = []
         observed = 0
         tables: list[str] = []
@@ -55,9 +81,15 @@ class NsightSystemsParquetProvider:
         ]
         if no_accelerator_activity:
             limitations.append("no_accelerator_activity_observed")
+        if capability_id in {"trace.operations", "trace.lifecycle"} and not files:
+            limitations.append(f"no_{capability_id.removeprefix('trace.')}_activity_observed")
         metrics: dict[str, Any] = {"table_count": len(tables), "row_count": observed}
         if capability_id == "gpu.launches":
             metrics["accelerator_activity_observed"] = not no_accelerator_activity
+        elif capability_id == "trace.operations":
+            metrics["operation_row_count"] = observed
+        elif capability_id == "trace.lifecycle":
+            metrics["lifecycle_row_count"] = observed
         return ProviderAnalysis(
             provider_id="nsight-systems-parquetdir",
             provider_version=provider_version,

--- a/src/flameox/providers/nvbench.py
+++ b/src/flameox/providers/nvbench.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from flameox.providers.benchmark_scaling import scaling_projection
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 
 _MAX_JSON_BYTES = 64 * 1024 * 1024
@@ -49,6 +50,19 @@ class NvbenchProvider:
         parsed = [self._read_bundle(path, max_rows=max_rows) for path in paths]
         if capability_id == "benchmark.compare":
             return self._compare(parsed, arguments, max_rows=max_rows)
+        if capability_id == "benchmark.scaling":
+            if any(bundle.measurement_count > len(bundle.rows) for bundle in parsed):
+                raise ProviderFailure(
+                    "LIMIT_EXCEEDED",
+                    "benchmark.scaling requires complete samples; raise the startup row limit",
+                )
+            return scaling_projection(
+                [row for bundle in parsed for row in bundle.rows],
+                arguments,
+                provider_id="nvbench",
+                provider_version=parsed[0].version,
+                max_rows=max_rows,
+            )
         rows: list[dict[str, Any]] = []
         observed = 0
         for input_index, bundle in enumerate(parsed):
@@ -318,12 +332,30 @@ def _sidecar_rows(
                 "value_int": None,
                 "value_float": value,
                 "value_index": index,
-                "dimensions": {
-                    "state": state.get("name"),
-                    "device": state.get("device"),
-                    "type_config_index": state.get("type_config_index"),
-                },
+                "dimensions": _state_dimensions(state),
             }
+
+
+def _state_dimensions(state: Mapping[str, Any]) -> dict[str, Any]:
+    name = state.get("name")
+    dimensions = {
+        "state": name,
+        "device": state.get("device"),
+        "type_config_index": state.get("type_config_index"),
+    }
+    if isinstance(name, str):
+        for component in name.split(","):
+            key, separator, value = component.strip().partition("=")
+            if (
+                separator
+                and key
+                and value
+                and len(key) <= 120
+                and len(value) <= 200
+                and all(character.isalnum() or character in "._:/-" for character in key)
+            ):
+                dimensions.setdefault(key, value)
+    return dimensions
 
 
 def _object(value: object, subject: str) -> dict[str, Any]:

--- a/src/flameox/providers/nvbench.py
+++ b/src/flameox/providers/nvbench.py
@@ -343,6 +343,7 @@ def _state_dimensions(state: Mapping[str, Any]) -> dict[str, Any]:
         "device": state.get("device"),
         "type_config_index": state.get("type_config_index"),
     }
+    parsed_name = False
     if isinstance(name, str):
         for component in name.split(","):
             key, separator, value = component.strip().partition("=")
@@ -355,6 +356,9 @@ def _state_dimensions(state: Mapping[str, Any]) -> dict[str, Any]:
                 and all(character.isalnum() or character in "._:/-" for character in key)
             ):
                 dimensions.setdefault(key, value)
+                parsed_name = True
+    if parsed_name:
+        dimensions.pop("state")
     return dimensions
 
 

--- a/src/flameox/providers/otlp.py
+++ b/src/flameox/providers/otlp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -54,8 +55,8 @@ class OtlpProvider:
         rows: list[dict[str, Any]] = [
             {"table": table, **dict(row)} for table, values in tables for row in values
         ]
-        counts = (
-            dict(response.counts)
+        counts: Mapping[str, int] = (
+            {str(name): count for name, count in response.counts.items()}
             if response.row_limit_exceeded
             else {table: len(values) for table, values in tables}
         )
@@ -63,6 +64,10 @@ class OtlpProvider:
         limitations = list(response.limitations)
         if response.row_limit_exceeded and "otlp_row_limit_exceeded" not in limitations:
             limitations.append("otlp_row_limit_exceeded")
+        if capability_id == "trace.operations":
+            return self._operations(response, counts, limitations, max_rows=max_rows)
+        if capability_id == "trace.lifecycle":
+            return self._lifecycle(response, counts, limitations, max_rows=max_rows)
         return ProviderAnalysis(
             provider_id="otlp",
             provider_version=OTLP_WORKER.implementation,
@@ -78,5 +83,127 @@ class OtlpProvider:
             ],
             rows_observed=observed,
             complete=not response.row_limit_exceeded,
+            limitations=limitations,
+        )
+
+    @staticmethod
+    def _operations(
+        response: Any,
+        counts: Mapping[str, int],
+        limitations: list[str],
+        *,
+        max_rows: int,
+    ) -> ProviderAnalysis:
+        aggregates: dict[tuple[str, int, int], list[int]] = defaultdict(lambda: [0, 0, 0])
+        missing_duration_count = 0
+        for span in response.spans:
+            duration = span.get("duration_ns")
+            if not isinstance(duration, int):
+                missing_duration_count += 1
+                continue
+            key = (str(span["name"]), int(span["kind"]), int(span["status_code"]))
+            aggregate = aggregates[key]
+            aggregate[0] += 1
+            aggregate[1] += duration
+            aggregate[2] = max(aggregate[2], duration)
+        rows = [
+            {
+                "operation": operation,
+                "span_kind": kind,
+                "status_code": status,
+                "call_count": values[0],
+                "total_duration_ns": values[1],
+                "mean_duration_ns": values[1] / values[0],
+                "max_duration_ns": values[2],
+            }
+            for (operation, kind, status), values in sorted(
+                aggregates.items(), key=lambda item: (-item[1][1], item[0])
+            )
+        ]
+        if missing_duration_count:
+            limitations.append(
+                f"{missing_duration_count} span(s) without a valid duration were omitted."
+            )
+        if response.row_limit_exceeded:
+            limitations.append("Operation aggregates cover only the bounded OTLP prefix.")
+        complete = not response.row_limit_exceeded and len(rows) <= max_rows
+        return ProviderAnalysis(
+            provider_id="otlp",
+            provider_version=OTLP_WORKER.implementation,
+            blocks=[
+                {
+                    "type": "metrics",
+                    "values": {
+                        "operation_count": len(aggregates),
+                        "span_count": counts.get("spans", len(response.spans)),
+                        "missing_duration_count": missing_duration_count,
+                    },
+                },
+                {"type": "table", "rows": rows[:max_rows]},
+            ],
+            rows_observed=len(rows) + int(response.row_limit_exceeded),
+            complete=complete,
+            limitations=limitations,
+        )
+
+    @staticmethod
+    def _lifecycle(
+        response: Any,
+        counts: Mapping[str, int],
+        limitations: list[str],
+        *,
+        max_rows: int,
+    ) -> ProviderAnalysis:
+        rows: list[dict[str, Any]] = []
+        for span in response.spans:
+            base = {
+                "trace_id": span["trace_id"],
+                "span_id": span["span_id"],
+                "parent_span_id": span["parent_span_id"],
+                "operation": span["name"],
+            }
+            start = span.get("start_time_unix_nano")
+            end = span.get("end_time_unix_nano")
+            if isinstance(start, int) and start > 0:
+                rows.append({"transition": "span_started", "time_unix_nano": start, **base})
+            if isinstance(end, int) and end > 0:
+                rows.append({"transition": "span_ended", "time_unix_nano": end, **base})
+        for event in response.events:
+            rows.append(
+                {
+                    "transition": "span_event",
+                    "time_unix_nano": event["time_unix_nano"],
+                    "trace_id": event["trace_id"],
+                    "span_id": event["span_id"],
+                    "parent_span_id": None,
+                    "operation": event["name"],
+                }
+            )
+        rows.sort(
+            key=lambda row: (
+                int(row["time_unix_nano"]),
+                str(row["span_id"]),
+                str(row["transition"]),
+            )
+        )
+        if response.row_limit_exceeded:
+            limitations.append("Lifecycle transitions cover only the bounded OTLP prefix.")
+        complete = not response.row_limit_exceeded and len(rows) <= max_rows
+        return ProviderAnalysis(
+            provider_id="otlp",
+            provider_version=OTLP_WORKER.implementation,
+            blocks=[
+                {
+                    "type": "metrics",
+                    "values": {
+                        "transition_count": len(rows),
+                        "span_count": counts.get("spans", len(response.spans)),
+                        "event_count": counts.get("events", len(response.events)),
+                    },
+                },
+                {"type": "table", "rows": rows[:max_rows]},
+            ],
+            rows_observed=len(rows) + int(response.row_limit_exceeded),
+            complete=complete,
             limitations=limitations,
         )

--- a/src/flameox/providers/perfetto.py
+++ b/src/flameox/providers/perfetto.py
@@ -94,11 +94,23 @@ class PerfettoProvider:
             slices = [row.model_dump(mode="json") for row in response.rows]
             rows = self._project(capability_id, slices)
             slice_count = len(slices)
+        metrics: dict[str, Any] = {"slice_count": slice_count}
+        limitations = [
+            "Slice duration is inclusive and nested slices can overlap.",
+            "Trace nesting does not by itself prove causal dependence.",
+        ]
+        if capability_id == "trace.pytorch":
+            metrics = {
+                "source_slice_count": slice_count,
+                "pytorch_event_count": len(rows),
+            }
+            if not rows:
+                limitations.append("no_pytorch_activity_observed")
         return ProviderAnalysis(
             provider_id="perfetto",
             provider_version=version,
             blocks=[
-                {"type": "metrics", "values": {"slice_count": slice_count}},
+                {"type": "metrics", "values": metrics},
                 {"type": "table", "rows": rows[:max_rows]},
             ],
             rows_observed=(
@@ -107,37 +119,56 @@ class PerfettoProvider:
                 else len(rows) + int(response.truncated)
             ),
             complete=not response.truncated and len(rows) <= max_rows,
-            limitations=[
-                "Slice duration is inclusive and nested slices can overlap.",
-                "Trace nesting does not by itself prove causal dependence.",
-            ],
+            limitations=limitations,
         )
 
     @staticmethod
     def _project(capability_id: str, slices: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        if capability_id != "trace.call_graph":
-            return slices
-        by_id = {int(row["id"]): row for row in slices}
-        edges: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
-        for row in slices:
-            parent_id = row.get("parent_id")
-            if parent_id is None or int(parent_id) not in by_id:
-                continue
-            parent = by_id[int(parent_id)]
-            aggregate = edges[(str(parent["name"]), str(row["name"]))]
-            aggregate[0] += 1
-            aggregate[1] += int(row["dur"])
-        return [
-            {
-                "parent": parent,
-                "child": child,
-                "sample_count": values[0],
-                "inclusive_duration_ns": values[1],
-            }
-            for (parent, child), values in sorted(
-                edges.items(), key=lambda item: (-item[1][1], item[0])
-            )
-        ]
+        if capability_id == "trace.call_graph":
+            by_id = {int(row["id"]): row for row in slices}
+            edges: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
+            for row in slices:
+                parent_id = row.get("parent_id")
+                if parent_id is None or int(parent_id) not in by_id:
+                    continue
+                parent = by_id[int(parent_id)]
+                aggregate = edges[(str(parent["name"]), str(row["name"]))]
+                aggregate[0] += 1
+                aggregate[1] += int(row["dur"])
+            return [
+                {
+                    "parent": parent,
+                    "child": child,
+                    "sample_count": values[0],
+                    "inclusive_duration_ns": values[1],
+                }
+                for (parent, child), values in sorted(
+                    edges.items(), key=lambda item: (-item[1][1], item[0])
+                )
+            ]
+        if capability_id == "trace.pytorch":
+            rows = []
+            for row in slices:
+                name = str(row["name"])
+                category = str(row.get("category") or "").casefold()
+                if not (
+                    "pytorch" in category
+                    or "torch" in category
+                    or name.startswith(("aten::", "autograd::", "torch::", "ProfilerStep#"))
+                    or row.get("input_shapes") is not None
+                    or row.get("allocation_bytes") is not None
+                ):
+                    continue
+                event_kind = (
+                    "operator"
+                    if name.startswith(("aten::", "autograd::", "torch::"))
+                    else "profiler_step"
+                    if name.startswith("ProfilerStep#")
+                    else "runtime"
+                )
+                rows.append({"event_kind": event_kind, **row})
+            return rows
+        return slices
 
     @staticmethod
     def _binary() -> Path:

--- a/src/flameox/providers/perfetto.py
+++ b/src/flameox/providers/perfetto.py
@@ -79,7 +79,13 @@ class PerfettoProvider:
                 artifact_path=str(path),
                 binary_path=str(binary),
                 max_rows=max_rows,
-                projection="call_graph" if capability_id == "trace.call_graph" else "slices",
+                projection=(
+                    "call_graph"
+                    if capability_id == "trace.call_graph"
+                    else "pytorch"
+                    if capability_id == "trace.pytorch"
+                    else "slices"
+                ),
             ),
             timeout_seconds=timeout_seconds,
             maximum_rss_bytes=maximum_rss_bytes,

--- a/src/flameox/providers/reliability.py
+++ b/src/flameox/providers/reliability.py
@@ -31,6 +31,7 @@ class ReliabilityProvider:
         invocations: dict[str, dict[str, Any]] = {}
         finished = False
         interrupted = False
+        teardown_failures: set[tuple[str, str]] = set()
         for index, event in self._events(path):
             event_name = event.get("event")
             if event_name == "run_finished":
@@ -38,6 +39,15 @@ class ReliabilityProvider:
                 continue
             if event_name in {"interrupted", "internal_error"}:
                 interrupted = True
+                continue
+            if (
+                event_name == "test_phase"
+                and event.get("phase") == "teardown"
+                and event.get("outcome") == "failed"
+                and isinstance(event.get("nodeid"), str)
+                and isinstance(event.get("worker_id"), str)
+            ):
+                teardown_failures.add((str(event["worker_id"]), str(event["nodeid"])))
                 continue
             if event_name != "fixture_phase":
                 continue
@@ -85,10 +95,21 @@ class ReliabilityProvider:
                 value for value in (setup_duration, teardown_duration) if isinstance(value, int)
             )
             worker_work[str(invocation["worker_id"])] += known_work
+            may_include_failed_teardown = bool(teardown_failures) and (
+                (str(invocation["worker_id"]), str(invocation["nodeid"])) in teardown_failures
+                or (
+                    str(invocation["scope"]) != "function"
+                    and any(
+                        worker_id == str(invocation["worker_id"])
+                        for worker_id, _nodeid in teardown_failures
+                    )
+                )
+            )
             complete = (
                 isinstance(setup_duration, int)
                 and isinstance(teardown_duration, int)
-                and invocation["teardown_outcome"] == "completed"
+                and invocation["teardown_outcome"] == "observed"
+                and not may_include_failed_teardown
             )
             invocation_rows.append(
                 {
@@ -96,6 +117,7 @@ class ReliabilityProvider:
                     "invocation_id": invocation_id,
                     **invocation,
                     "known_work_ns": known_work,
+                    "teardown_failure_reported": may_include_failed_teardown,
                     "complete": complete,
                 }
             )
@@ -150,6 +172,7 @@ class ReliabilityProvider:
                         "invocation_count": len(invocation_rows),
                         "worker_count": len(worker_work),
                         "incomplete_invocation_count": incomplete_count,
+                        "teardown_failure_count": len(teardown_failures),
                         "summed_fixture_work_ns": sum(worker_work.values()),
                         "max_worker_fixture_work_ns": max(worker_work.values(), default=0),
                     },
@@ -165,6 +188,8 @@ class ReliabilityProvider:
                 "critical-path measurement.",
                 "Interrupted runs retain incomplete fixture invocations instead of treating "
                 "missing finalizers as zero duration.",
+                "Pytest reports teardown failures per test rather than per fixture; affected "
+                "function fixtures and broader-scope fixtures on that worker remain incomplete.",
             ],
         )
 

--- a/src/flameox/providers/reliability.py
+++ b/src/flameox/providers/reliability.py
@@ -14,13 +14,158 @@ _MAX_LINE_BYTES = 64 * 1024
 class ReliabilityProvider:
     """Bounded projections for explicit pytest and semantic-observation streams."""
 
-    def analyze(self, path: Path, format_name: str, *, max_rows: int) -> ProviderAnalysis:
+    def analyze(
+        self, capability_id: str, path: Path, format_name: str, *, max_rows: int
+    ) -> ProviderAnalysis:
         if format_name == "pytest":
+            if capability_id == "pytest.fixtures":
+                return self._pytest_fixtures(path, max_rows=max_rows)
             return self._pytest(path, max_rows=max_rows)
         if format_name == "observations":
             return self._observations(path, max_rows=max_rows)
         raise ProviderFailure(
             "UNSUPPORTED_FORMAT", f"Unsupported reliability format: {format_name}"
+        )
+
+    def _pytest_fixtures(self, path: Path, *, max_rows: int) -> ProviderAnalysis:
+        invocations: dict[str, dict[str, Any]] = {}
+        finished = False
+        interrupted = False
+        for index, event in self._events(path):
+            event_name = event.get("event")
+            if event_name == "run_finished":
+                finished = True
+                continue
+            if event_name in {"interrupted", "internal_error"}:
+                interrupted = True
+                continue
+            if event_name != "fixture_phase":
+                continue
+            required = ("fixture", "scope", "phase", "outcome", "worker_id", "invocation_id")
+            if not all(isinstance(event.get(field), str) for field in required):
+                raise ProviderFailure("DECODE_FAILURE", "Fixture event fields are invalid")
+            duration = event.get("duration_ns")
+            if duration is not None and (
+                not isinstance(duration, int) or isinstance(duration, bool) or duration < 0
+            ):
+                raise ProviderFailure("DECODE_FAILURE", "Fixture duration is invalid")
+            invocation_id = str(event["invocation_id"])
+            invocation = invocations.setdefault(
+                invocation_id,
+                {
+                    "index": index,
+                    "fixture": str(event["fixture"]),
+                    "scope": str(event["scope"]),
+                    "worker_id": str(event["worker_id"]),
+                    "nodeid": str(event.get("nodeid") or ""),
+                    "setup_duration_ns": None,
+                    "teardown_duration_ns": None,
+                    "setup_outcome": None,
+                    "teardown_outcome": None,
+                },
+            )
+            if any(
+                invocation[field] != str(event.get(field) or "")
+                for field in ("fixture", "scope", "worker_id", "nodeid")
+            ):
+                raise ProviderFailure("DECODE_FAILURE", "Fixture invocation identity changed")
+            phase = str(event["phase"])
+            if phase not in {"setup", "teardown"} or invocation[f"{phase}_outcome"] is not None:
+                raise ProviderFailure("DECODE_FAILURE", "Fixture phase is invalid or repeated")
+            invocation[f"{phase}_duration_ns"] = duration
+            invocation[f"{phase}_outcome"] = str(event["outcome"])
+
+        aggregate_values: dict[tuple[str, str], dict[str, Any]] = {}
+        worker_work: dict[str, int] = defaultdict(int)
+        invocation_rows: list[dict[str, Any]] = []
+        for invocation_id, invocation in invocations.items():
+            setup_duration = invocation["setup_duration_ns"]
+            teardown_duration = invocation["teardown_duration_ns"]
+            known_work = sum(
+                value for value in (setup_duration, teardown_duration) if isinstance(value, int)
+            )
+            worker_work[str(invocation["worker_id"])] += known_work
+            complete = (
+                isinstance(setup_duration, int)
+                and isinstance(teardown_duration, int)
+                and invocation["teardown_outcome"] == "completed"
+            )
+            invocation_rows.append(
+                {
+                    "row_kind": "fixture_invocation",
+                    "invocation_id": invocation_id,
+                    **invocation,
+                    "known_work_ns": known_work,
+                    "complete": complete,
+                }
+            )
+            key = (str(invocation["fixture"]), str(invocation["scope"]))
+            aggregate = aggregate_values.setdefault(
+                key,
+                {
+                    "invocation_count": 0,
+                    "workers": set(),
+                    "setup_work_ns": 0,
+                    "teardown_work_ns": 0,
+                    "incomplete_invocation_count": 0,
+                },
+            )
+            aggregate["invocation_count"] += 1
+            aggregate["workers"].add(str(invocation["worker_id"]))
+            aggregate["setup_work_ns"] += setup_duration if isinstance(setup_duration, int) else 0
+            aggregate["teardown_work_ns"] += (
+                teardown_duration if isinstance(teardown_duration, int) else 0
+            )
+            aggregate["incomplete_invocation_count"] += int(not complete)
+        aggregate_rows = [
+            {
+                "row_kind": "fixture_aggregate",
+                "fixture": fixture,
+                "scope": scope,
+                "invocation_count": values["invocation_count"],
+                "worker_count": len(values["workers"]),
+                "setup_work_ns": values["setup_work_ns"],
+                "teardown_work_ns": values["teardown_work_ns"],
+                "known_work_ns": values["setup_work_ns"] + values["teardown_work_ns"],
+                "incomplete_invocation_count": values["incomplete_invocation_count"],
+            }
+            for (fixture, scope), values in aggregate_values.items()
+        ]
+        aggregate_rows.sort(key=lambda row: (-int(row["known_work_ns"]), str(row["fixture"])))
+        invocation_rows.sort(
+            key=lambda row: (-int(row["known_work_ns"]), str(row["invocation_id"]))
+        )
+        rows = [*aggregate_rows, *invocation_rows]
+        completion = "interrupted" if interrupted else "complete" if finished else "incomplete"
+        incomplete_count = sum(not bool(row["complete"]) for row in invocation_rows)
+        return ProviderAnalysis(
+            provider_id="pytest",
+            provider_version="event-stream-v2",
+            blocks=[
+                {
+                    "type": "metrics",
+                    "values": {
+                        "completion": completion,
+                        "fixture_count": len(aggregate_rows),
+                        "invocation_count": len(invocation_rows),
+                        "worker_count": len(worker_work),
+                        "incomplete_invocation_count": incomplete_count,
+                        "summed_fixture_work_ns": sum(worker_work.values()),
+                        "max_worker_fixture_work_ns": max(worker_work.values(), default=0),
+                    },
+                },
+                {"type": "table", "rows": rows[:max_rows]},
+            ],
+            rows_observed=len(rows),
+            complete=len(rows) <= max_rows,
+            limitations=[
+                "Summed fixture work can overlap across xdist workers and is not wall-clock "
+                "critical-path duration.",
+                "max_worker_fixture_work_ns is accumulated known work on one worker, not a "
+                "critical-path measurement.",
+                "Interrupted runs retain incomplete fixture invocations instead of treating "
+                "missing finalizers as zero duration.",
+            ],
         )
 
     def _pytest(self, path: Path, *, max_rows: int) -> ProviderAnalysis:

--- a/src/flameox/providers/structured_workers.py
+++ b/src/flameox/providers/structured_workers.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
-from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
+from flameox.providers.contracts import ProviderAnalysis
+from flameox.runtime_contracts import PstatsMetric
 from flameox.workers.compute_sanitizer_contract import (
     COMPUTE_SANITIZER_WORKER,
     ComputeSanitizerWorkerRequest,
 )
 from flameox.workers.harness import IsolatedWorkerHarness
-from flameox.workers.pstats_contract import PSTATS_WORKER, PstatsMetric, PstatsWorkerRequest
+from flameox.workers.pstats_contract import PSTATS_WORKER, PstatsWorkerRequest
 from flameox.workers.v8_profiles_contract import (
     V8_PROFILE_WORKER,
     V8ProfileRequest,
@@ -35,19 +36,19 @@ class StructuredWorkerProviders:
         maximum_rss_bytes: int,
         maximum_output_bytes: int,
     ) -> ProviderAnalysis | None:
-        if capability_id == "cpu.hotspots" and format_name == "pstats":
+        if capability_id in {"cpu.hotspots", "cpu.callers"} and format_name == "pstats":
             metric = str(arguments.get("metric") or "self_time_seconds")
-            if metric not in {
-                "self_time_seconds",
-                "cumulative_time_seconds",
-                "total_calls",
-                "primitive_calls",
-            }:
-                raise ProviderFailure("INVALID_INPUT", f"Unsupported pstats metric: {metric}")
             pstats_result = self.harness.run_typed_sync(
                 PSTATS_WORKER,
                 PstatsWorkerRequest(
+                    projection="call_graph" if capability_id == "cpu.callers" else "hotspots",
                     metric=cast(PstatsMetric, metric),
+                    function=(
+                        str(arguments["function"])
+                        if arguments.get("function") is not None
+                        else None
+                    ),
+                    direction=cast(Any, arguments.get("direction", "both")),
                     artifact_path=str(path),
                     max_rows=max_rows,
                 ),
@@ -55,17 +56,23 @@ class StructuredWorkerProviders:
                 maximum_rss_bytes=maximum_rss_bytes,
                 maximum_writable_growth_bytes=maximum_output_bytes,
             )
+            metrics: dict[str, object] = {
+                "function_count": pstats_result.function_count,
+                "reader_python_version": pstats_result.reader_version,
+            }
+            if capability_id == "cpu.callers":
+                metrics["edge_count"] = pstats_result.edge_count
+                metrics["direction"] = arguments.get("direction", "both")
+                metrics["function_filter"] = arguments.get("function")
+            else:
+                metrics["metric"] = pstats_result.metric
             return ProviderAnalysis(
                 provider_id="python-pstats",
                 provider_version=PSTATS_WORKER.implementation,
                 blocks=[
                     {
                         "type": "metrics",
-                        "values": {
-                            "function_count": pstats_result.function_count,
-                            "metric": pstats_result.metric,
-                            "reader_python_version": pstats_result.reader_version,
-                        },
+                        "values": metrics,
                     },
                     {"type": "table", "rows": [dict(row) for row in pstats_result.rows]},
                 ],

--- a/src/flameox/providers/structured_workers.py
+++ b/src/flameox/providers/structured_workers.py
@@ -76,7 +76,11 @@ class StructuredWorkerProviders:
                     },
                     {"type": "table", "rows": [dict(row) for row in pstats_result.rows]},
                 ],
-                rows_observed=pstats_result.function_count,
+                rows_observed=(
+                    pstats_result.edge_count
+                    if capability_id == "cpu.callers"
+                    else pstats_result.function_count
+                ),
                 complete=not pstats_result.truncated,
                 limitations=list(pstats_result.limitations),
             )

--- a/src/flameox/pytest_capture.py
+++ b/src/flameox/pytest_capture.py
@@ -12,20 +12,30 @@ from typing import Any
 
 pytest = importlib.import_module("pytest")
 
-_OUTPUT_ENVIRONMENT = "FLAMEOX_PYTEST_OUTPUT"
 _MAX_TEXT = 4096
 _MAX_EVENT_BYTES = 64 * 1024
 _FIXTURE_INVOCATIONS = itertools.count(1)
+_output_path: Path | None = None
+_current_worker_id = "main"
+
+
+def pytest_addoption(parser: Any) -> None:
+    parser.addoption("--flameox-output", required=True, help="Flameox event stream path")
+
+
+def pytest_configure(config: Any) -> None:
+    global _current_worker_id, _output_path
+    _output_path = Path(str(config.getoption("--flameox-output")))
+    _current_worker_id = _worker_id(config)
 
 
 def _write(event: dict[str, Any]) -> None:
-    output = os.environ.get(_OUTPUT_ENVIRONMENT)
-    if output is None:
-        raise pytest.UsageError(f"{_OUTPUT_ENVIRONMENT} is required by the Flameox plugin")
+    if _output_path is None:
+        raise pytest.UsageError("--flameox-output is required by the Flameox plugin")
     encoded = (json.dumps(event, separators=(",", ":"), sort_keys=True) + "\n").encode()
     if len(encoded) > _MAX_EVENT_BYTES:
         raise pytest.UsageError("Flameox pytest event exceeds 64 KiB")
-    destination = Path(output)
+    destination = _output_path
     destination.parent.mkdir(parents=True, exist_ok=True)
     descriptor = os.open(destination, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
     try:
@@ -62,7 +72,7 @@ def pytest_fixture_setup(fixturedef: Any, request: Any) -> Any:
                 "fixture": fixture,
                 "scope": scope,
                 "phase": "teardown",
-                "outcome": "completed" if teardown_started_ns is not None else "incomplete",
+                "outcome": "observed" if teardown_started_ns is not None else "incomplete",
                 "duration_ns": (
                     max(0, finished_ns - teardown_started_ns)
                     if teardown_started_ns is not None
@@ -138,7 +148,8 @@ def pytest_collectreport(report: Any) -> None:
 
 
 def pytest_runtest_logreport(report: Any) -> None:
-    worker = getattr(report, "worker_id", "main")
+    if _current_worker_id == "main" and hasattr(report, "worker_id"):
+        return
     _write(
         {
             "event": "test_phase",
@@ -146,7 +157,7 @@ def pytest_runtest_logreport(report: Any) -> None:
             "phase": _text(report.when),
             "outcome": _text(report.outcome),
             "duration_ns": max(0, round(report.duration * 1_000_000_000)),
-            "worker_id": _text(worker),
+            "worker_id": _current_worker_id,
         }
     )
 

--- a/src/flameox/pytest_capture.py
+++ b/src/flameox/pytest_capture.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import itertools
 import json
 import os
 import time
@@ -14,6 +15,7 @@ pytest = importlib.import_module("pytest")
 _OUTPUT_ENVIRONMENT = "FLAMEOX_PYTEST_OUTPUT"
 _MAX_TEXT = 4096
 _MAX_EVENT_BYTES = 64 * 1024
+_FIXTURE_INVOCATIONS = itertools.count(1)
 
 
 def _write(event: dict[str, Any]) -> None:
@@ -34,6 +36,84 @@ def _write(event: dict[str, Any]) -> None:
 
 def _text(value: object) -> str:
     return str(value)[:_MAX_TEXT]
+
+
+def _worker_id(config: Any) -> str:
+    worker_input = getattr(config, "workerinput", None)
+    if isinstance(worker_input, dict) and isinstance(worker_input.get("workerid"), str):
+        return _text(worker_input["workerid"])
+    return "main"
+
+
+@pytest.hookimpl(wrapper=True)  # type: ignore[untyped-decorator]
+def pytest_fixture_setup(fixturedef: Any, request: Any) -> Any:
+    worker_id = _worker_id(request.config)
+    invocation_id = f"{worker_id}:{next(_FIXTURE_INVOCATIONS)}"
+    fixture = _text(fixturedef.argname)
+    scope = _text(fixturedef.scope)
+    nodeid = _text(getattr(request.node, "nodeid", ""))
+    teardown_started_ns: int | None = None
+
+    def finish_teardown() -> None:
+        finished_ns = time.perf_counter_ns()
+        _write(
+            {
+                "event": "fixture_phase",
+                "fixture": fixture,
+                "scope": scope,
+                "phase": "teardown",
+                "outcome": "completed" if teardown_started_ns is not None else "incomplete",
+                "duration_ns": (
+                    max(0, finished_ns - teardown_started_ns)
+                    if teardown_started_ns is not None
+                    else None
+                ),
+                "worker_id": worker_id,
+                "invocation_id": invocation_id,
+                "nodeid": nodeid,
+            }
+        )
+
+    def begin_teardown() -> None:
+        nonlocal teardown_started_ns
+        teardown_started_ns = time.perf_counter_ns()
+
+    request.addfinalizer(finish_teardown)
+    started_ns = time.perf_counter_ns()
+    try:
+        result = yield
+    except BaseException:
+        _write(
+            {
+                "event": "fixture_phase",
+                "fixture": fixture,
+                "scope": scope,
+                "phase": "setup",
+                "outcome": "failed",
+                "duration_ns": max(0, time.perf_counter_ns() - started_ns),
+                "worker_id": worker_id,
+                "invocation_id": invocation_id,
+                "nodeid": nodeid,
+            }
+        )
+        raise
+    else:
+        _write(
+            {
+                "event": "fixture_phase",
+                "fixture": fixture,
+                "scope": scope,
+                "phase": "setup",
+                "outcome": "passed",
+                "duration_ns": max(0, time.perf_counter_ns() - started_ns),
+                "worker_id": worker_id,
+                "invocation_id": invocation_id,
+                "nodeid": nodeid,
+            }
+        )
+        return result
+    finally:
+        request.addfinalizer(begin_teardown)
 
 
 def pytest_sessionstart(session: object) -> None:

--- a/src/flameox/pytest_runner.py
+++ b/src/flameox/pytest_runner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import importlib
-import os
 
 pytest = importlib.import_module("pytest")
 
@@ -19,13 +18,11 @@ def main() -> int:
         if parsed.pytest_arguments[:1] == ["--"]
         else parsed.pytest_arguments
     )
-    os.environ["FLAMEOX_PYTEST_OUTPUT"] = parsed.output
-    existing_plugins = os.environ.get("PYTEST_PLUGINS")
-    capture_plugin = "flameox.pytest_capture"
-    os.environ["PYTEST_PLUGINS"] = (
-        f"{existing_plugins},{capture_plugin}" if existing_plugins else capture_plugin
+    return int(
+        pytest.main(
+            ["-p", "flameox.pytest_capture", "--flameox-output", parsed.output, *arguments],
+        )
     )
-    return int(pytest.main(arguments))
 
 
 if __name__ == "__main__":

--- a/src/flameox/pytest_runner.py
+++ b/src/flameox/pytest_runner.py
@@ -4,24 +4,9 @@ from __future__ import annotations
 
 import argparse
 import importlib
-import importlib.util
 import os
-import sys
-from pathlib import Path
-from types import ModuleType
 
 pytest = importlib.import_module("pytest")
-
-
-def _capture_plugin() -> ModuleType:
-    path = Path(__file__).with_name("pytest_capture.py")
-    spec = importlib.util.spec_from_file_location("_flameox_pytest_capture", path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError("Flameox pytest capture plugin could not be loaded")
-    plugin = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = plugin
-    spec.loader.exec_module(plugin)
-    return plugin
 
 
 def main() -> int:
@@ -35,7 +20,12 @@ def main() -> int:
         else parsed.pytest_arguments
     )
     os.environ["FLAMEOX_PYTEST_OUTPUT"] = parsed.output
-    return int(pytest.main(arguments, plugins=[_capture_plugin()]))
+    existing_plugins = os.environ.get("PYTEST_PLUGINS")
+    capture_plugin = "flameox.pytest_capture"
+    os.environ["PYTEST_PLUGINS"] = (
+        f"{existing_plugins},{capture_plugin}" if existing_plugins else capture_plugin
+    )
+    return int(pytest.main(arguments))
 
 
 if __name__ == "__main__":

--- a/src/flameox/runtime_contracts.py
+++ b/src/flameox/runtime_contracts.py
@@ -91,16 +91,49 @@ class PreviewArguments(StrictModel):
     )
 
 
-class SummaryArguments(StrictModel):
+PstatsMetric = Literal[
+    "self_time_seconds",
+    "cumulative_time_seconds",
+    "total_calls",
+    "primitive_calls",
+]
+
+
+class CpuHotspotArguments(StrictModel):
+    metric: PstatsMetric | None = Field(
+        default=None,
+        description=(
+            "Ranking metric for pstats artifacts; omit for self_time_seconds. Other CPU formats "
+            "use their native fixed weight metric."
+        ),
+    )
+
+
+class CpuCallGraphArguments(StrictModel):
+    function: str | None = Field(
+        default=None,
+        description="Bound edges to function or file identities containing this text.",
+        min_length=1,
+        max_length=200,
+    )
+    direction: Literal["callers", "callees", "both"] = Field(
+        default="both",
+        description="Return callers of, callees from, or all edges touching the function filter.",
+    )
+
+
+class ScalingArguments(StrictModel):
+    input_dimension: str = Field(
+        description="Numeric benchmark dimension used as the scaling input axis.",
+        min_length=1,
+        max_length=120,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._:/-]*$",
+    )
     metric: str | None = Field(
         default=None,
-        description="Provider-supported metric to summarize; omit for its default metric.",
-        max_length=120,
-    )
-    group_by: str | None = Field(
-        default=None,
-        description="Provider-supported dimension used to group summary rows.",
-        max_length=120,
+        description="Benchmark series to analyze; omit to analyze every compatible series.",
+        min_length=1,
+        max_length=200,
     )
 
 
@@ -152,7 +185,9 @@ class CompareArguments(StrictModel):
 ArgumentModel = type[
     EmptyArguments
     | PreviewArguments
-    | SummaryArguments
+    | CpuHotspotArguments
+    | CpuCallGraphArguments
+    | ScalingArguments
     | StaticArguments
     | WindowArguments
     | CompareArguments
@@ -293,6 +328,10 @@ class PySpyCaptureArguments(StrictModel):
     )
     native: bool = Field(
         default=False, description="Include native extension frames when supported."
+    )
+    subprocesses: bool = Field(
+        default=False,
+        description="Monitor newly created Python child processes and preserve process markers.",
     )
 
 
@@ -783,12 +822,49 @@ class Capability:
     formats: tuple[str, ...]
     model: ArgumentModel
     limitation: str = "Observed artifact contents do not by themselves prove causality."
+    minimum_sources: int = 1
+    maximum_sources: int = 1
+
+    def validate_source_count(self, count: int) -> None:
+        if self.minimum_sources <= count <= self.maximum_sources:
+            return
+        expected = (
+            str(self.minimum_sources)
+            if self.minimum_sources == self.maximum_sources
+            else f"{self.minimum_sources} to {self.maximum_sources}"
+        )
+        raise RuntimeFailure(
+            "INVALID_INPUT",
+            f"{self.id} requires {expected} analysis source(s); received {count}.",
+            details={
+                "capability_id": self.id,
+                "minimum_sources": self.minimum_sources,
+                "maximum_sources": self.maximum_sources,
+                "actual_sources": count,
+            },
+        )
 
 
 def _caps(
-    ids: Iterable[str], summary: str, formats: tuple[str, ...], model: ArgumentModel
+    ids: Iterable[str],
+    summary: str,
+    formats: tuple[str, ...],
+    model: ArgumentModel,
+    *,
+    minimum_sources: int = 1,
+    maximum_sources: int = 1,
 ) -> list[Capability]:
-    return [Capability(item, summary, formats, model) for item in ids]
+    return [
+        Capability(
+            item,
+            summary,
+            formats,
+            model,
+            minimum_sources=minimum_sources,
+            maximum_sources=maximum_sources,
+        )
+        for item in ids
+    ]
 
 
 CAPABILITIES = tuple(
@@ -805,31 +881,31 @@ CAPABILITIES = tuple(
             "rocprof-pftrace",
             "xctrace",
         ),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("trace.call_graph",),
         "Project bounded caller-callee edges from Chrome, Perfetto, or PyTorch traces.",
         ("perfetto", "chrome-trace", "pytorch"),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("trace.pytorch",),
         "Summarize bounded PyTorch operator and event evidence.",
         ("perfetto", "chrome-trace", "pytorch"),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("trace.operations",),
         "Summarize bounded operation timing from OTLP or Nsight Systems traces.",
         ("otlp", "nsys-rep", "nsys-parquet"),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("trace.lifecycle",),
         "Summarize bounded execution lifecycle events from OTLP or Nsight Systems traces.",
         ("otlp", "nsys-rep", "nsys-parquet"),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("trace.window",),
@@ -841,97 +917,117 @@ CAPABILITIES = tuple(
         ("cpu.hotspots",),
         "Rank bounded CPU evidence.",
         ("cpuprofile", "pstats", "py-spy", "perf", "perf-data"),
-        SummaryArguments,
+        CpuHotspotArguments,
+    )
+    + _caps(
+        ("cpu.callers",),
+        "Project bounded caller-callee edges from deterministic pstats evidence.",
+        ("pstats",),
+        CpuCallGraphArguments,
     )
     + _caps(
         ("memory.hotspots",),
         "Rank bounded allocation hotspots from a Memray capture.",
         ("memray",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("memory.retained",),
         "Rank bounded retained-memory evidence from a Memray capture.",
         ("memray",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("benchmark.summary",),
         "Summarize bounded benchmark latency measurements.",
         ("pyperf", "samples", "nvbench"),
-        SummaryArguments,
+        EmptyArguments,
+        maximum_sources=MAX_INPUTS,
     )
     + _caps(
         ("benchmark.scaling",),
-        "Summarize how benchmark measurements scale across declared parameters.",
+        "Estimate how benchmark measurements scale across a declared numeric input axis.",
         ("pyperf", "samples", "nvbench"),
-        SummaryArguments,
+        ScalingArguments,
+        maximum_sources=MAX_INPUTS,
     )
     + _caps(
         ("benchmark.compare",),
         "Compare compatible benchmark artifacts.",
         ("pyperf", "samples", "nvbench"),
         CompareArguments,
+        minimum_sources=2,
+        maximum_sources=MAX_INPUTS,
     )
     + _caps(
         ("inference.summary",),
         "Summarize bounded inference-export measurements.",
         ("aiperf", "vllm-benchmark", "sglang-benchmark", "mooncake-trace"),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("inference.compare",),
         "Compare compatible prompt-free inference measurements.",
         ("aiperf", "vllm-benchmark", "sglang-benchmark", "mooncake-trace"),
         CompareArguments,
+        minimum_sources=2,
+        maximum_sources=MAX_INPUTS,
     )
     + _caps(
         ("gpu.launches",),
         "Summarize GPU launch evidence.",
         ("nsys-rep", "nsys-parquet"),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("gpu.kernel_metrics",),
         "Summarize GPU kernel metrics.",
         ("nsight-compute",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("triton.autotune",),
         "Summarize Triton autotune evidence.",
         ("triton",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("sanitizer.failures",),
         "Summarize Compute Sanitizer failures.",
         ("compute-sanitizer",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("kernel.validation",),
         "Summarize semantic kernel validation results.",
         ("kernel-validation",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("kernel.compare",),
         "Compare compatible kernel evidence.",
         ("kernel-validation",),
         CompareArguments,
+        minimum_sources=2,
+        maximum_sources=MAX_INPUTS,
     )
     + _caps(
         ("failures.summary",),
         "Summarize bounded reliability evidence.",
         ("pytest", "observations"),
-        SummaryArguments,
+        EmptyArguments,
+    )
+    + _caps(
+        ("pytest.fixtures",),
+        "Rank bounded pytest fixture setup and finalizer evidence.",
+        ("pytest",),
+        EmptyArguments,
     )
     + _caps(
         ("coverage.summary",),
         "Summarize native coverage.py evidence.",
         ("coverage",),
-        SummaryArguments,
+        EmptyArguments,
     )
     + _caps(
         ("static.performance_candidates",),
@@ -944,6 +1040,7 @@ CAPABILITIES = tuple(
         "Preview a bounded artifact without mutation.",
         ("json", "jsonl", "csv", "text", "parquet"),
         PreviewArguments,
+        maximum_sources=MAX_INPUTS,
     )
 )
 CAPABILITY_BY_ID = {item.id: item for item in CAPABILITIES}

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -84,6 +84,7 @@ from flameox.runtime_contracts import (
     Capability,
     CaptureArguments,
     CaptureTarget,
+    CpuHotspotArguments,
     EvidenceSource,
     ExperimentCase,
     ExperimentDesign,
@@ -302,6 +303,7 @@ class AnalysisRuntime:
         capability = CAPABILITY_BY_ID.get(capability_id)
         if capability is None:
             raise RuntimeFailure("UNKNOWN_CAPABILITY", f"Unknown capability: {capability_id}")
+        capability.validate_source_count(len(sources))
         selected_limits = limits.lowered_against(self.limits) if limits else self.limits
         validated = TypeAdapter(capability.model).validate_python(arguments)
         resolved = self._resolve_sources(sources, selected_limits)
@@ -311,6 +313,20 @@ class AnalysisRuntime:
             )
         ):
             raise RuntimeFailure("UNSUPPORTED_FORMAT", f"Unsupported format: {bad}")
+        if (
+            isinstance(validated, CpuHotspotArguments)
+            and validated.metric is not None
+            and any(item.format != "pstats" for item in resolved)
+        ):
+            raise RuntimeFailure(
+                "INVALID_INPUT",
+                "cpu.hotspots metric selection is supported only for pstats artifacts",
+                details={
+                    "capability_id": capability.id,
+                    "option": "metric",
+                    "accepted_formats": ["pstats"],
+                },
+            )
         identity = {
             "capability_id": capability_id,
             "inputs": [
@@ -493,6 +509,7 @@ class AnalysisRuntime:
                     f"the limit is {MAX_INPUTS}."
                 ),
             )
+        capability.validate_source_count(source_count)
         return ValidatedCaptureRequest(
             capability=capability,
             capture_arguments=capture_arguments,
@@ -817,6 +834,16 @@ class AnalysisRuntime:
             result["preserved"] = self.preserve_evidence(str(result["analysis_id"]))
             return result
         cached = self.analyses[str(result["analysis_id"])]
+        if target.provider_id == "py-spy":
+            process_scope = (
+                "the target and newly created Python subprocesses"
+                if bool(target.capture_arguments.get("subprocesses", False))
+                else "the target process only"
+            )
+            result["limitations"].append(
+                f"py-spy sampled {process_scope}; sampled stacks are not complete process-tree "
+                "execution evidence."
+            )
         cached.sources = captured
         cached.manifest_body["capture_request"] = {
             "target": target.model_dump(mode="json"),
@@ -1672,10 +1699,15 @@ class AnalysisRuntime:
                 len(sources) == 1
                 and sources[0].format in {"pytest", "observations"}
                 and capability_id
-                in {"failures.summary", "coverage.summary", "static.performance_candidates"}
+                in {
+                    "failures.summary",
+                    "pytest.fixtures",
+                    "coverage.summary",
+                    "static.performance_candidates",
+                }
             ):
                 return self.reliability.analyze(
-                    sources[0].path, sources[0].format, max_rows=max_rows
+                    capability_id, sources[0].path, sources[0].format, max_rows=max_rows
                 )
             if (
                 len(sources) == 1

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -90,6 +90,7 @@ from flameox.runtime_contracts import (
     ExperimentDesign,
     PathSource,
     PreviewArguments,
+    PySpyCaptureArguments,
     RequestLimits,
     RuntimeFailure,
     Source,
@@ -835,9 +836,10 @@ class AnalysisRuntime:
             return result
         cached = self.analyses[str(result["analysis_id"])]
         if target.provider_id == "py-spy":
+            py_spy_arguments = cast(PySpyCaptureArguments, capture_arguments)
             process_scope = (
                 "the target and newly created Python subprocesses"
-                if bool(target.capture_arguments.get("subprocesses", False))
+                if py_spy_arguments.subprocesses
                 else "the target process only"
             )
             result["limitations"].append(

--- a/src/flameox/workers/perfetto.py
+++ b/src/flameox/workers/perfetto.py
@@ -88,6 +88,19 @@ _CALL_GRAPH_QUERY = f"""
     LIMIT {{limit:d}}
 """
 
+_PYTORCH_QUERY = f"""
+    SELECT * FROM ({_SLICE_QUERY}) AS bounded_slices
+    WHERE lower(coalesce(category, '')) LIKE '%pytorch%'
+       OR lower(coalesce(category, '')) LIKE '%torch%'
+       OR name LIKE 'aten::%'
+       OR name LIKE 'autograd::%'
+       OR name LIKE 'torch::%'
+       OR name LIKE 'ProfilerStep#%'
+       OR input_shapes IS NOT NULL
+       OR allocation_bytes IS NOT NULL
+    LIMIT {{limit:d}}
+"""
+
 
 def _row(row: Any, names: tuple[str, ...]) -> dict[str, object]:
     return {name: getattr(row, name) for name in names}
@@ -136,11 +149,12 @@ def _query(request: PerfettoWorkerRequest) -> PerfettoWorkerResult:
                     ),
                     projected_total=total,
                 )
-            rows = list(
-                processor.query(
-                    f"SELECT * FROM ({_SLICE_QUERY}) AS bounded_slices LIMIT {max_rows + 1:d}"
-                )
+            query = (
+                _PYTORCH_QUERY.format(limit=max_rows + 1)
+                if request.projection == "pytorch"
+                else f"SELECT * FROM ({_SLICE_QUERY}) AS bounded_slices LIMIT {max_rows + 1:d}"
             )
+            rows = list(processor.query(query))
             return PerfettoExtractResult(
                 truncated=len(rows) > max_rows,
                 rows=tuple(

--- a/src/flameox/workers/perfetto_contract.py
+++ b/src/flameox/workers/perfetto_contract.py
@@ -13,7 +13,7 @@ class PerfettoExtractRequest(ContractModel):
     artifact_path: str = Field(min_length=1, max_length=4_096)
     binary_path: str = Field(min_length=1, max_length=4_096)
     max_rows: Annotated[int, Field(gt=0, le=100_000_000)]
-    projection: Literal["slices", "call_graph"] = "slices"
+    projection: Literal["slices", "call_graph", "pytorch"] = "slices"
 
 
 class PerfettoWindowRequest(ContractModel):

--- a/src/flameox/workers/pstats.py
+++ b/src/flameox/workers/pstats.py
@@ -13,6 +13,8 @@ from flameox.workers.pstats_contract import PSTATS_WORKER, PstatsWorkerRequest, 
 
 def _handle(request: PstatsWorkerRequest, _job_root: Path) -> PstatsWorkerResult:
     stats = cast(Any, pstats.Stats(request.artifact_path)).stats
+    if request.projection == "call_graph":
+        return _call_graph(request, stats)
     rows: list[dict[str, Any]] = []
     for (filename, line, function), values in stats.items():
         primitive_calls, total_calls, self_time, cumulative_time, _callers = values
@@ -32,6 +34,7 @@ def _handle(request: PstatsWorkerRequest, _job_root: Path) -> PstatsWorkerResult
         reader_version=".".join(map(str, sys.version_info[:3])),
         metric=request.metric,
         function_count=len(rows),
+        edge_count=0,
         rows=cast(tuple[dict[str, JsonValue], ...], tuple(rows[: request.max_rows])),
         truncated=len(rows) > request.max_rows,
         limitations=(
@@ -40,6 +43,86 @@ def _handle(request: PstatsWorkerRequest, _job_root: Path) -> PstatsWorkerResult
             "Profile observations rank work but do not establish causal optimization impact.",
         ),
     )
+
+
+def _call_graph(request: PstatsWorkerRequest, stats: dict[Any, Any]) -> PstatsWorkerResult:
+    rows: list[dict[str, Any]] = []
+    for callee_key, values in stats.items():
+        callee = _identity(callee_key)
+        callers = values[4]
+        if not isinstance(callers, dict):
+            continue
+        for caller_key, raw_edge in callers.items():
+            caller = _identity(caller_key)
+            if not _matches_edge(request, caller, callee):
+                continue
+            primitive_calls, total_calls, self_time, cumulative_time = _edge_values(raw_edge)
+            rows.append(
+                {
+                    "caller_function": caller["function"],
+                    "caller_file": caller["file"],
+                    "caller_line": caller["line"],
+                    "callee_function": callee["function"],
+                    "callee_file": callee["file"],
+                    "callee_line": callee["line"],
+                    "primitive_calls": primitive_calls,
+                    "total_calls": total_calls,
+                    "self_time_seconds": self_time,
+                    "cumulative_time_seconds": cumulative_time,
+                }
+            )
+    rows.sort(
+        key=lambda row: (
+            -float(row["cumulative_time_seconds"] or 0),
+            str(row["caller_file"]),
+            int(row["caller_line"]),
+            str(row["callee_file"]),
+            int(row["callee_line"]),
+        )
+    )
+    return PstatsWorkerResult(
+        reader_version=".".join(map(str, sys.version_info[:3])),
+        metric=request.metric,
+        function_count=len(stats),
+        edge_count=len(rows),
+        rows=cast(tuple[dict[str, JsonValue], ...], tuple(rows[: request.max_rows])),
+        truncated=len(rows) > request.max_rows,
+        limitations=(
+            "pstats caller edges are deterministic instrumentation, not sampled stack frequency.",
+            "pstats files have no compatibility guarantee across Python versions or profilers.",
+            "Caller relationships show observed attribution and do not prove causal dependence.",
+        ),
+    )
+
+
+def _identity(key: Any) -> dict[str, Any]:
+    filename, line, function = key
+    return {"function": str(function), "file": str(filename), "line": int(line)}
+
+
+def _matches_edge(
+    request: PstatsWorkerRequest,
+    caller: dict[str, Any],
+    callee: dict[str, Any],
+) -> bool:
+    if request.function is None:
+        return True
+    needle = request.function.casefold()
+    caller_matches = needle in f"{caller['file']}:{caller['line']}:{caller['function']}".casefold()
+    callee_matches = needle in f"{callee['file']}:{callee['line']}:{callee['function']}".casefold()
+    if request.direction == "callers":
+        return callee_matches
+    if request.direction == "callees":
+        return caller_matches
+    return caller_matches or callee_matches
+
+
+def _edge_values(value: Any) -> tuple[int, int, float | None, float | None]:
+    if isinstance(value, tuple) and len(value) == 4:
+        primitive_calls, total_calls, self_time, cumulative_time = value
+        return int(primitive_calls), int(total_calls), float(self_time), float(cumulative_time)
+    calls = int(value)
+    return calls, calls, None, None
 
 
 def main() -> int:

--- a/src/flameox/workers/pstats_contract.py
+++ b/src/flameox/workers/pstats_contract.py
@@ -5,19 +5,16 @@ from typing import Annotated, Literal
 from pydantic import Field, JsonValue, TypeAdapter
 
 from flameox.models import ContractModel
+from flameox.runtime_contracts import PstatsMetric
 from flameox.workers.protocol import WorkerDefinition, WorkerOperationId
-
-PstatsMetric = Literal[
-    "self_time_seconds",
-    "cumulative_time_seconds",
-    "total_calls",
-    "primitive_calls",
-]
 
 
 class PstatsWorkerRequest(ContractModel):
     artifact_path: str = Field(min_length=1, max_length=4_096)
+    projection: Literal["hotspots", "call_graph"] = "hotspots"
     metric: PstatsMetric = "self_time_seconds"
+    function: str | None = Field(default=None, min_length=1, max_length=200)
+    direction: Literal["callers", "callees", "both"] = "both"
     max_rows: Annotated[int, Field(gt=0, le=1_001)]
 
 
@@ -25,6 +22,7 @@ class PstatsWorkerResult(ContractModel):
     reader_version: str = Field(min_length=1, max_length=100)
     metric: PstatsMetric
     function_count: Annotated[int, Field(ge=0)]
+    edge_count: Annotated[int, Field(ge=0)] = 0
     rows: tuple[dict[str, JsonValue], ...]
     truncated: bool
     limitations: tuple[str, ...] = Field(default=(), max_length=16)

--- a/tests/providers/test_cpu.py
+++ b/tests/providers/test_cpu.py
@@ -68,6 +68,7 @@ def test_pstats_caller_projection_filters_direction_without_losing_edge_metrics(
 
     assert result["provider"]["id"] == "python-pstats"
     assert result["blocks"][0]["values"]["edge_count"] == 1
+    assert result["coverage"]["rows_observed"] == 1
     row = result["blocks"][1]["rows"][0]
     assert row["caller_function"] == "caller"
     assert row["callee_function"] == "leaf"

--- a/tests/providers/test_cpu.py
+++ b/tests/providers/test_cpu.py
@@ -42,6 +42,39 @@ def test_pstats_profile_is_bounded_deterministic_cpu_evidence(tmp_path: Path) ->
     assert any("no compatibility guarantee" in item for item in result["limitations"])
 
 
+def test_pstats_caller_projection_filters_direction_without_losing_edge_metrics(
+    tmp_path: Path,
+) -> None:
+    profile = tmp_path / "callers.pstats"
+
+    def leaf() -> int:
+        return sum(range(20))
+
+    def caller() -> int:
+        return leaf()
+
+    profiler = cProfile.Profile()
+    profiler.runcall(caller)
+    profiler.dump_stats(profile)
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "cpu.callers",
+            [PathSource(path=str(profile), format="pstats", producer="cProfile")],
+            {"function": "leaf", "direction": "callers"},
+        )
+    finally:
+        runtime.close()
+
+    assert result["provider"]["id"] == "python-pstats"
+    assert result["blocks"][0]["values"]["edge_count"] == 1
+    row = result["blocks"][1]["rows"][0]
+    assert row["caller_function"] == "caller"
+    assert row["callee_function"] == "leaf"
+    assert row["total_calls"] == 1
+    assert row["cumulative_time_seconds"] >= row["self_time_seconds"]
+
+
 def test_pyspy_speedscope_profile_ranks_typed_frames(tmp_path: Path) -> None:
     profile = tmp_path / "profile.speedscope.json"
     profile.write_text(

--- a/tests/providers/test_nsight_systems.py
+++ b/tests/providers/test_nsight_systems.py
@@ -90,6 +90,41 @@ def test_nsight_systems_projects_native_uint64_identifiers_losslessly(tmp_path: 
     assert preserved["evidence_id"]
 
 
+def test_nsight_systems_trace_projections_select_semantic_table_families(
+    tmp_path: Path,
+) -> None:
+    parquetdir = tmp_path / "report.parquetdir"
+    parquetdir.mkdir()
+    pq.write_table(
+        pa.table({"name": ["cudaLaunchKernel"], "duration_ns": [10]}),
+        parquetdir / "CUDA_API_TRACE.parquet",
+    )
+    pq.write_table(
+        pa.table({"process_id": [7], "event": ["started"]}),
+        parquetdir / "PROCESS_LIFECYCLE.parquet",
+    )
+    pq.write_table(
+        pa.table({"kernel": ["ignored"]}),
+        parquetdir / "CUDA_GPU_KERN_SUM.parquet",
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    source = [PathSource(path=str(parquetdir), format="nsys-parquet")]
+    try:
+        summary = runtime.analyze("trace.summary", source, {})
+        operations = runtime.analyze("trace.operations", source, {})
+        lifecycle = runtime.analyze("trace.lifecycle", source, {})
+    finally:
+        runtime.close()
+
+    assert {row["table"] for row in summary["blocks"][1]["rows"]} == {
+        "CUDA_API_TRACE",
+        "CUDA_GPU_KERN_SUM",
+        "PROCESS_LIFECYCLE",
+    }
+    assert {row["table"] for row in operations["blocks"][1]["rows"]} == {"CUDA_API_TRACE"}
+    assert {row["table"] for row in lifecycle["blocks"][1]["rows"]} == {"PROCESS_LIFECYCLE"}
+
+
 @pytest.mark.process
 def test_cpu_only_nsight_capture_is_typed_negative_accelerator_evidence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/providers/test_nsight_systems.py
+++ b/tests/providers/test_nsight_systems.py
@@ -100,6 +100,10 @@ def test_nsight_systems_trace_projections_select_semantic_table_families(
         parquetdir / "CUDA_API_TRACE.parquet",
     )
     pq.write_table(
+        pa.table({"name": ["poll"], "duration_ns": [5]}),
+        parquetdir / "OSRT_API.parquet",
+    )
+    pq.write_table(
         pa.table({"process_id": [7], "event": ["started"]}),
         parquetdir / "PROCESS_LIFECYCLE.parquet",
     )
@@ -119,9 +123,13 @@ def test_nsight_systems_trace_projections_select_semantic_table_families(
     assert {row["table"] for row in summary["blocks"][1]["rows"]} == {
         "CUDA_API_TRACE",
         "CUDA_GPU_KERN_SUM",
+        "OSRT_API",
         "PROCESS_LIFECYCLE",
     }
-    assert {row["table"] for row in operations["blocks"][1]["rows"]} == {"CUDA_API_TRACE"}
+    assert {row["table"] for row in operations["blocks"][1]["rows"]} == {
+        "CUDA_API_TRACE",
+        "OSRT_API",
+    }
     assert {row["table"] for row in lifecycle["blocks"][1]["rows"]} == {"PROCESS_LIFECYCLE"}
 
 

--- a/tests/providers/test_nvbench.py
+++ b/tests/providers/test_nvbench.py
@@ -16,7 +16,7 @@ from flameox.runtime_contracts import (
 from flameox.stateless import AnalysisRuntime
 
 
-def _bundle(root: Path, samples: list[float]) -> Path:
+def _bundle(root: Path, samples: list[float], *, elements: int = 65_536) -> Path:
     root.mkdir()
     sidecar = root / "results.json-bin" / "0.bin"
     sidecar.parent.mkdir()
@@ -35,7 +35,7 @@ def _bundle(root: Path, samples: list[float]) -> Path:
                         "name": "cub.scan",
                         "states": [
                             {
-                                "name": "elements=65536",
+                                "name": f"elements={elements}",
                                 "device": 0,
                                 "is_skipped": False,
                                 "summaries": [
@@ -96,6 +96,30 @@ def test_nvbench_directory_preserves_native_sample_values_and_compares(tmp_path:
         "input:results.json",
         "input:results.json-bin/0.bin",
     }
+
+
+def test_nvbench_scaling_uses_numeric_state_dimensions(tmp_path: Path) -> None:
+    sources = [
+        PathSource(
+            path=str(_bundle(tmp_path / f"size-{elements}", [duration], elements=elements)),
+            format="nvbench",
+        )
+        for elements, duration in ((10, 1.0), (20, 4.0), (40, 16.0))
+    ]
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            sources,
+            {"input_dimension": "elements", "metric": "cub.scan.sample_times"},
+        )
+    finally:
+        runtime.close()
+
+    row = result["blocks"][1]["rows"][0]
+    assert row["status"] == "estimated"
+    assert row["point_count"] == 3
+    assert row["exponent"] == pytest.approx(2.0)
 
 
 def test_nvbench_rejects_unbound_sidecars_and_nonfinite_samples(tmp_path: Path) -> None:

--- a/tests/providers/test_perfetto.py
+++ b/tests/providers/test_perfetto.py
@@ -12,8 +12,10 @@ from flameox.workers.perfetto_contract import PerfettoExtractResult, PerfettoSli
 class _Harness:
     def __init__(self, response: PerfettoExtractResult) -> None:
         self.response = response
+        self.requests: list[Any] = []
 
-    def run_typed_sync(self, *_args: Any, **_kwargs: Any) -> PerfettoExtractResult:
+    def run_typed_sync(self, _worker: Any, request: Any, **_kwargs: Any) -> PerfettoExtractResult:
+        self.requests.append(request)
         return self.response
 
 
@@ -57,7 +59,8 @@ def test_pytorch_projection_excludes_generic_perfetto_slices(
             _slice(3, "ProfilerStep#1", category="pytorch"),
         ),
     )
-    provider = PerfettoProvider(_Harness(response))  # type: ignore[arg-type]
+    harness = _Harness(response)
+    provider = PerfettoProvider(harness)  # type: ignore[arg-type]
     binary = tmp_path / "trace_processor"
     binary.write_bytes(b"binary")
     monkeypatch.setattr(PerfettoProvider, "_binary", staticmethod(lambda: binary))
@@ -92,6 +95,7 @@ def test_pytorch_projection_excludes_generic_perfetto_slices(
         "ProfilerStep#1",
     ]
     assert pytorch.blocks[0]["values"]["pytorch_event_count"] == 2
+    assert harness.requests[-1].projection == "pytorch"
 
 
 def test_pytorch_projection_does_not_replace_existing_call_graph_projection() -> None:

--- a/tests/providers/test_perfetto.py
+++ b/tests/providers/test_perfetto.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from flameox.providers.perfetto import PerfettoProvider
+from flameox.workers.perfetto_contract import PerfettoExtractResult, PerfettoSliceRow
+
+
+class _Harness:
+    def __init__(self, response: PerfettoExtractResult) -> None:
+        self.response = response
+
+    def run_typed_sync(self, *_args: Any, **_kwargs: Any) -> PerfettoExtractResult:
+        return self.response
+
+
+def _slice(
+    identifier: int,
+    name: str,
+    *,
+    category: str | None = None,
+    parent_id: int | None = None,
+) -> PerfettoSliceRow:
+    return PerfettoSliceRow(
+        id=identifier,
+        parent_id=parent_id,
+        name=name,
+        ts=identifier * 10,
+        dur=5,
+        track_id=1,
+        category=category,
+        thread_name="main",
+        process_name="python",
+        filename=None,
+        line=None,
+        input_shapes=None,
+        allocation_bytes=None,
+        phase=None,
+        correlation_id=None,
+        device=None,
+        stream=None,
+    )
+
+
+def test_pytorch_projection_excludes_generic_perfetto_slices(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = PerfettoExtractResult(
+        truncated=False,
+        rows=(
+            _slice(1, "event_loop", category="python"),
+            _slice(2, "aten::matmul", category="cpu_op"),
+            _slice(3, "ProfilerStep#1", category="pytorch"),
+        ),
+    )
+    provider = PerfettoProvider(_Harness(response))  # type: ignore[arg-type]
+    binary = tmp_path / "trace_processor"
+    binary.write_bytes(b"binary")
+    monkeypatch.setattr(PerfettoProvider, "_binary", staticmethod(lambda: binary))
+    monkeypatch.setattr(PerfettoProvider, "_identity", staticmethod(lambda _path: "test"))
+
+    summary = provider.analyze(
+        "trace.summary",
+        tmp_path / "trace.json",
+        {},
+        max_rows=10,
+        timeout_seconds=1,
+        maximum_rss_bytes=1024,
+        maximum_output_bytes=1024,
+    )
+    pytorch = provider.analyze(
+        "trace.pytorch",
+        tmp_path / "trace.json",
+        {},
+        max_rows=10,
+        timeout_seconds=1,
+        maximum_rss_bytes=1024,
+        maximum_output_bytes=1024,
+    )
+
+    assert [row["name"] for row in summary.blocks[1]["rows"]] == [
+        "event_loop",
+        "aten::matmul",
+        "ProfilerStep#1",
+    ]
+    assert [row["name"] for row in pytorch.blocks[1]["rows"]] == [
+        "aten::matmul",
+        "ProfilerStep#1",
+    ]
+    assert pytorch.blocks[0]["values"]["pytorch_event_count"] == 2
+
+
+def test_pytorch_projection_does_not_replace_existing_call_graph_projection() -> None:
+    rows = [
+        _slice(1, "parent").model_dump(mode="json"),
+        _slice(2, "child", parent_id=1).model_dump(mode="json"),
+    ]
+
+    assert PerfettoProvider._project("trace.call_graph", rows) == [
+        {
+            "parent": "parent",
+            "child": "child",
+            "sample_count": 1,
+            "inclusive_duration_ns": 5,
+        }
+    ]

--- a/tests/test_cli_stateless.py
+++ b/tests/test_cli_stateless.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 from flameox import __version__
@@ -250,7 +251,7 @@ def test_setup_without_a_tty_requires_an_explicit_client(tmp_path: Path) -> None
 
     assert result.exit_code == 2
     assert "No MCP client selected" in result.output
-    assert "--client codex --yes" in result.output
+    assert "--client codex --yes" in " ".join(unstyle(result.output).split())
     assert not (tmp_path / "flameox-data").exists()
 
 

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1021,6 +1021,49 @@ def test_benchmark_scaling_reports_inconclusive_without_declared_dimension_value
 
 
 @pytest.mark.process
+def test_benchmark_scaling_keeps_non_axis_dimensions_as_distinct_series(tmp_path: Path) -> None:
+    artifact = tmp_path / "variants.samples.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "flameox.benchmark-samples.v1",
+                "producer": "example-benchmark",
+                "producer_version": "1.0",
+                "benchmarks": [
+                    {
+                        "name": "operation",
+                        "unit": "ns",
+                        "measurement_clock": "host_monotonic",
+                        "synchronization": "not_required",
+                        "dimensions": {"elements": str(size), "dtype": dtype},
+                        "samples": [duration],
+                    }
+                    for dtype, size, duration in (
+                        ("float32", 10, 100),
+                        ("float32", 20, 400),
+                        ("float64", 10, 1_000),
+                        ("float64", 20, 2_000),
+                    )
+                ],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            [PathSource(path=str(artifact), format="samples")],
+            {"input_dimension": "elements"},
+        )
+    finally:
+        runtime.close()
+
+    rows = result["blocks"][1]["rows"]
+    assert {row["dimensions"]["dtype"] for row in rows} == {"float32", "float64"}
+    assert sorted(row["exponent"] for row in rows) == pytest.approx([1.0, 2.0])
+
+
+@pytest.mark.process
 def test_pyperf_capture_binds_native_output_before_analysis(tmp_path: Path) -> None:
     async def exercise() -> None:
         runtime = AnalysisRuntime(
@@ -1625,6 +1668,76 @@ def test_pytest_fixture_capture_attributes_session_work_per_xdist_worker(
     assert result["provider"] == {"id": "pytest", "version": "event-stream-v2"}
 
 
+@pytest.mark.process
+def test_pytest_fixture_capture_retains_teardown_failure(tmp_path: Path) -> None:
+    (tmp_path / "conftest.py").write_text(
+        "import pytest\n\n"
+        "@pytest.fixture(autouse=True)\n"
+        "def broken_teardown():\n"
+        "    yield\n"
+        "    raise RuntimeError('teardown failed')\n"
+    )
+    test_file = tmp_path / "test_teardown.py"
+    test_file.write_text("def test_body_passes():\n    pass\n")
+
+    async def exercise() -> dict[str, Any]:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            return await runtime.capture_and_analyze(
+                CaptureTarget(
+                    argv=[sys.executable, "-m", "pytest", "-q", str(test_file)],
+                    cwd=str(tmp_path),
+                    provider_id="pytest",
+                ),
+                "pytest.fixtures",
+            )
+        finally:
+            runtime.close()
+
+    result = anyio.run(exercise)
+    metrics = result["blocks"][0]["values"]
+    assert metrics["teardown_failure_count"] == 1
+    invocation = next(
+        row
+        for row in result["blocks"][1]["rows"]
+        if row["row_kind"] == "fixture_invocation" and row["fixture"] == "broken_teardown"
+    )
+    assert invocation["teardown_failure_reported"] is True
+    assert invocation["complete"] is False
+
+
+@pytest.mark.process
+def test_pytest_capture_does_not_instrument_nested_pytest_processes(tmp_path: Path) -> None:
+    nested = tmp_path / "test_nested.py"
+    nested.write_text("def test_nested():\n    pass\n")
+    outer = tmp_path / "test_outer.py"
+    outer.write_text(
+        "import subprocess\n"
+        "import sys\n\n"
+        "def test_outer():\n"
+        f"    completed = subprocess.run([sys.executable, '-m', 'pytest', '-q', {str(nested)!r}])\n"
+        "    assert completed.returncode == 0\n"
+    )
+
+    async def exercise() -> dict[str, Any]:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            return await runtime.capture_and_analyze(
+                CaptureTarget(
+                    argv=[sys.executable, "-m", "pytest", "-q", str(outer)],
+                    cwd=str(tmp_path),
+                    provider_id="pytest",
+                ),
+                "failures.summary",
+            )
+        finally:
+            runtime.close()
+
+    result = anyio.run(exercise)
+    assert result["blocks"][0]["values"]["collected"] == 1
+    assert result["blocks"][0]["values"]["executed"] == 1
+
+
 @pytest.mark.unit
 def test_pytest_interruption_is_not_overwritten_by_session_finish(tmp_path: Path) -> None:
     events = tmp_path / "pytest.jsonl"
@@ -1672,7 +1785,7 @@ def test_pytest_fixture_projection_aggregates_workers_and_preserves_incomplete_r
             "fixture": "database",
             "scope": "session",
             "phase": "teardown",
-            "outcome": "completed",
+            "outcome": "observed",
             "duration_ns": 5,
             "worker_id": "gw0",
             "invocation_id": "gw0:1",
@@ -1889,8 +2002,15 @@ def test_aiperf_export_is_projected_without_prompts_or_repository(tmp_path: Path
 
 
 @pytest.mark.process
+@pytest.mark.parametrize(
+    ("subprocesses", "expected_enabled"),
+    [(True, True), ("false", False)],
+)
 def test_py_spy_capture_executes_managed_tool_when_request_path_is_empty(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    subprocesses: bool | str,
+    expected_enabled: bool,
 ) -> None:
     workload_python = sys.executable
     managed_bin = tmp_path / "managed" / "bin"
@@ -1921,7 +2041,7 @@ def test_py_spy_capture_executes_managed_tool_when_request_path_is_empty(
                     environment={"PATH": ""},
                     cwd=str(tmp_path),
                     provider_id="py-spy",
-                    capture_arguments={"subprocesses": True},
+                    capture_arguments={"subprocesses": subprocesses},
                 ),
                 "cpu.hotspots",
                 preserve=True,
@@ -1934,12 +2054,15 @@ def test_py_spy_capture_executes_managed_tool_when_request_path_is_empty(
     result, manifest = anyio.run(exercise)
     execution = result["capture"]["executions"][0]
     assert execution["capture_argv"][0] == str(managed_pyspy)
-    assert "--subprocesses" in execution["capture_argv"]
+    assert ("--subprocesses" in execution["capture_argv"]) is expected_enabled
     assert execution["status"] == "succeeded"
     assert result["provider"]["id"] == "py-spy-speedscope"
-    assert any("newly created Python subprocesses" in item for item in result["limitations"])
+    expected_scope = (
+        "newly created Python subprocesses" if expected_enabled else "target process only"
+    )
+    assert any(expected_scope in item for item in result["limitations"])
     assert manifest["body"]["capture_request"]["target"]["capture_arguments"] == {
-        "subprocesses": True
+        "subprocesses": subprocesses
     }
 
 

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -20,7 +20,7 @@ from mcp import Client, StdioServerParameters
 from mcp.client.session import ClientSession
 from mcp.client.stdio import stdio_client
 from mcp.shared.exceptions import MCPError
-from mcp_types import TextResourceContents
+from mcp_types import TextContent, TextResourceContents
 from pydantic import ValidationError
 
 from flameox import __version__
@@ -96,6 +96,56 @@ def test_typed_capability_never_falls_back_to_generic_rows(tmp_path: Path) -> No
 
 
 @pytest.mark.unit
+def test_analysis_rejects_source_cardinality_before_resolving_paths(tmp_path: Path) -> None:
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "memory.hotspots",
+                [
+                    PathSource(path=str(tmp_path / "missing-a.bin"), format="memray"),
+                    PathSource(path=str(tmp_path / "missing-b.bin"), format="memray"),
+                ],
+                {},
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "INVALID_INPUT"
+    assert failure.value.details == {
+        "capability_id": "memory.hotspots",
+        "minimum_sources": 1,
+        "maximum_sources": 1,
+        "actual_sources": 2,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("capability_id", "arguments"),
+    [
+        ("failures.summary", {"group_by": "not-a-dimension"}),
+        ("cpu.hotspots", {"metric": "not-a-metric"}),
+    ],
+)
+def test_analysis_rejects_options_not_declared_by_the_capability(
+    tmp_path: Path,
+    capability_id: str,
+    arguments: dict[str, str],
+) -> None:
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(ValidationError):
+            runtime.analyze(
+                capability_id,
+                [PathSource(path=str(tmp_path / "missing.json"), format="observations")],
+                arguments,
+            )
+    finally:
+        runtime.close()
+
+
+@pytest.mark.unit
 def test_capture_rejects_declared_provider_capability_mismatch_before_execution(
     tmp_path: Path,
 ) -> None:
@@ -158,6 +208,48 @@ def test_capture_rejects_experiments_that_exceed_analysis_source_limit(tmp_path:
         finally:
             runtime.close()
         assert failure.value.code == "LIMIT_EXCEEDED"
+
+    anyio.run(exercise)
+    assert not marker.exists()
+
+
+@pytest.mark.unit
+def test_capture_rejects_experiment_unsupported_by_single_source_analysis(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "executed"
+
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            with pytest.raises(RuntimeFailure) as failure:
+                await runtime.capture_and_analyze(
+                    CaptureTarget(
+                        argv=[sys.executable, "-c", f"open({str(marker)!r}, 'w').close()"],
+                        cwd=str(tmp_path),
+                        provider_id="coverage",
+                    ),
+                    "coverage.summary",
+                    mode="experiment",
+                    experiment=ExperimentDesign(
+                        cases=[ExperimentCase(name="a"), ExperimentCase(name="b")],
+                        blocks=1,
+                        seed=1,
+                        metric="wall_time_ns",
+                        estimand="median_difference",
+                        practical_threshold=0,
+                    ),
+                )
+        finally:
+            runtime.close()
+
+        assert failure.value.code == "INVALID_INPUT"
+        assert failure.value.details == {
+            "capability_id": "coverage.summary",
+            "minimum_sources": 1,
+            "maximum_sources": 1,
+            "actual_sources": 2,
+        }
 
     anyio.run(exercise)
     assert not marker.exists()
@@ -758,6 +850,29 @@ def _write_benchmark_samples(path: Path, values: list[int]) -> None:
     )
 
 
+def _write_scaling_samples(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "flameox.benchmark-samples.v1",
+                "producer": "example-benchmark",
+                "producer_version": "1.0",
+                "benchmarks": [
+                    {
+                        "name": "operation",
+                        "unit": "ns",
+                        "measurement_clock": "host_monotonic",
+                        "synchronization": "not_required",
+                        "dimensions": {"elements": str(elements)},
+                        "samples": [duration, duration],
+                    }
+                    for elements, duration in ((10, 100), (20, 400), (40, 1_600))
+                ],
+            }
+        )
+    )
+
+
 @pytest.mark.process
 def test_pyperf_summary_uses_native_isolated_reader(tmp_path: Path) -> None:
     artifact = tmp_path / "benchmark.json"
@@ -858,6 +973,54 @@ def test_structured_benchmark_samples_are_isolated_and_comparable(tmp_path: Path
 
 
 @pytest.mark.process
+def test_benchmark_scaling_estimates_power_law_from_declared_numeric_dimension(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "scaling.samples.json"
+    _write_scaling_samples(artifact)
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            [PathSource(path=str(artifact), format="samples")],
+            {"input_dimension": "elements", "metric": "operation"},
+        )
+    finally:
+        runtime.close()
+
+    metrics = result["blocks"][0]["values"]
+    assert metrics["scaling_status"] == "estimated"
+    assert metrics["input_dimension"] == "elements"
+    row = result["blocks"][1]["rows"][0]
+    assert row["benchmark"] == "operation"
+    assert row["point_count"] == 3
+    assert row["exponent"] == pytest.approx(2.0)
+    assert row["r_squared"] == pytest.approx(1.0)
+
+
+@pytest.mark.process
+def test_benchmark_scaling_reports_inconclusive_without_declared_dimension_values(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "benchmark.json"
+    _write_pyperf_suite(artifact, [0.01, 0.02])
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            [PathSource(path=str(artifact), format="pyperf")],
+            {"input_dimension": "elements"},
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][0]["values"]["scaling_status"] == "inconclusive"
+    assert result["blocks"][1]["rows"][0]["status"] == "inconclusive"
+    assert result["blocks"][1]["rows"][0]["exponent"] is None
+    assert any("numeric 'elements'" in item for item in result["limitations"])
+
+
+@pytest.mark.process
 def test_pyperf_capture_binds_native_output_before_analysis(tmp_path: Path) -> None:
     async def exercise() -> None:
         runtime = AnalysisRuntime(
@@ -951,7 +1114,7 @@ def test_composed_evidence_namespaces_colliding_source_roles(tmp_path: Path) -> 
         composed = runtime.analyze(
             "benchmark.scaling",
             [EvidenceSource(kind="evidence", evidence_id=value) for value in evidence_ids],
-            {},
+            {"input_dimension": "elements"},
         )
         preserved = runtime.preserve_evidence(composed["analysis_id"])
         manifest = runtime.read_evidence(preserved["evidence_id"])
@@ -1132,7 +1295,7 @@ def test_native_nsight_report_uses_cached_parquetdir_export(
     assert not (tmp_path / ".flameox").exists()
 
 
-def _write_otlp_trace(path: Path) -> None:
+def _write_otlp_trace(path: Path, *, include_event: bool = False) -> None:
     from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
         ExportTraceServiceRequest,
     )
@@ -1148,6 +1311,10 @@ def _write_otlp_trace(path: Path) -> None:
         span.name = f"span-{index}"
         span.start_time_unix_nano = start
         span.end_time_unix_nano = start + 10
+        if include_event and index == 2:
+            event = span.events.add()
+            event.name = "checkpoint"
+            event.time_unix_nano = start + 5
     path.write_bytes(request.SerializeToString())
 
 
@@ -1196,6 +1363,40 @@ def test_otlp_window_filters_inside_isolated_parser(tmp_path: Path) -> None:
 
     span_rows = [row for row in result["blocks"][1]["rows"] if row["table"] == "spans"]
     assert [row["name"] for row in span_rows] == ["span-2"]
+
+
+@pytest.mark.process
+def test_otlp_operation_and_lifecycle_projections_are_semantically_distinct(
+    tmp_path: Path,
+) -> None:
+    trace = tmp_path / "trace.otlp"
+    _write_otlp_trace(trace, include_event=True)
+    source = [PathSource(path=str(trace), format="otlp")]
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        summary = runtime.analyze("trace.summary", source, {})
+        operations = runtime.analyze("trace.operations", source, {})
+        lifecycle = runtime.analyze("trace.lifecycle", source, {})
+    finally:
+        runtime.close()
+
+    assert {row["table"] for row in summary["blocks"][1]["rows"]} >= {"spans", "events"}
+    assert [row["operation"] for row in operations["blocks"][1]["rows"]] == [
+        "span-1",
+        "span-2",
+        "span-3",
+    ]
+    assert all("total_duration_ns" in row for row in operations["blocks"][1]["rows"])
+    transitions = lifecycle["blocks"][1]["rows"]
+    assert {row["transition"] for row in transitions} == {
+        "span_started",
+        "span_event",
+        "span_ended",
+    }
+    assert (
+        next(row for row in transitions if row["transition"] == "span_event")["operation"]
+        == "checkpoint"
+    )
 
 
 @pytest.mark.unit
@@ -1367,6 +1568,63 @@ def test_pytest_capture_produces_analyzable_session_evidence(tmp_path: Path) -> 
     assert not (tmp_path / ".flameox").exists()
 
 
+@pytest.mark.process
+def test_pytest_fixture_capture_attributes_session_work_per_xdist_worker(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "conftest.py").write_text(
+        "import time\n\n"
+        "import pytest\n\n"
+        "@pytest.fixture(scope='session', autouse=True)\n"
+        "def database():\n"
+        "    time.sleep(0.01)\n"
+        "    yield\n"
+        "    time.sleep(0.01)\n"
+    )
+    test_file = tmp_path / "test_parallel.py"
+    test_file.write_text(
+        "import pytest\n\n"
+        "@pytest.mark.parametrize('case', range(4))\n"
+        "def test_case(case):\n"
+        "    assert case >= 0\n"
+    )
+
+    async def exercise() -> dict[str, Any]:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            return await runtime.capture_and_analyze(
+                CaptureTarget(
+                    argv=[sys.executable, "-m", "pytest", "-q", "-n", "2", str(test_file)],
+                    cwd=str(tmp_path),
+                    provider_id="pytest",
+                ),
+                "pytest.fixtures",
+            )
+        finally:
+            runtime.close()
+
+    result = anyio.run(exercise)
+    rows = result["blocks"][1]["rows"]
+    aggregate = next(
+        row
+        for row in rows
+        if row["row_kind"] == "fixture_aggregate" and row["fixture"] == "database"
+    )
+    assert aggregate["scope"] == "session"
+    assert aggregate["invocation_count"] == 2
+    assert aggregate["worker_count"] == 2
+    assert aggregate["setup_work_ns"] > 0
+    assert aggregate["teardown_work_ns"] > 0
+    assert aggregate["incomplete_invocation_count"] == 0
+    invocations = [
+        row
+        for row in rows
+        if row["row_kind"] == "fixture_invocation" and row["fixture"] == "database"
+    ]
+    assert {row["worker_id"] for row in invocations} == {"gw0", "gw1"}
+    assert result["provider"] == {"id": "pytest", "version": "event-stream-v2"}
+
+
 @pytest.mark.unit
 def test_pytest_interruption_is_not_overwritten_by_session_finish(tmp_path: Path) -> None:
     events = tmp_path / "pytest.jsonl"
@@ -1390,6 +1648,75 @@ def test_pytest_interruption_is_not_overwritten_by_session_finish(tmp_path: Path
         runtime.close()
 
     assert result["blocks"][0]["values"]["completion"] == "interrupted"
+
+
+@pytest.mark.unit
+def test_pytest_fixture_projection_aggregates_workers_and_preserves_incomplete_runs(
+    tmp_path: Path,
+) -> None:
+    events = tmp_path / "pytest.jsonl"
+    fixture_events = [
+        {
+            "event": "fixture_phase",
+            "fixture": "database",
+            "scope": "session",
+            "phase": "setup",
+            "outcome": "passed",
+            "duration_ns": 10,
+            "worker_id": "gw0",
+            "invocation_id": "gw0:1",
+            "nodeid": "",
+        },
+        {
+            "event": "fixture_phase",
+            "fixture": "database",
+            "scope": "session",
+            "phase": "teardown",
+            "outcome": "completed",
+            "duration_ns": 5,
+            "worker_id": "gw0",
+            "invocation_id": "gw0:1",
+            "nodeid": "",
+        },
+        {
+            "event": "fixture_phase",
+            "fixture": "database",
+            "scope": "session",
+            "phase": "setup",
+            "outcome": "passed",
+            "duration_ns": 12,
+            "worker_id": "gw1",
+            "invocation_id": "gw1:1",
+            "nodeid": "",
+        },
+        {"event": "interrupted"},
+    ]
+    events.write_text("\n".join(json.dumps(event) for event in fixture_events) + "\n")
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "pytest.fixtures", [PathSource(path=str(events), format="pytest")], {}
+        )
+    finally:
+        runtime.close()
+
+    metrics = result["blocks"][0]["values"]
+    assert metrics["completion"] == "interrupted"
+    assert metrics["worker_count"] == 2
+    assert metrics["invocation_count"] == 2
+    assert metrics["incomplete_invocation_count"] == 1
+    aggregate = result["blocks"][1]["rows"][0]
+    assert aggregate == {
+        "row_kind": "fixture_aggregate",
+        "fixture": "database",
+        "scope": "session",
+        "invocation_count": 2,
+        "worker_count": 2,
+        "setup_work_ns": 22,
+        "teardown_work_ns": 5,
+        "known_work_ns": 27,
+        "incomplete_invocation_count": 1,
+    }
 
 
 @pytest.mark.unit
@@ -1585,26 +1912,35 @@ def test_py_spy_capture_executes_managed_tool_when_request_path_is_empty(
     managed_pyspy.chmod(0o755)
     monkeypatch.setattr("flameox.stateless.sys.executable", str(managed_python))
 
-    async def exercise() -> dict[str, Any]:
+    async def exercise() -> tuple[dict[str, Any], dict[str, Any]]:
         runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
         try:
-            return await runtime.capture_and_analyze(
+            result = await runtime.capture_and_analyze(
                 CaptureTarget(
                     argv=[workload_python, "-c", "sum(range(100))"],
                     environment={"PATH": ""},
                     cwd=str(tmp_path),
                     provider_id="py-spy",
+                    capture_arguments={"subprocesses": True},
                 ),
                 "cpu.hotspots",
+                preserve=True,
             )
+            manifest = runtime.read_evidence(result["preserved"]["evidence_id"])
+            return result, manifest
         finally:
             runtime.close()
 
-    result = anyio.run(exercise)
+    result, manifest = anyio.run(exercise)
     execution = result["capture"]["executions"][0]
     assert execution["capture_argv"][0] == str(managed_pyspy)
+    assert "--subprocesses" in execution["capture_argv"]
     assert execution["status"] == "succeeded"
     assert result["provider"]["id"] == "py-spy-speedscope"
+    assert any("newly created Python subprocesses" in item for item in result["limitations"])
+    assert manifest["body"]["capture_request"]["target"]["capture_arguments"] == {
+        "subprocesses": True
+    }
 
 
 @pytest.mark.unit
@@ -1623,14 +1959,60 @@ def test_mcp_tools_are_generated_from_typed_capabilities() -> None:
         assert {tool.name for tool in tools} == set(expected)
         assert all(tool.output_schema is not None for tool in tools)
         by_name = {tool.name: tool for tool in tools}
+        multi_source_capabilities = {
+            "artifact.preview": (1, 32),
+            "benchmark.summary": (1, 32),
+            "benchmark.scaling": (1, 32),
+            "benchmark.compare": (2, 32),
+            "inference.compare": (2, 32),
+            "kernel.compare": (2, 32),
+        }
+        for capability in CAPABILITIES:
+            source_schema = by_name[analysis_tool_name(capability)].input_schema["properties"][
+                "sources"
+            ]
+            expected_minimum, expected_maximum = multi_source_capabilities.get(
+                capability.id, (1, 1)
+            )
+            assert source_schema["minItems"] == expected_minimum
+            assert source_schema["maxItems"] == expected_maximum
+            if compatible_capture_providers(capability):
+                execution_schema = by_name[capture_tool_name(capability)].input_schema[
+                    "properties"
+                ]["execution"]
+                if expected_maximum == 1:
+                    assert execution_schema["$ref"].endswith("/SingleExecution")
+                else:
+                    assert execution_schema["discriminator"]["propertyName"] == "kind"
         analysis_schema = by_name["analyze_cpu_hotspots"].input_schema
+        cpu_options = analysis_schema["$defs"]["CpuHotspotArguments"]["properties"]
+        assert set(cpu_options) == {"metric"}
+        assert cpu_options["metric"]["anyOf"][0]["enum"] == [
+            "self_time_seconds",
+            "cumulative_time_seconds",
+            "total_calls",
+            "primitive_calls",
+        ]
+        failures_schema = by_name["analyze_failures_summary"].input_schema
+        assert failures_schema["$defs"]["EmptyArguments"]["properties"] == {}
+        assert failures_schema["properties"]["options"]["$ref"].endswith("/EmptyArguments")
         assert set(analysis_schema["properties"]) == {
             "sources",
             "options",
             "limits",
             "continuation",
         }
-        assert analysis_schema["required"] == ["sources", "options"]
+        assert analysis_schema["required"] == ["sources"]
+        assert by_name["analyze_trace_window"].input_schema["required"] == [
+            "sources",
+            "options",
+        ]
+        scaling_schema = by_name["analyze_benchmark_scaling"].input_schema
+        assert scaling_schema["required"] == ["sources", "options"]
+        assert set(scaling_schema["$defs"]["ScalingArguments"]["properties"]) == {
+            "input_dimension",
+            "metric",
+        }
         capture_schema = by_name["capture_cpu_hotspots"].input_schema
         assert set(capture_schema["properties"]) == {
             "target",
@@ -1645,12 +2027,19 @@ def test_mcp_tools_are_generated_from_typed_capabilities() -> None:
             "perf": "#/$defs/PerfProvider",
             "py-spy": "#/$defs/PySpyProvider",
         }
-        assert capture_schema["required"] == ["target", "provider", "options", "execution"]
+        assert capture_schema["required"] == ["target", "provider", "execution"]
+        assert by_name["capture_trace_window"].input_schema["required"] == [
+            "target",
+            "provider",
+            "execution",
+            "options",
+        ]
         target_schema = capture_schema["$defs"]["DirectTarget"]["properties"]
         assert "without a shell" in target_schema["argv"]["description"]
         assert "existing absolute directory" in target_schema["cwd"]["description"].lower()
         assert "minimal allowlisted environment" in target_schema["environment"]["description"]
-        experiment_schema = capture_schema["$defs"]["ExperimentDesign"]["properties"]
+        benchmark_capture = by_name["capture_benchmark_summary"].input_schema
+        experiment_schema = benchmark_capture["$defs"]["ExperimentDesign"]["properties"]
         assert "first case is the baseline" in experiment_schema["cases"]["description"]
         assert "nanoseconds" in experiment_schema["practical_threshold"]["description"]
         assert (
@@ -1672,17 +2061,44 @@ def test_mcp_tools_are_generated_from_typed_capabilities() -> None:
             by_name["analyze_benchmark_compare"].input_schema["properties"]["sources"]["minItems"]
             == 2
         )
+        assert (
+            by_name["analyze_memory_hotspots"].input_schema["properties"]["sources"]["maxItems"]
+            == 1
+        )
+        assert by_name["preview_artifact"].input_schema["properties"]["sources"]["maxItems"] == 32
+        assert (
+            by_name["analyze_benchmark_summary"].input_schema["properties"]["sources"]["maxItems"]
+            == 32
+        )
+        assert capture_schema["properties"]["execution"]["$ref"].endswith("/SingleExecution")
+        assert (
+            benchmark_capture["properties"]["execution"]["discriminator"]["propertyName"] == "kind"
+        )
         assert "capture_benchmark_compare" not in by_name
         analysis_annotations = by_name["analyze_cpu_hotspots"].annotations
         capture_annotations = by_name["capture_cpu_hotspots"].annotations
         assert analysis_annotations and analysis_annotations.read_only_hint is True
         assert capture_annotations and capture_annotations.destructive_hint is True
+        assert capture_annotations.open_world_hint is True
+        assert "external side effects" in (by_name["capture_cpu_hotspots"].description or "")
+        assert "randomized paired blocks" in (
+            by_name["capture_benchmark_summary"].description or ""
+        )
+        assert "numeric input axis" in (by_name["analyze_benchmark_scaling"].description or "")
+        assert "already captured separately" in (
+            by_name["analyze_benchmark_compare"].description or ""
+        )
         prepare = next(tool for tool in tools if tool.name == "prepare_providers")
         assert prepare.annotations and prepare.annotations.open_world_hint is True
         assert prepare.annotations.read_only_hint is False
         assert prepare.annotations.destructive_hint is False
+        capture_names = {
+            capture_tool_name(capability)
+            for capability in CAPABILITIES
+            if compatible_capture_providers(capability)
+        }
         assert all(
-            tool.annotations and tool.annotations.open_world_hint is False
+            tool.annotations and tool.annotations.open_world_hint is (tool.name in capture_names)
             for tool in tools
             if tool.name != "prepare_providers"
         )
@@ -1774,6 +2190,10 @@ def test_mcp_prepares_managed_providers_and_only_guides_host_tools(
             )
 
         assert result.is_error is False
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+        assert "Provider preparation completed" in result.content[0].text
+        assert "requested_providers" not in result.content[0].text
         assert result.structured_content["requested_providers"] == [
             "memray",
             "nsight-compute",
@@ -1837,7 +2257,7 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
             artifact.write_text('[{"value":1}]')
             inspected = await session.call_tool(
                 "preview_artifact",
-                {"sources": [{"kind": "path", "path": str(artifact)}], "options": {}},
+                {"sources": [{"kind": "path", "path": str(artifact)}]},
             )
             invalid = await session.call_tool(
                 "preview_artifact", {"sources": [], "options": {}, "unexpected": True}
@@ -1850,7 +2270,6 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
                         "cwd": str(tmp_path),
                     },
                     "provider": {"kind": "direct"},
-                    "options": {},
                     "execution": {"kind": "single"},
                 },
             )
@@ -1858,7 +2277,7 @@ def test_real_stdio_initialize_and_catalog_match_the_stateless_contract(tmp_path
             await session.validate_tool_result("capture_process_output", captured)
 
         assert initialized.server_info.version == __version__
-        assert len(tools.tools) == 44
+        assert len(tools.tools) == 47
         assert "preview_artifact" in [tool.name for tool in tools.tools]
         assert "capture_gpu_kernel_metrics" in [tool.name for tool in tools.tools]
         assert all(tool.output_schema is not None for tool in tools.tools)

--- a/uv.lock
+++ b/uv.lock
@@ -1038,6 +1038,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1119,6 +1128,7 @@ dev = [
     { name = "pyarrow-stubs" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "vulture" },
 ]
@@ -1179,6 +1189,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.1" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8,<4" },
     { name = "pytz", specifier = ">=2024.2" },
     { name = "questionary", specifier = ">=2.1,<3" },
     { name = "rfc8785", specifier = "==0.1.4" },
@@ -3480,6 +3491,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Flameox's capability registry previously described more behavior than the MCP surface and several providers could faithfully expose. Agents could select unsupported option combinations, discover source-count constraints only after dispatch, miss paired experiment mode, or receive multiple trace questions through effectively identical projections.

This change makes the registry the common contract for source cardinality, capability-specific options, capture admission, generated MCP schemas, and provider projections. It also adds the missing scaling, CPU caller-edge, py-spy subprocess, and pytest fixture evidence needed to answer the open investigation workflows without generic fallbacks.

Fixes #428.
Fixes #429.
Fixes #430.
Fixes #431.
Fixes #432.
Fixes #433.
Fixes #434.
Fixes #435.
Fixes #436.
Fixes #437.
Fixes #438.
Fixes #439.

## Problem and expected behavior

The affected paths shared three contract failures:

1. Capability constraints were partly inferred by the MCP transport, partly deferred to providers, and sometimes absent from runtime admission.
2. Distinct evidence questions such as scaling, operations, lifecycle, PyTorch activity, caller edges, and fixture cost did not always produce distinct bounded evidence.
3. Model-visible MCP metadata did not clearly route agents between exploratory profiles, paired experiments, scaling over an input axis, and comparison of artifacts captured separately.

The expected invariant is that the capability declaration determines what can be called, runtime preflight rejects requests before side effects, and the selected provider returns evidence shaped for that question with its coverage and limitations intact.

## Change

- Give each capability an explicit source range and typed option model. MCP schemas and runtime admission now use the same declaration; experiments unsupported by single-source analyses fail before executing a case.
- Add closed pstats metric selection and `cpu.callers`, including bounded caller/callee filtering and deterministic edge attribution.
- Add py-spy subprocess capture and preserve the selected process scope in capture provenance and limitations.
- Add `pytest.fixtures` with setup/finalizer timing per fixture invocation and xdist worker. The plugin is loaded in workers as well as the controller, and interrupted invocations remain incomplete rather than becoming zero-duration work.
- Implement benchmark scaling as a log-log power-law estimate over a declared positive numeric dimension. Insufficient data produces a typed inconclusive result.
- Give OTLP operations/lifecycle, Nsight Systems operations/lifecycle, and Perfetto PyTorch activity separate projections while preserving the existing Perfetto call graph.
- Mark arbitrary target capture as open-world and describe its external-side-effect boundary.
- Make defaultable MCP `options` optional while keeping models with required fields required in generated SDK schemas.
- Add routing guidance for experiments, scaling, and existing-artifact comparison. Successful calls retain the full validated result in `structuredContent` and use a concise text block for content-only clients instead of duplicating every evidence row.

Native artifacts, failed executions, experiment structure, immutable manifests, and the observed/derived distinction remain unchanged. This does not add an unrestricted execution or query surface.

## Suggested review order

1. `runtime_contracts.py` and `stateless.py`: capability ownership and pre-execution admission.
2. `mcp/server.py`: generated schemas, annotations, routing descriptions, and concise success content.
3. `providers/` and `workers/pstats.py`: scaling and question-specific projections.
4. `pytest_capture.py` and `pytest_runner.py`: finalizer ordering and xdist worker loading.
5. Provider tests, stateless integration tests, then the contract documentation.

## Contract and boundary impact

- Semantic owner and changed stage: capability declarations own source and option constraints; capture preflight is the earliest changed runtime stage.
- Public CLI or MCP contract: the catalog grows from 44 to 47 tools; defaultable `options` may be omitted; single-source capture tools no longer advertise experiment mode; success text becomes concise while `structuredContent` remains authoritative.
- Storage, artifact, provenance, or schema contract: no persisted schema migration; py-spy process scope is retained in the existing capture request and limitations.
- Adapter, provider, platform, or direct-target compatibility: adds pytest-xdist as a development dependency; py-spy subprocess behavior is opt-in; existing provider formats remain accepted.
- Cancellation, concurrency, security, or containment impact: fixture events are appended independently by xdist workers; capture remains bounded but cannot prevent target side effects.
- Native artifact, failed-attempt, and observed/derived/inferred claim handling: preserved; scaling coefficients and exponents are explicitly derived estimates with stated limits.

## Evidence and regression coverage

- Tests added or updated: generated MCP schema/cardinality tests, no-side-effect experiment rejection, power-law and inconclusive scaling cases, pstats caller edges, py-spy subprocess provenance, distinct OTLP/Nsight/Perfetto projections, concise MCP success content, and real two-worker pytest-xdist fixture capture.
- Base evidence: the linked issues record the prior 44-tool catalog, duplicated text/structured results, missing routing language, generic option schema, and source-derived provider gaps. The xdist regression reproduced during implementation: controller-only plugin registration yielded no fixture aggregate until worker loading was fixed.
- User-visible MCP output: the catalog now contains 47 tools and measured 364,676 bytes as compact JSON. Full evidence remains in `structuredContent`; text identifies the capability, completion state, analysis handle, and next action.
- Remaining proof gaps: model-selection A/B evaluation and rendering measurements in third-party MCP hosts were not run. Real SDK stdio behavior and output-schema validation are covered locally.

For changes that affect evidence or conclusions:

- [x] Observed, derived, and inferred claims remain distinguishable.
- [x] Inputs, versions, provenance, and relevant corpus or artifact identity remain bound.
- [x] Any compatibility, limitation, incompleteness, or uncertainty is exposed to callers.

## Validation

- `uv run pytest -q` — 175 passed, 87 deselected.
- `uv run pytest -q -m process` — 83 passed, 1 skipped because the optional `aiperf` package was unavailable, 178 deselected.
- `uv run ruff check src tests tools` — passed.
- `uv run ruff format --check src tests tools` — 109 files already formatted.
- `uv run mypy src tests tools` — passed across 109 source files.
- `uv run lint-imports` — 2 architecture contracts kept, 0 broken.
- Validation commit: `2d30238`.

## Compatibility and safety

- Breaking changes or migration steps: callers that supplied generic `metric` or `group_by` fields to capabilities that never supported them now receive validation errors. CPU metric selection is limited to the declared pstats vocabulary.
- Supported platform/provider changes: py-spy can opt into newly created Python subprocesses; pytest fixture attribution supports local and xdist execution.
- Security, privacy, or containment review: no fixture values are serialized; capture annotations and descriptions now state the external-side-effect boundary; command execution still uses validated argv without a shell.
- Performance or resource-budget impact: fixture instrumentation adds one bounded event per setup and teardown phase. No runtime-performance claim is made; dedicated overhead benchmarking was not run.

## Review checklist

- [x] The PR has one focused outcome and the title follows `type(scope): outcome`.
- [x] Related issues are linked.
- [x] Tests cover changed observable behavior and meaningful failure paths.
- [x] Base evidence or the remaining base-proof gap is stated.
- [x] Documentation and owning contracts are updated.
- [x] User-visible MCP changes include representative output.
- [x] The final diff was checked for secrets, unrelated cleanup, and unsupported claims.
