### PR TITLE
fix(evidence): enforce trustworthy projection contracts

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -20,6 +20,20 @@ roles and formats, and selection description. Generated MCP schemas, pre-executi
 checks, and capture argument validation consume that same contract so their format claims cannot
 drift.
 
+Adding or removing a format is complete only when these surfaces agree:
+
+1. the capability's accepted formats;
+2. the capture-provider contract and invocation builder, when capture is supported;
+3. explicit-path suffix detection;
+4. analysis dispatch into the provider or isolated worker;
+5. generated MCP analysis and capture schemas;
+6. the support table below.
+
+Tests exercise explicit-path analysis and, when applicable, capture through the public runtime.
+They also assert that the capture-contract and invocation-builder registries have identical provider
+IDs. A parser or worker that is not reachable through a declared capability is either intentionally
+internal and documented as such, or an incomplete registration—not latent support.
+
 Capability tools remain discoverable when a provider is absent. Capture validates the selected
 provider's package, executable, platform, version, permission, and required external resources as
 part of the attempted operation, before workload execution. An unavailable provider returns a typed
@@ -35,7 +49,7 @@ Artifact analysis and typed capture are separate contracts:
 | Evidence family | Explicit artifact analysis | Typed capture provider |
 | --- | --- | --- |
 | CPU profiles | Node/V8, cProfile pstats, py-spy Speedscope, perf collapsed stacks, perf data | `node-cpu-profile`, `py-spy`, `perf` |
-| Memory profiles | Memray | `memray` |
+| Memory profiles | Memray, Node/V8 sampling heap profiles | `memray`, `node-heap-profile` |
 | Benchmarks | pyperf, benchmark samples, PyTorch samples, NVBench | `pyperf`, `benchmark-samples`, `nvbench` |
 | Execution traces | Perfetto/Chrome, PyTorch, OTLP, ROCprof PFTrace, xctrace, Nsight Systems | `torch-profiler`, `rocprofv3`, `xctrace`, `nsight-systems` |
 | GPU and kernels | Nsight Systems, Nsight Compute, Compute Sanitizer, Triton, kernel validation | `nsight-systems`, `nsight-compute`, `compute-sanitizer` |
@@ -69,17 +83,33 @@ look up runs or mutable records.
 Semantic selection happens before bounding. A provider must filter for the requested projection
 before applying row, byte, or worker limits, and `rows_observed`, `complete`, and truncation must
 describe that same projected population. A bounded prefix of unrelated native rows is not evidence
-that the requested activity is absent.
+that the requested activity is absent. OTLP time windows apply their span predicate before resource
+and scope rows consume the normalization budget; only owning context for retained spans is emitted.
 
 Projection identity includes every non-axis dimension that can distinguish a series, including
 device, dtype, variant, scope, and worker identity where applicable. Providers must not blend those
 series. When a composite native label is successfully decomposed into named dimensions, the raw
 label must not remain as a redundant identity that changes with the selected axis.
 
+Numeric aggregation requires compatible semantic units. Providers normalize convertible units to
+one declared output unit before pooling and reject incompatible dimensions; for example, seconds
+and nanoseconds may become seconds, while bytes and elapsed time cannot share a CPU-hotspot total.
+Rows and metrics expose the normalized unit so consumers never have to infer it from the format.
+
 Native selectors such as table families, event categories, and field names require a representative
 artifact or authoritative format fixture. Unmatched selectors stay incomplete or explicitly limited;
 they must not silently become complete negative evidence. Adding a projection also requires a
 regression check for sibling projections that share its reader or dispatch path.
+
+Raw parser safety limits are independent from normalized output limits. In particular, V8 node and
+sample ceilings bound native traversal, while the hotspot row limit bounds the ranked aggregate
+projection. A partial SARIF document is likewise incomplete even when every parsed result fits in
+the returned table.
+
+Native references are validated before aggregation. Sample-to-node, edge-to-frame, parent-to-child,
+and similar identifiers must resolve inside the same artifact unless the format explicitly defines
+an external reference. A syntactically valid but unresolved identifier is corrupt evidence, not an
+ignorable sample.
 
 The runtime projects provider blocks into the RFC 8785 JSON domain before
 bounding or preservation. Native integers outside JSON's interoperable safe

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -88,6 +88,11 @@ metrics and rows remain open JSON values. Success uses structured content direct
 details. MCP SDK argument-validation errors occur before tool execution and therefore use the
 protocol error shape rather than the tool's output schema.
 
+Failure messages and details are protocol data. MCP handlers project typed `RuntimeFailure` values
+but never serialize arbitrary exception text: filesystem exceptions may contain host paths, and
+dependency exceptions may contain argv or environment-derived values. Unexpected failures use a
+stable operation-specific summary; cancellation remains a control path and is re-raised.
+
 `prepare_providers` and the capture tools are open-world. Preparation resolves the exact package
 requirement through `uvx`, verifies that environment by running Flameox's version command, and
 returns the same requirement in a global, version-pinned MCP launcher. Capture tools execute an
@@ -122,11 +127,18 @@ can choose which of its rows to request. They can cross process boundaries, so
 a CLI invocation can resume a previous page. A changed input cannot reuse a
 continuation.
 
+Decoded offsets must be integers within the available bounded population. Negative offsets and
+offsets at or beyond the end fail with `INVALID_INPUT`; they never use Python slicing semantics or
+produce empty complete evidence. Continuation tests cover wrong-request, changed-input, negative,
+non-integer, and beyond-end cases.
+
 Projection providers may expose a bounded prefix when their native reader cannot
 resume safely. Such results keep `coverage.complete=false`, identify
 `truncation.reason=provider_limit`, and do not emit a continuation after the last
 retrievable row. A continuation therefore always names a consumable next page;
-it never promises access beyond a provider's declared projection bound.
+it never promises access beyond a provider's declared projection bound. MCP summaries direct that
+terminal case toward a narrower semantic query or a reduced recapture; preservation cannot recover
+rows the provider never returned.
 
 Requests may lower startup row, result-byte, timeout, output-byte, and durable
 provenance-byte limits. Durable provenance bounds the captured argv and execution

--- a/docs/investigations.md
+++ b/docs/investigations.md
@@ -73,6 +73,24 @@ positive input values is explicitly inconclusive rather than falling back to a g
 summary. The fit describes the measured range; it does not establish asymptotic complexity or a
 causal performance change.
 
+Comparison and scaling aggregate native samples into per-series sums and counts inside their
+bounded readers. The sample population may therefore exceed the result-row page size without being
+silently clipped. The independent native sample and semantic-series safety ceilings still apply.
+
+## Comparison compatibility
+
+Benchmark and kernel comparisons join only complete semantic identities. Units, dimensions,
+timing protocols, devices, dtypes, shapes, scopes, phases, and other declared identity axes are not
+pooled merely because a metric name matches. The result reports identities absent from one or more
+inputs rather than manufacturing a ratio across them.
+
+Inference exports expose digest-only workload and system identities when their native format
+provides enough metadata. Known-different identities fail validation by default. A caller may set
+`allow_heterogeneous=true` for an explicitly exploratory ratio; the result labels that comparison
+`heterogeneous` and retains the differing axes. Missing identity axes produce `partial`, not a
+claim of compatibility. Prompts, generations, endpoints, and raw model or dataset names remain
+excluded from normalized evidence.
+
 ## Pytest fixture work
 
 `pytest.fixtures` records fixture setup and finalizer phases without serializing fixture values.
@@ -82,6 +100,10 @@ mistaken for one global invocation. Aggregate work is summed evidence and can ov
 workers; Flameox reports the maximum accumulated worker work separately and does not label either
 quantity as wall-clock critical-path duration. Interrupted runs preserve incomplete invocations
 instead of assigning missing finalizers a zero duration.
+
+Session completion also retains pytest's nonzero `run_finished.exitstatus`. Repeated phase reports
+remain an ordered attempt history; a failed attempt followed by a passing attempt is reported as
+flaky rather than allowing the later report to erase the failure.
 
 The capture plugin is scoped to the owned pytest invocation and propagated through pytest arguments
 to xdist workers; it does not export plugin state that would instrument nested pytest processes.

--- a/docs/runtime-safety.md
+++ b/docs/runtime-safety.md
@@ -62,6 +62,10 @@ Readers see no bundle or one complete bundle. Corruption is never repaired in
 place or hidden by a catalog rebuild. Abandoned staging is removed only when the
 recorded owner process is provably absent.
 
+Repository validation treats persisted JSON as boundary input even when its digest is correct.
+Nested request and execution structures are parsed before query, materialization, or MCP projection;
+downstream code does not discover malformed state through `KeyError` or `AttributeError`.
+
 ## Privacy
 
 All work stays local. Manifests preserve explicit paths, provider identity,
@@ -71,3 +75,7 @@ artifacts, launch native viewers, or expose payload bytes through MCP resources.
 The ordinary MCP evidence resource is a structurally allowlisted projection: full argv,
 environment values, working directories, source paths, and scratch paths remain available only
 through explicit local canonical-manifest inspection.
+
+The same rule applies to failures. MCP messages use stable, path-free summaries for unexpected I/O
+and dependency errors and do not include raw exception strings. Local exception chaining retains the
+cause for debugging without making it part of the agent-visible contract.

--- a/docs/storage-and-evidence.md
+++ b/docs/storage-and-evidence.md
@@ -43,6 +43,11 @@ analysis requests, the evidence-episode timestamp, data-file digests, coverage,
 and limitations. Process-local handles such as `analysis_id` and continuation
 tokens are excluded from preserved data.
 
+Content identity does not establish schema validity. Readers parse the complete manifest shape,
+including nested capture targets, executions, analysis inputs, offsets, and failure records, before
+querying or projecting it. A self-consistent manifest with a correctly recomputed evidence ID but an
+invalid nested request is repository corruption.
+
 The stored envelope adds `format_version` and `evidence_id`. The canonical manifest remains the
 local repository and CLI contract. MCP resources expose a separate redacted projection so durable
 provenance is not confused with agent-visible metadata:
@@ -78,6 +83,10 @@ is provably dead.
 inventory digest before filtering. A continuation is bound to that inventory;
 mutation makes it stale rather than silently changing the page. Filters cover
 evidence kind, capability, provider, input digest, and time bounds.
+
+Cursor offsets are strict non-negative integers and must identify an item inside the bound
+inventory. An offset at or beyond the inventory end is invalid rather than an empty successful
+page; an empty page therefore means that the valid remaining inventory contains no matches.
 
 `flameox://evidence/{evidence_id}` validates the canonical manifest and returns its redacted MCP
 projection. `flameox evidence show` remains the explicit local administrative view of the full

--- a/src/flameox/adapters/sarif.py
+++ b/src/flameox/adapters/sarif.py
@@ -68,6 +68,7 @@ class SarifCoverage:
 @dataclass(frozen=True, slots=True)
 class SarifParseResult:
     supported: bool
+    complete: bool
     candidates: tuple[SarifCandidate, ...]
     analyzers: tuple[SarifAnalyzer, ...]
     exit_status: int | None
@@ -327,6 +328,7 @@ def _normalize_document(
         limitations.append("Only provider-native SARIF 2.1.0 reports can be normalized.")
         return SarifParseResult(
             supported=False,
+            complete=parse_error is None and document.root_finished,
             candidates=(),
             analyzers=(),
             exit_status=None,
@@ -373,6 +375,7 @@ def _normalize_document(
         limitations.append("SARIF runs reported multiple analyzer exit statuses.")
     return SarifParseResult(
         supported=True,
+        complete=parse_error is None and document.root_finished,
         candidates=tuple(normalization.candidates),
         analyzers=tuple(document.analyzers),
         exit_status=exit_status,

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -402,6 +402,8 @@ def create_server(
                 return _failure(
                     RuntimeFailure("DECODE_FAILURE", "Input could not be decoded during analysis.")
                 )
+            except Exception:
+                return _failure(RuntimeFailure("ANALYSIS_FAILURE", "Analysis failed unexpectedly."))
 
         # MCP SDK 2.0 derives schemas and diagnostic names from the registered callable.
         handler.__name__ = analysis_tool_name(capability)

--- a/src/flameox/mcp/server.py
+++ b/src/flameox/mcp/server.py
@@ -195,11 +195,17 @@ def _success_summary(value: dict[str, Any], *, resource: ResourceLink | None) ->
         state = "complete" if complete else "bounded or incomplete"
         continuation = value.get("continuation")
         preserved = value.get("preserved")
+        truncation = value.get("truncation")
+        provider_limited = (
+            isinstance(truncation, dict) and truncation.get("reason") == "provider_limit"
+        )
         next_action = (
             "follow the returned evidence resource"
             if resource is not None or isinstance(preserved, dict)
             else "request the continuation page"
             if isinstance(continuation, str)
+            else "narrow the semantic query or recapture; no continuation is available"
+            if provider_limited
             else "preserve the session analysis if durable evidence is needed"
         )
         return (
@@ -388,8 +394,14 @@ def create_server(
                 )
             except RuntimeFailure as error:
                 return _failure(error)
-            except (OSError, ValueError, json.JSONDecodeError) as error:
-                return _failure(RuntimeFailure("DECODE_FAILURE", str(error)))
+            except OSError:
+                return _failure(
+                    RuntimeFailure("DECODE_FAILURE", "Input could not be read during analysis.")
+                )
+            except (ValueError, json.JSONDecodeError):
+                return _failure(
+                    RuntimeFailure("DECODE_FAILURE", "Input could not be decoded during analysis.")
+                )
 
         # MCP SDK 2.0 derives schemas and diagnostic names from the registered callable.
         handler.__name__ = analysis_tool_name(capability)
@@ -493,9 +505,12 @@ def create_server(
                 return _failure(error)
             except asyncio.CancelledError:
                 raise
-            except Exception as error:
+            except Exception:
                 return _failure(
-                    RuntimeFailure("EXECUTION_FAILURE", str(error) or type(error).__name__)
+                    RuntimeFailure(
+                        "EXECUTION_FAILURE",
+                        "Capture failed unexpectedly without trustworthy evidence.",
+                    )
                 )
 
         handler.__name__ = capture_tool_name(capability)

--- a/src/flameox/providers/aiperf.py
+++ b/src/flameox/providers/aiperf.py
@@ -7,7 +7,9 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from flameox.canonical import digest_model
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
+from flameox.providers.inference_comparison import assess_comparison
 from flameox.workers.aiperf_contract import (
     AIPERF_WORKER,
     AIPerfProjectionRow,
@@ -51,6 +53,20 @@ class AIPerfProvider:
             int(value) for row in successful if (value := row.get("latency_ns")) is not None
         ]
         ttfts = [int(value) for row in successful if (value := row.get("ttft_ns")) is not None]
+        scheduled = [int(value) for row in rows if (value := row.get("scheduled_ns")) is not None]
+        first_scheduled = min(scheduled) if scheduled else None
+        workload = [
+            {
+                "input_tokens": row["input_tokens"],
+                "output_tokens": row["output_tokens"],
+                "scheduled_offset_ns": (
+                    int(row["scheduled_ns"]) - first_scheduled
+                    if first_scheduled is not None and row.get("scheduled_ns") is not None
+                    else None
+                ),
+            }
+            for row in rows
+        ]
         limitations = [
             "Prompt and response bodies are intentionally excluded from normalized evidence."
         ]
@@ -69,6 +85,12 @@ class AIPerfProvider:
                         "output_tokens": sum(int(row["output_tokens"]) for row in rows),
                         "median_ttft_ns": statistics.median(ttfts) if ttfts else None,
                         "p95_latency_ns": self._percentile(latencies, 0.95),
+                        "comparison_identity": {
+                            "workload": digest_model(
+                                workload, projection="flameox.inference.workload/v1"
+                            )
+                        },
+                        "comparison_identity_unavailable": ["system"],
                     },
                 },
                 {"type": "table", "rows": rows},
@@ -139,6 +161,9 @@ class AIPerfProvider:
                 "INVALID_INPUT", f"Every input must contain successful {metric} observations"
             )
         baseline = statistics.fmean(series[baseline_index])
+        compatibility, identity_differences, identity_unavailable = assess_comparison(
+            analyses, arguments
+        )
         rows: list[dict[str, Any]] = []
         for index, values in enumerate(series):
             if index == baseline_index:
@@ -154,6 +179,9 @@ class AIPerfProvider:
                     "ratio": candidate / baseline if baseline else None,
                     "baseline_samples": len(series[baseline_index]),
                     "candidate_samples": len(values),
+                    "compatibility": compatibility,
+                    "identity_differences": identity_differences,
+                    "identity_unavailable": identity_unavailable,
                 }
             )
         return ProviderAnalysis(
@@ -162,14 +190,29 @@ class AIPerfProvider:
             blocks=[
                 {
                     "type": "metrics",
-                    "values": {"input_count": len(analyses), "metric": metric},
+                    "values": {
+                        "input_count": len(analyses),
+                        "metric": metric,
+                        "compatibility": compatibility,
+                        "identity_differences": identity_differences,
+                        "identity_unavailable": identity_unavailable,
+                    },
                 },
                 {"type": "table", "rows": rows[:max_rows]},
             ],
             rows_observed=len(rows),
             complete=len(rows) <= max_rows,
             limitations=[
-                "Ratios compare arithmetic means of successful prompt-free request projections."
+                "Ratios compare arithmetic means of successful prompt-free request projections.",
+                "The inference system identity is unavailable from AIPerf request records.",
+                *(
+                    [
+                        "Known-different identities were compared only because heterogeneous "
+                        "mode was explicit."
+                    ]
+                    if compatibility == "heterogeneous"
+                    else []
+                ),
             ],
         )
 

--- a/src/flameox/providers/benchmark_scaling.py
+++ b/src/flameox/providers/benchmark_scaling.py
@@ -48,8 +48,8 @@ def scaling_projection(
         )
         identity = (benchmark, unit, dimension_identity)
         identity_dimensions[identity] = non_axis_dimensions
-        sample_sum = row.get("sample_sum")
-        sample_count = row.get("sample_count")
+        sample_sum = row.get("positive_sample_sum", row.get("sample_sum"))
+        sample_count = row.get("positive_sample_count", row.get("sample_count"))
         value = row.get("value_int") if sample_sum is None else sample_sum
         if value is None:
             value = row.get("value_float")

--- a/src/flameox/providers/benchmark_scaling.py
+++ b/src/flameox/providers/benchmark_scaling.py
@@ -22,8 +22,8 @@ def scaling_projection(
 
     input_dimension = str(arguments["input_dimension"])
     requested_metric = arguments.get("metric")
-    series: dict[tuple[str, str, str], dict[float, list[float]]] = defaultdict(
-        lambda: defaultdict(list)
+    series: dict[tuple[str, str, str], dict[float, tuple[float, int]]] = defaultdict(
+        lambda: defaultdict(lambda: (0.0, 0))
     )
     identity_dimensions: dict[tuple[str, str, str], dict[str, Any]] = {}
     omitted_measurements = 0
@@ -48,32 +48,42 @@ def scaling_projection(
         )
         identity = (benchmark, unit, dimension_identity)
         identity_dimensions[identity] = non_axis_dimensions
-        value = row.get("value_int")
+        sample_sum = row.get("sample_sum")
+        sample_count = row.get("sample_count")
+        value = row.get("value_int") if sample_sum is None else sample_sum
         if value is None:
             value = row.get("value_float")
+        count = sample_count if sample_sum is not None else 1
         if (
             not isinstance(raw_input, str | int | float)
             or isinstance(raw_input, bool)
             or not isinstance(value, str | int | float)
             or isinstance(value, bool)
+            or not isinstance(count, int)
+            or isinstance(count, bool)
+            or count <= 0
         ):
             omitted_measurements += 1
             continue
         try:
             input_value = float(raw_input)
-            measurement = float(value)
+            measurement_total = float(value)
         except ValueError:
             omitted_measurements += 1
             continue
         if (
             not math.isfinite(input_value)
-            or not math.isfinite(measurement)
+            or not math.isfinite(measurement_total)
             or input_value <= 0
-            or measurement <= 0
+            or measurement_total / count <= 0
         ):
             omitted_measurements += 1
             continue
-        series[identity][input_value].append(measurement)
+        prior_total, prior_count = series[identity][input_value]
+        series[identity][input_value] = (
+            prior_total + measurement_total,
+            prior_count + count,
+        )
 
     output: list[dict[str, Any]] = []
     estimated = 0
@@ -81,7 +91,7 @@ def scaling_projection(
         benchmark, unit, _dimension_identity = identity
         dimensions = identity_dimensions[identity]
         points = sorted(
-            (input_value, fmean(values)) for input_value, values in series[identity].items()
+            (input_value, total / count) for input_value, (total, count) in series[identity].items()
         )
         if len(points) < 2:
             output.append(

--- a/src/flameox/providers/benchmarks.py
+++ b/src/flameox/providers/benchmarks.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from statistics import fmean
 from typing import Any
 
+from flameox.canonical import canonical_bytes
 from flameox.providers.benchmark_scaling import scaling_projection
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 from flameox.workers.benchmark_samples_contract import (
@@ -13,6 +13,8 @@ from flameox.workers.benchmark_samples_contract import (
 )
 from flameox.workers.harness import IsolatedWorkerHarness
 from flameox.workers.pyperf_contract import PYPERF_WORKER, PyperfWorkerRequest, PyperfWorkerResult
+
+_MAX_AGGREGATE_SERIES = 100_000
 
 
 class BenchmarkProvider:
@@ -52,7 +54,20 @@ class BenchmarkProvider:
         parsed = [
             self.harness.run_typed_sync(
                 PYPERF_WORKER,
-                PyperfWorkerRequest(artifact_path=str(path), max_rows=max_rows),
+                PyperfWorkerRequest(
+                    artifact_path=str(path),
+                    max_rows=(
+                        _MAX_AGGREGATE_SERIES
+                        if capability_id in {"benchmark.compare", "benchmark.scaling"}
+                        else max_rows
+                    ),
+                    projection=(
+                        "series"
+                        if capability_id in {"benchmark.compare", "benchmark.scaling"}
+                        else "samples"
+                    ),
+                    metric=arguments.get("metric"),
+                ),
                 timeout_seconds=timeout_seconds,
                 maximum_rss_bytes=maximum_rss_bytes,
                 maximum_writable_growth_bytes=maximum_output_bytes,
@@ -65,7 +80,7 @@ class BenchmarkProvider:
             if any(result.truncated for result in parsed):
                 raise ProviderFailure(
                     "LIMIT_EXCEEDED",
-                    "benchmark.scaling requires complete samples; raise the startup row limit",
+                    "benchmark.scaling exceeds the bounded semantic-series limit",
                 )
             return scaling_projection(
                 [dict(row) for result in parsed for row in result.rows],
@@ -116,10 +131,30 @@ class BenchmarkProvider:
         maximum_rss_bytes: int,
         maximum_output_bytes: int,
     ) -> ProviderAnalysis:
+        projection_arguments = (
+            compare_arguments if compare_arguments is not None else scaling_arguments
+        )
         parsed = [
             self.harness.run_typed_sync(
                 BENCHMARK_SAMPLES_WORKER,
-                BenchmarkSamplesWorkerRequest(artifact_path=str(path), max_rows=max_rows),
+                BenchmarkSamplesWorkerRequest(
+                    artifact_path=str(path),
+                    max_rows=(
+                        _MAX_AGGREGATE_SERIES
+                        if compare_arguments is not None or scaling_arguments is not None
+                        else max_rows
+                    ),
+                    projection=(
+                        "series"
+                        if compare_arguments is not None or scaling_arguments is not None
+                        else "samples"
+                    ),
+                    metric=(
+                        projection_arguments.get("metric")
+                        if projection_arguments is not None
+                        else None
+                    ),
+                ),
                 timeout_seconds=timeout_seconds,
                 maximum_rss_bytes=maximum_rss_bytes,
                 maximum_writable_growth_bytes=maximum_output_bytes,
@@ -130,7 +165,7 @@ class BenchmarkProvider:
             if any(item.truncated for item in parsed):
                 raise ProviderFailure(
                     "LIMIT_EXCEEDED",
-                    "benchmark.compare requires complete samples; raise the startup row limit",
+                    "benchmark.compare exceeds the bounded semantic-series limit",
                 )
             return self._compare_row_sets(
                 [item.rows for item in parsed],
@@ -143,7 +178,7 @@ class BenchmarkProvider:
             if any(item.truncated for item in parsed):
                 raise ProviderFailure(
                     "LIMIT_EXCEEDED",
-                    "benchmark.scaling requires complete samples; raise the startup row limit",
+                    "benchmark.scaling exceeds the bounded semantic-series limit",
                 )
             return scaling_projection(
                 [dict(row) for result in parsed for row in result.rows],
@@ -202,33 +237,62 @@ class BenchmarkProvider:
         if baseline_index >= len(row_sets):
             raise ProviderFailure("INVALID_INPUT", "baseline_index does not select an input")
         requested_metric = arguments.get("metric")
-        series: list[dict[tuple[str, str], list[float]]] = []
+        series: list[dict[bytes, tuple[float, int]]] = []
+        identities: list[dict[bytes, dict[str, Any]]] = []
         for rows in row_sets:
-            values: dict[tuple[str, str], list[float]] = {}
+            values: dict[bytes, tuple[float, int]] = {}
+            members: dict[bytes, dict[str, Any]] = {}
             for row in rows:
                 if row["is_warmup"]:
                     continue
-                identity = (str(row["benchmark"]), str(row["unit"]))
-                if requested_metric is not None and identity[0] != requested_metric:
+                identity = {
+                    "benchmark": str(row["benchmark"]),
+                    "unit": str(row["unit"]),
+                    "dimensions": dict(row.get("dimensions", {})),
+                    "scope": row.get("scope"),
+                    "phase": row.get("phase"),
+                    "loop_count": row.get("loop_count"),
+                }
+                if requested_metric is not None and identity["benchmark"] != requested_metric:
                     continue
-                value = row["value_int"] if row["value_int"] is not None else row["value_float"]
-                if isinstance(value, int | float) and not isinstance(value, bool):
-                    values.setdefault(identity, []).append(float(value))
+                sample_sum = row.get("sample_sum")
+                sample_count = row.get("sample_count")
+                value = (
+                    (row["value_int"] if row["value_int"] is not None else row["value_float"])
+                    if sample_sum is None
+                    else sample_sum
+                )
+                count = sample_count if sample_sum is not None else 1
+                if (
+                    isinstance(value, int | float)
+                    and not isinstance(value, bool)
+                    and isinstance(count, int)
+                    and not isinstance(count, bool)
+                    and count > 0
+                ):
+                    key = canonical_bytes(identity)
+                    total, prior_count = values.get(key, (0.0, 0))
+                    values[key] = total + float(value), prior_count + count
+                    members[key] = identity
             series.append(values)
+            identities.append(members)
         common = set(series[baseline_index])
         for values in series:
             common.intersection_update(values)
+        all_identities = set().union(*(set(values) for values in series))
+        unmatched = all_identities.difference(common)
         output: list[dict[str, Any]] = []
         baseline = series[baseline_index]
-        for identity in sorted(common):
-            baseline_mean = fmean(baseline[identity])
+        for key in sorted(common):
+            baseline_total, baseline_count = baseline[key]
+            baseline_mean = baseline_total / baseline_count
             for input_index, values in enumerate(series):
                 if input_index != baseline_index:
-                    candidate_mean = fmean(values[identity])
+                    candidate_total, candidate_count = values[key]
+                    candidate_mean = candidate_total / candidate_count
                     output.append(
                         {
-                            "benchmark": identity[0],
-                            "unit": identity[1],
+                            **identities[baseline_index][key],
                             "baseline_index": baseline_index,
                             "candidate_index": input_index,
                             "baseline_mean": baseline_mean,
@@ -245,6 +309,7 @@ class BenchmarkProvider:
                     "values": {
                         "input_count": len(row_sets),
                         "compatible_metric_count": len(common),
+                        "unmatched_identity_count": len(unmatched),
                     },
                 },
                 {"type": "table", "rows": output[:max_rows]},
@@ -252,7 +317,12 @@ class BenchmarkProvider:
             rows_observed=len(output),
             complete=len(output) <= max_rows,
             limitations=[
-                "Ratios summarize observed sample means and do not establish causal improvement."
+                "Ratios summarize observed sample means and do not establish causal improvement.",
+                *(
+                    ["Series absent from one or more inputs were not compared."]
+                    if unmatched
+                    else []
+                ),
             ],
         )
 
@@ -265,7 +335,7 @@ class BenchmarkProvider:
         if any(result.truncated for result in parsed):
             raise ProviderFailure(
                 "LIMIT_EXCEEDED",
-                "benchmark.compare requires complete samples; raise the startup row limit",
+                "benchmark.compare exceeds the bounded semantic-series limit",
             )
         return BenchmarkProvider._compare_row_sets(
             [result.rows for result in parsed],

--- a/src/flameox/providers/capture.py
+++ b/src/flameox/providers/capture.py
@@ -145,6 +145,21 @@ def _node_cpu(request: CaptureBuildRequest, _: ManagedExecutable) -> CaptureInvo
     return CaptureInvocation(argv, request.environment, ((output, "cpuprofile", "cpu-profile"),))
 
 
+def _node_heap(request: CaptureBuildRequest, _: ManagedExecutable) -> CaptureInvocation:
+    _arguments(request, EmptyArguments)
+    output = request.directory / "profile.heapprofile"
+    argv = (
+        request.target_argv[0],
+        "--heap-prof",
+        f"--heap-prof-dir={request.directory}",
+        f"--heap-prof-name={output.name}",
+        *request.target_argv[1:],
+    )
+    return CaptureInvocation(
+        argv, request.environment, ((output, "heapprofile", "memory-profile"),)
+    )
+
+
 def _benchmark_samples(request: CaptureBuildRequest, _: ManagedExecutable) -> CaptureInvocation:
     arguments = cast(
         BenchmarkSamplesCaptureArguments,
@@ -406,6 +421,7 @@ CAPTURE_BUILDERS: dict[str, CaptureBuilder] = {
     "direct": _direct,
     "memray": _memray,
     "node-cpu-profile": _node_cpu,
+    "node-heap-profile": _node_heap,
     "nsight-compute": _nsight_compute,
     "nsight-systems": _nsight_systems,
     "nvbench": _nvbench,

--- a/src/flameox/providers/cpu.py
+++ b/src/flameox/providers/cpu.py
@@ -12,6 +12,12 @@ _MAX_PROFILE_BYTES = 64 * 1024 * 1024
 _MAX_FRAMES = 100_000
 _MAX_SAMPLES = 1_000_000
 _MAX_LINE_BYTES = 256 * 1024
+_SPEEDSCOPE_TIME_SCALES = {
+    "nanoseconds": 1e-9,
+    "microseconds": 1e-6,
+    "milliseconds": 1e-3,
+    "seconds": 1.0,
+}
 
 
 class CpuProfileProvider:
@@ -47,6 +53,7 @@ class CpuProfileProvider:
         inclusive_weights: defaultdict[int, float] = defaultdict(float)
         sample_count = 0
         unresolved_sample_count = 0
+        weight_units: set[str] = set()
         for profile_value in profiles:
             profile = _object(profile_value, "Speedscope sampled profile")
             if profile.get("type") != "sampled":
@@ -61,6 +68,13 @@ class CpuProfileProvider:
                 raise ProviderFailure("DECODE_FAILURE", "Speedscope samples are invalid")
             if weights is not None and len(weights) != len(samples):
                 raise ProviderFailure("DECODE_FAILURE", "Speedscope weights do not match samples")
+            weight_unit, weight_scale = _speedscope_weight_unit(profile.get("unit", "none"))
+            weight_units.add(weight_unit)
+            if len(weight_units) > 1:
+                raise ProviderFailure(
+                    "UNSUPPORTED_FORMAT",
+                    "Speedscope CPU profiles cannot mix time weights with sample counts",
+                )
             sample_count += len(samples)
             if sample_count > _MAX_SAMPLES:
                 raise ProviderFailure("LIMIT_EXCEEDED", "Speedscope sample count exceeds the limit")
@@ -71,7 +85,9 @@ class CpuProfileProvider:
                     unresolved_sample_count += 1
                     continue
                 stack = [_frame_index(value, len(normalized_frames)) for value in stack_value]
-                weight = 1.0 if weights is None else _number(weights[sample_index], "sample weight")
+                weight = (
+                    1.0 if weights is None else _number(weights[sample_index], "sample weight")
+                ) * weight_scale
                 self_weights[stack[-1]] += weight
                 for frame_index in set(stack):
                     inclusive_weights[frame_index] += weight
@@ -80,6 +96,7 @@ class CpuProfileProvider:
                 **normalized_frames[index],
                 "self_weight": self_weights[index],
                 "inclusive_weight": inclusive_weights[index],
+                "unit": next(iter(weight_units)),
             }
             for index in inclusive_weights
         ]
@@ -96,7 +113,11 @@ class CpuProfileProvider:
                 f"{unresolved_sample_count} of {sample_count} samples had no resolved Python "
                 "frames and were excluded from frame aggregation."
             )
-        metrics = {"frame_count": len(frames), "sample_count": sample_count}
+        metrics = {
+            "frame_count": len(frames),
+            "sample_count": sample_count,
+            "weight_unit": next(iter(weight_units)),
+        }
         if unresolved_sample_count:
             metrics["unresolved_sample_count"] = unresolved_sample_count
         return ProviderAnalysis(
@@ -175,6 +196,19 @@ def _object(value: object, subject: str) -> dict[str, Any]:
     return cast(dict[str, Any], value)
 
 
+def _speedscope_weight_unit(value: object) -> tuple[str, float]:
+    if value == "bytes":
+        raise ProviderFailure(
+            "UNSUPPORTED_FORMAT",
+            "Byte-weighted Speedscope profiles are not CPU hotspot evidence",
+        )
+    if value == "none":
+        return "samples", 1.0
+    if isinstance(value, str) and value in _SPEEDSCOPE_TIME_SCALES:
+        return "seconds", _SPEEDSCOPE_TIME_SCALES[value]
+    raise ProviderFailure("DECODE_FAILURE", "Speedscope weight unit is invalid")
+
+
 def _frame(value: object, index: int) -> dict[str, Any]:
     frame = _object(value, "Speedscope frame")
     name = frame.get("name")
@@ -198,7 +232,10 @@ def _frame_index(value: object, frame_count: int) -> int:
 def _number(value: object, subject: str) -> float:
     if not isinstance(value, int | float) or isinstance(value, bool):
         raise ProviderFailure("DECODE_FAILURE", f"{subject} is invalid")
-    result = float(value)
+    try:
+        result = float(value)
+    except OverflowError as error:
+        raise ProviderFailure("DECODE_FAILURE", f"{subject} is invalid") from error
     if not math.isfinite(result) or result < 0:
         raise ProviderFailure("DECODE_FAILURE", f"{subject} is invalid")
     return result

--- a/src/flameox/providers/inference_comparison.py
+++ b/src/flameox/providers/inference_comparison.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from flameox.canonical import canonical_bytes
+from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
+
+type Compatibility = Literal["compatible", "partial", "heterogeneous"]
+
+
+def comparison_identity(analysis: ProviderAnalysis) -> tuple[dict[str, Any], set[str]]:
+    metrics = analysis.blocks[0].get("values", {}) if analysis.blocks else {}
+    if not isinstance(metrics, dict):
+        return {}, {"system", "workload"}
+    identity = metrics.get("comparison_identity", {})
+    unavailable = metrics.get("comparison_identity_unavailable", [])
+    return (
+        dict(identity) if isinstance(identity, dict) else {},
+        {str(field) for field in unavailable if isinstance(field, str)}
+        if isinstance(unavailable, list)
+        else {"system", "workload"},
+    )
+
+
+def assess_comparison(
+    analyses: Sequence[ProviderAnalysis], arguments: Mapping[str, Any]
+) -> tuple[Compatibility, dict[str, list[Any | None]], list[str]]:
+    observed = [comparison_identity(analysis) for analysis in analyses]
+    fields = set().union(*(set(identity) | unavailable for identity, unavailable in observed))
+    differences: dict[str, list[Any | None]] = {}
+    unavailable_fields: set[str] = set()
+    for field in sorted(fields):
+        values = [identity.get(field) for identity, _unavailable in observed]
+        present = [value for value in values if value is not None]
+        if len(present) != len(values):
+            unavailable_fields.add(field)
+        if len({canonical_bytes(value) for value in present}) > 1:
+            differences[field] = values
+
+    allow_heterogeneous = arguments.get("allow_heterogeneous") is True
+    if differences and not allow_heterogeneous:
+        raise ProviderFailure(
+            "INVALID_INPUT",
+            "Inference inputs have incompatible observed identities; set "
+            "allow_heterogeneous=true for an explicitly exploratory comparison",
+            details={"differing_fields": sorted(differences)},
+        )
+    compatibility: Compatibility = (
+        "heterogeneous" if differences else "partial" if unavailable_fields else "compatible"
+    )
+    return compatibility, differences, sorted(unavailable_fields)

--- a/src/flameox/providers/inference_comparison.py
+++ b/src/flameox/providers/inference_comparison.py
@@ -3,10 +3,28 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal
 
-from flameox.canonical import canonical_bytes
+from flameox.canonical import canonical_bytes, digest_model
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 
 type Compatibility = Literal["compatible", "partial", "heterogeneous"]
+
+
+def field_identities(
+    groups: Mapping[str, tuple[Mapping[str, Any], Sequence[str]]],
+) -> tuple[dict[str, str], list[str]]:
+    """Digest identity fields independently so absent metadata remains distinguishable."""
+    identity: dict[str, str] = {}
+    unavailable: list[str] = []
+    for group, (values, fields) in groups.items():
+        for field in fields:
+            name = f"{group}.{field}"
+            if field not in values:
+                unavailable.append(name)
+                continue
+            identity[name] = digest_model(
+                {field: values[field]}, projection=f"flameox.inference.{name}/v1"
+            )
+    return identity, unavailable
 
 
 def comparison_identity(analysis: ProviderAnalysis) -> tuple[dict[str, Any], set[str]]:

--- a/src/flameox/providers/inference_exports.py
+++ b/src/flameox/providers/inference_exports.py
@@ -10,9 +10,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-from flameox.canonical import canonical_bytes, digest_model, sha256_id
+from flameox.canonical import canonical_bytes, sha256_id
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
-from flameox.providers.inference_comparison import assess_comparison
+from flameox.providers.inference_comparison import assess_comparison, field_identities
 
 _VLLM_MAX_BYTES = 16 * 1024 * 1024
 _SGLANG_MAX_BYTES = 1024 * 1024
@@ -225,10 +225,13 @@ class InferenceExportProvider:
                 "num_prompts",
             ),
         )
-        system = {
-            name: observed[name]
-            for name in ("model", "served_model_name", "tokenizer", "backend")
-            if name in observed
+        system: dict[str, Any] = {
+            **(
+                {"model": observed.get("model", observed.get("served_model_name"))}
+                if "model" in observed or "served_model_name" in observed
+                else {}
+            ),
+            **{name: observed[name] for name in ("tokenizer", "backend") if name in observed},
         }
         workload: dict[str, Any] = {
             "total_requests": document.total_requests,
@@ -241,16 +244,24 @@ class InferenceExportProvider:
                 if name in observed
             },
         }
-        comparison_identity = {
-            "workload": digest_model(workload, projection="flameox.inference.workload/v1")
-        }
-        unavailable: list[str] = []
-        if system:
-            comparison_identity["system"] = digest_model(
-                system, projection="flameox.inference.system/v1"
-            )
-        else:
-            unavailable.append("system")
+        comparison_identity, unavailable = field_identities(
+            {
+                "system": (system, ("model", "tokenizer", "backend")),
+                "workload": (
+                    workload,
+                    (
+                        "total_requests",
+                        "total_input_tokens",
+                        "total_output_tokens",
+                        "time_scale",
+                        "dataset_name",
+                        "request_rate",
+                        "max_concurrency",
+                        "num_prompts",
+                    ),
+                ),
+            }
+        )
         rows: list[dict[str, Any]] = []
 
         def add(name: str, value: int | float | None, unit: str, aggregation: str) -> None:
@@ -365,7 +376,7 @@ class InferenceExportProvider:
                 "max_concurrency",
             ),
         )
-        system = {
+        system: dict[str, Any] = {
             name: observed[name] for name in ("model", "tokenizer", "backend") if name in observed
         }
         workload: dict[str, Any] = {
@@ -386,16 +397,24 @@ class InferenceExportProvider:
                 if name in observed
             }
         )
-        comparison_identity = {
-            "workload": digest_model(workload, projection="flameox.inference.workload/v1")
-        }
-        unavailable: list[str] = []
-        if system:
-            comparison_identity["system"] = digest_model(
-                system, projection="flameox.inference.system/v1"
-            )
-        else:
-            unavailable.append("system")
+        comparison_identity, unavailable = field_identities(
+            {
+                "system": (system, ("model", "tokenizer", "backend")),
+                "workload": (
+                    workload,
+                    (
+                        "completed",
+                        "num_prompts",
+                        "total_input_tokens",
+                        "total_output_tokens",
+                        "concurrency",
+                        "dataset_name",
+                        "request_rate",
+                        "max_concurrency",
+                    ),
+                ),
+            }
+        )
         return ProviderAnalysis(
             provider_id="sglang-benchmark",
             provider_version="aggregate-v1",

--- a/src/flameox/providers/inference_exports.py
+++ b/src/flameox/providers/inference_exports.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import statistics
@@ -9,7 +10,9 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from flameox.canonical import canonical_bytes, digest_model, sha256_id
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
+from flameox.providers.inference_comparison import assess_comparison
 
 _VLLM_MAX_BYTES = 16 * 1024 * 1024
 _SGLANG_MAX_BYTES = 1024 * 1024
@@ -90,6 +93,21 @@ class _VllmDocument(_Model):
         if not math.isfinite(self.actual_duration) or not math.isfinite(self.time_scale):
             raise ValueError("duration and time scale must be finite")
         return self
+
+
+def _observed_scalars(payload: Mapping[str, Any], names: Sequence[str]) -> dict[str, Any]:
+    observed: dict[str, Any] = {}
+    for name in names:
+        value = payload.get(name)
+        is_text = isinstance(value, str) and bool(value) and len(value) <= 4_096
+        is_number = (
+            isinstance(value, int | float)
+            and not isinstance(value, bool)
+            and math.isfinite(float(value))
+        )
+        if is_text or is_number:
+            observed[name] = value
+    return observed
 
 
 _SGLANG_REQUIRED = {"duration", "completed", "total_input_tokens", "total_output_tokens"}
@@ -194,6 +212,45 @@ class InferenceExportProvider:
         except ValidationError as error:
             raise ProviderFailure("DECODE_FAILURE", "Invalid vLLM benchmark export") from error
         metrics = document.metrics
+        observed = _observed_scalars(
+            payload,
+            (
+                "model",
+                "served_model_name",
+                "tokenizer",
+                "backend",
+                "dataset_name",
+                "request_rate",
+                "max_concurrency",
+                "num_prompts",
+            ),
+        )
+        system = {
+            name: observed[name]
+            for name in ("model", "served_model_name", "tokenizer", "backend")
+            if name in observed
+        }
+        workload: dict[str, Any] = {
+            "total_requests": document.total_requests,
+            "total_input_tokens": metrics.total_input,
+            "total_output_tokens": metrics.total_output,
+            "time_scale": document.time_scale,
+            **{
+                name: observed[name]
+                for name in ("dataset_name", "request_rate", "max_concurrency", "num_prompts")
+                if name in observed
+            },
+        }
+        comparison_identity = {
+            "workload": digest_model(workload, projection="flameox.inference.workload/v1")
+        }
+        unavailable: list[str] = []
+        if system:
+            comparison_identity["system"] = digest_model(
+                system, projection="flameox.inference.system/v1"
+            )
+        else:
+            unavailable.append("system")
         rows: list[dict[str, Any]] = []
 
         def add(name: str, value: int | float | None, unit: str, aggregation: str) -> None:
@@ -258,6 +315,8 @@ class InferenceExportProvider:
                         "successful_requests": document.successful_requests,
                         "failed_requests": document.failed_requests,
                         "measurement_count": len(rows),
+                        "comparison_identity": comparison_identity,
+                        "comparison_identity_unavailable": unavailable,
                     },
                 },
                 {"type": "table", "rows": returned},
@@ -295,6 +354,48 @@ class InferenceExportProvider:
         except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
             raise ProviderFailure("DECODE_FAILURE", "Invalid aggregate SGLang export") from error
         rows = [self._sglang_row(name, selected[name]) for name in sorted(selected)]
+        observed = _observed_scalars(
+            payload,
+            (
+                "model",
+                "tokenizer",
+                "backend",
+                "dataset_name",
+                "request_rate",
+                "max_concurrency",
+            ),
+        )
+        system = {
+            name: observed[name] for name in ("model", "tokenizer", "backend") if name in observed
+        }
+        workload: dict[str, Any] = {
+            name: selected[name]
+            for name in (
+                "completed",
+                "num_prompts",
+                "total_input_tokens",
+                "total_output_tokens",
+                "concurrency",
+            )
+            if name in selected
+        }
+        workload.update(
+            {
+                name: observed[name]
+                for name in ("dataset_name", "request_rate", "max_concurrency")
+                if name in observed
+            }
+        )
+        comparison_identity = {
+            "workload": digest_model(workload, projection="flameox.inference.workload/v1")
+        }
+        unavailable: list[str] = []
+        if system:
+            comparison_identity["system"] = digest_model(
+                system, projection="flameox.inference.system/v1"
+            )
+        else:
+            unavailable.append("system")
         return ProviderAnalysis(
             provider_id="sglang-benchmark",
             provider_version="aggregate-v1",
@@ -304,6 +405,8 @@ class InferenceExportProvider:
                     "values": {
                         "completed_requests": int(selected["completed"]),
                         "measurement_count": len(rows),
+                        "comparison_identity": comparison_identity,
+                        "comparison_identity_unavailable": unavailable,
                     },
                 },
                 {"type": "table", "rows": rows[:max_rows]},
@@ -348,6 +451,7 @@ class InferenceExportProvider:
         first_timestamp: int | None = None
         max_input_length = 0
         max_output_length = 0
+        workload_digest = hashlib.sha256()
         try:
             with path.open("rb") as stream:
                 for line_index, raw in enumerate(stream):
@@ -367,6 +471,17 @@ class InferenceExportProvider:
                     observed += 1
                     max_input_length = max(max_input_length, int(row["input_length"]))
                     max_output_length = max(max_output_length, int(row["output_length"]))
+                    workload_digest.update(
+                        canonical_bytes(
+                            [
+                                row["timestamp_ms"],
+                                row["input_length"],
+                                row["output_length"],
+                                row["prefix_hash_count"],
+                            ]
+                        )
+                        + b"\n"
+                    )
                     if len(rows) < max_rows:
                         rows.append(row)
         except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
@@ -387,6 +502,8 @@ class InferenceExportProvider:
                         "request_count": observed,
                         "max_input_length": max_input_length,
                         "max_output_length": max_output_length,
+                        "comparison_identity": {"workload": sha256_id(workload_digest.hexdigest())},
+                        "comparison_identity_unavailable": ["system"],
                     },
                 },
                 {"type": "table", "rows": rows},
@@ -452,6 +569,9 @@ class InferenceExportProvider:
                 "INVALID_INPUT", f"Every input must expose the numeric metric {metric}"
             )
         baseline = statistics.fmean(series[baseline_index])
+        compatibility, identity_differences, identity_unavailable = assess_comparison(
+            analyses, arguments
+        )
         rows = []
         for index, values in enumerate(series):
             if index == baseline_index:
@@ -467,18 +587,45 @@ class InferenceExportProvider:
                     "ratio": candidate / baseline if baseline else None,
                     "baseline_samples": len(series[baseline_index]),
                     "candidate_samples": len(values),
+                    "compatibility": compatibility,
+                    "identity_differences": identity_differences,
+                    "identity_unavailable": identity_unavailable,
                 }
             )
         return ProviderAnalysis(
             provider_id=format_name,
             provider_version=analyses[0].provider_version,
             blocks=[
-                {"type": "metrics", "values": {"input_count": len(analyses), "metric": metric}},
+                {
+                    "type": "metrics",
+                    "values": {
+                        "input_count": len(analyses),
+                        "metric": metric,
+                        "compatibility": compatibility,
+                        "identity_differences": identity_differences,
+                        "identity_unavailable": identity_unavailable,
+                    },
+                },
                 {"type": "table", "rows": rows[:max_rows]},
             ],
             rows_observed=len(rows),
             complete=len(rows) <= max_rows,
-            limitations=["Comparisons use arithmetic means of prompt-free normalized metrics."],
+            limitations=[
+                "Comparisons use arithmetic means of prompt-free normalized metrics.",
+                *(
+                    ["The inference system identity is unavailable from one or more exports."]
+                    if identity_unavailable
+                    else []
+                ),
+                *(
+                    [
+                        "Known-different identities were compared only because heterogeneous "
+                        "mode was explicit."
+                    ]
+                    if compatibility == "heterogeneous"
+                    else []
+                ),
+            ],
         )
 
     @staticmethod

--- a/src/flameox/providers/kernel_evidence.py
+++ b/src/flameox/providers/kernel_evidence.py
@@ -195,46 +195,63 @@ class KernelEvidenceProvider:
         if baseline_index >= len(documents):
             raise ProviderFailure("INVALID_INPUT", "baseline_index does not select an input")
         requested_metric = arguments.get("metric")
-        series: list[dict[tuple[str, str, str], float]] = []
-        statuses: list[dict[tuple[str, str, str], str]] = []
+        series: list[dict[bytes, float]] = []
+        identities: list[dict[bytes, dict[str, Any]]] = []
+        statuses: list[dict[bytes, str]] = []
         for document in documents:
-            values: dict[tuple[str, str, str], float] = {}
-            state: dict[tuple[str, str, str], str] = {}
+            values: dict[bytes, float] = {}
+            members: dict[bytes, dict[str, Any]] = {}
+            state: dict[bytes, str] = {}
             for row in self._kernel_rows(document):
                 if row["evidence_kind"] != "measurement":
                     continue
-                identity = (str(row["case_id"]), str(row["output"]), str(row["metric"]))
-                if requested_metric is not None and identity[2] != requested_metric:
+                identity = {
+                    "case_id": str(row["case_id"]),
+                    "dimensions": row["dimensions"],
+                    "seed": row["seed"],
+                    "device": row["device"],
+                    "output": str(row["output"]),
+                    "dtype": str(row["dtype"]),
+                    "shape": row["shape"],
+                    "metric": str(row["metric"]),
+                    "comparator": row["comparator"],
+                    "threshold": row["threshold"],
+                    "unit": str(row["unit"]),
+                }
+                if requested_metric is not None and identity["metric"] != requested_metric:
                     continue
                 value = row["value"]
                 if isinstance(value, int | float) and not isinstance(value, bool):
-                    values[identity] = float(value)
-                    state[identity] = str(row["metric_status"])
+                    key = canonical_bytes(identity)
+                    values[key] = float(value)
+                    members[key] = identity
+                    state[key] = str(row["metric_status"])
             series.append(values)
+            identities.append(members)
             statuses.append(state)
         common = set(series[baseline_index])
         for values in series:
             common.intersection_update(values)
+        all_identities = set().union(*(set(values) for values in series))
+        unmatched = all_identities.difference(common)
         rows: list[dict[str, Any]] = []
-        for identity in sorted(common):
-            baseline = series[baseline_index][identity]
+        for key in sorted(common):
+            baseline = series[baseline_index][key]
             for input_index, values in enumerate(series):
                 if input_index == baseline_index:
                     continue
-                candidate = values[identity]
+                candidate = values[key]
                 rows.append(
                     {
-                        "case_id": identity[0],
-                        "output": identity[1],
-                        "metric": identity[2],
+                        **identities[baseline_index][key],
                         "baseline_index": baseline_index,
                         "candidate_index": input_index,
                         "baseline_value": baseline,
                         "candidate_value": candidate,
                         "delta": candidate - baseline,
                         "ratio": candidate / baseline if baseline else None,
-                        "baseline_status": statuses[baseline_index][identity],
-                        "candidate_status": statuses[input_index][identity],
+                        "baseline_status": statuses[baseline_index][key],
+                        "candidate_status": statuses[input_index][key],
                     }
                 )
         return ProviderAnalysis(
@@ -246,6 +263,7 @@ class KernelEvidenceProvider:
                     "values": {
                         "input_count": len(documents),
                         "compatible_metric_count": len(common),
+                        "unmatched_identity_count": len(unmatched),
                     },
                 },
                 {"type": "table", "rows": rows[:max_rows]},
@@ -254,7 +272,12 @@ class KernelEvidenceProvider:
             complete=len(rows) <= max_rows,
             limitations=[
                 "Metric deltas compare declared validation outputs; they do not establish "
-                "performance."
+                "performance.",
+                *(
+                    ["Measurements absent from one or more inputs were not compared."]
+                    if unmatched
+                    else []
+                ),
             ],
         )
 

--- a/src/flameox/providers/nsight_systems.py
+++ b/src/flameox/providers/nsight_systems.py
@@ -19,6 +19,12 @@ _OPERATION_TABLE_PREFIXES = (
     "VULKAN",
     "DX12",
 )
+_ACCELERATOR_TABLE_PREFIXES = (
+    "CUDA_GPU_",
+    "CUDA_KERNEL",
+    "CUDA_MEM",
+    "CUPTI_ACTIVITY_",
+)
 _LIFECYCLE_TABLE_PREFIXES = (
     "PROCESS",
     "THREAD",
@@ -49,7 +55,9 @@ class NsightSystemsParquetProvider:
                 "UNSUPPORTED_FORMAT", "Nsight Systems Parquet directory contains no tables"
             )
         if capability_id == "gpu.launches":
-            files = [file for file in files if file.stem.upper().startswith(("CUDA_", "CUPTI_"))]
+            files = [
+                file for file in files if file.stem.upper().startswith(_ACCELERATOR_TABLE_PREFIXES)
+            ]
         elif capability_id == "trace.operations":
             files = [
                 file for file in files if file.stem.upper().startswith(_OPERATION_TABLE_PREFIXES)

--- a/src/flameox/providers/nvbench.py
+++ b/src/flameox/providers/nvbench.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from flameox.canonical import canonical_bytes
 from flameox.providers.benchmark_scaling import scaling_projection
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 
@@ -28,7 +29,7 @@ class _NvbenchBundle:
     rows: list[dict[str, Any]]
     measurement_count: int
     benchmark_names: set[str]
-    series: dict[tuple[str, str], tuple[float, int]]
+    series: dict[bytes, tuple[dict[str, Any], float, int]]
 
 
 class NvbenchProvider:
@@ -51,13 +52,19 @@ class NvbenchProvider:
         if capability_id == "benchmark.compare":
             return self._compare(parsed, arguments, max_rows=max_rows)
         if capability_id == "benchmark.scaling":
-            if any(bundle.measurement_count > len(bundle.rows) for bundle in parsed):
-                raise ProviderFailure(
-                    "LIMIT_EXCEEDED",
-                    "benchmark.scaling requires complete samples; raise the startup row limit",
-                )
             return scaling_projection(
-                [row for bundle in parsed for row in bundle.rows],
+                [
+                    {
+                        **identity,
+                        "is_warmup": False,
+                        "value_int": None,
+                        "value_float": None,
+                        "sample_sum": total,
+                        "sample_count": count,
+                    }
+                    for bundle in parsed
+                    for identity, total, count in bundle.series.values()
+                ],
                 arguments,
                 provider_id="nvbench",
                 provider_version=parsed[0].version,
@@ -111,22 +118,37 @@ class NvbenchProvider:
         for bundle in bundles:
             common.intersection_update(bundle.series)
         if requested_metric is not None:
-            common = {identity for identity in common if identity[0] == requested_metric}
+            common = {
+                key
+                for key in common
+                if bundles[baseline_index].series[key][0]["benchmark"] == requested_metric
+            }
+        all_identities = set().union(*(set(bundle.series) for bundle in bundles))
+        if requested_metric is not None:
+            all_identities = {
+                key
+                for key in all_identities
+                if any(
+                    bundle.series[key][0]["benchmark"] == requested_metric
+                    for bundle in bundles
+                    if key in bundle.series
+                )
+            }
+        unmatched = all_identities.difference(common)
         baseline = bundles[baseline_index].series
         rows: list[dict[str, Any]] = []
-        for identity in sorted(common):
-            baseline_sum, baseline_count = baseline[identity]
+        for key in sorted(common):
+            identity, baseline_sum, baseline_count = baseline[key]
             baseline_mean = baseline_sum / baseline_count
             for input_index, bundle in enumerate(bundles):
                 if input_index == baseline_index:
                     continue
-                candidate_sum, candidate_count = bundle.series[identity]
+                _candidate_identity, candidate_sum, candidate_count = bundle.series[key]
                 candidate_mean = candidate_sum / candidate_count
                 if len(rows) < max_rows:
                     rows.append(
                         {
-                            "benchmark": identity[0],
-                            "unit": identity[1],
+                            **identity,
                             "baseline_index": baseline_index,
                             "candidate_index": input_index,
                             "baseline_mean": baseline_mean,
@@ -144,6 +166,7 @@ class NvbenchProvider:
                     "values": {
                         "input_count": len(bundles),
                         "compatible_metric_count": len(common),
+                        "unmatched_identity_count": len(unmatched),
                     },
                 },
                 {"type": "table", "rows": rows},
@@ -151,7 +174,12 @@ class NvbenchProvider:
             rows_observed=observed,
             complete=observed <= len(rows),
             limitations=[
-                "Ratios summarize observed sample means and do not establish causal improvement."
+                "Ratios summarize observed sample means and do not establish causal improvement.",
+                *(
+                    ["Series absent from one or more inputs were not compared."]
+                    if unmatched
+                    else []
+                ),
             ],
         )
 
@@ -194,7 +222,7 @@ class NvbenchProvider:
         if not isinstance(benchmarks, list) or len(benchmarks) > _MAX_BENCHMARKS:
             raise ProviderFailure("LIMIT_EXCEEDED", "NVBench benchmark count is invalid")
         rows: list[dict[str, Any]] = []
-        series: dict[tuple[str, str], tuple[float, int]] = {}
+        series: dict[bytes, tuple[dict[str, Any], float, int]] = {}
         benchmark_names: set[str] = set()
         measurement_count = 0
         state_count = 0
@@ -229,7 +257,13 @@ class NvbenchProvider:
                     series_name = _HINTS[cast(str, hint)][1]
                     metric_name = f"{benchmark_name}.{series_name}"
                     benchmark_names.add(metric_name)
-                    total, seen = series.get((metric_name, unit), (0.0, 0))
+                    identity = {
+                        "benchmark": metric_name,
+                        "unit": unit,
+                        "dimensions": _state_dimensions(state),
+                    }
+                    key = canonical_bytes(identity)
+                    _previous_identity, total, seen = series.get(key, (identity, 0.0, 0))
                     for row in _sidecar_rows(
                         sidecar,
                         count=count,
@@ -243,7 +277,7 @@ class NvbenchProvider:
                         seen += 1
                         if max_rows is None or len(rows) < max_rows:
                             rows.append(row)
-                    series[(metric_name, unit)] = total, seen
+                    series[key] = identity, total, seen
                     if measurement_count > _MAX_SAMPLES:
                         raise ProviderFailure(
                             "LIMIT_EXCEEDED", "NVBench sample count exceeds the limit"

--- a/src/flameox/providers/reliability.py
+++ b/src/flameox/providers/reliability.py
@@ -329,9 +329,12 @@ class ReliabilityProvider:
 
     @staticmethod
     def _pytest_classification(reports: dict[str, str]) -> str:
-        if reports.get("setup") == "failed" or reports.get("teardown") == "failed":
+        if reports.get("setup") in {"failed", "rerun"} or reports.get("teardown") in {
+            "failed",
+            "rerun",
+        }:
             return "errored"
-        if reports.get("call") == "failed":
+        if reports.get("call") in {"failed", "rerun"}:
             return "failed"
         if "skipped" in reports.values():
             return "skipped"
@@ -348,13 +351,16 @@ class ReliabilityProvider:
         }
         outcomes = {phase: values[-1] for phase, values in attempts.items()}
         classification = cls._pytest_classification(outcomes)
-        if classification == "passed" and any("failed" in values for values in attempts.values()):
+        failed_attempts = {"failed", "rerun"}
+        if classification == "passed" and any(
+            failed_attempts.intersection(values) for values in attempts.values()
+        ):
             classification = "flaky"
         failing_phase = next(
             (
                 phase
                 for phase in ("setup", "call", "teardown")
-                if "failed" in attempts.get(phase, [])
+                if failed_attempts.intersection(attempts.get(phase, []))
             ),
             None,
         )

--- a/src/flameox/providers/reliability.py
+++ b/src/flameox/providers/reliability.py
@@ -31,11 +31,15 @@ class ReliabilityProvider:
         invocations: dict[str, dict[str, Any]] = {}
         finished = False
         interrupted = False
+        exit_status: int | None = None
         teardown_failures: set[tuple[str, str]] = set()
         for index, event in self._events(path):
             event_name = event.get("event")
             if event_name == "run_finished":
                 finished = True
+                reported_status = event.get("exitstatus")
+                if isinstance(reported_status, int) and not isinstance(reported_status, bool):
+                    exit_status = reported_status
                 continue
             if event_name in {"interrupted", "internal_error"}:
                 interrupted = True
@@ -158,24 +162,29 @@ class ReliabilityProvider:
             key=lambda row: (-int(row["known_work_ns"]), str(row["invocation_id"]))
         )
         rows = [*aggregate_rows, *invocation_rows]
-        completion = "interrupted" if interrupted else "complete" if finished else "incomplete"
+        completion = self._pytest_completion(
+            finished=finished, interrupted=interrupted, exit_status=exit_status
+        )
         incomplete_count = sum(not bool(row["complete"]) for row in invocation_rows)
+        metrics: dict[str, Any] = {
+            "completion": completion,
+            "fixture_count": len(aggregate_rows),
+            "invocation_count": len(invocation_rows),
+            "worker_count": len(worker_work),
+            "incomplete_invocation_count": incomplete_count,
+            "teardown_failure_count": len(teardown_failures),
+            "summed_fixture_work_ns": sum(worker_work.values()),
+            "max_worker_fixture_work_ns": max(worker_work.values(), default=0),
+        }
+        if exit_status not in {None, 0}:
+            metrics["exit_status"] = exit_status
         return ProviderAnalysis(
             provider_id="pytest",
             provider_version="event-stream-v2",
             blocks=[
                 {
                     "type": "metrics",
-                    "values": {
-                        "completion": completion,
-                        "fixture_count": len(aggregate_rows),
-                        "invocation_count": len(invocation_rows),
-                        "worker_count": len(worker_work),
-                        "incomplete_invocation_count": incomplete_count,
-                        "teardown_failure_count": len(teardown_failures),
-                        "summed_fixture_work_ns": sum(worker_work.values()),
-                        "max_worker_fixture_work_ns": max(worker_work.values(), default=0),
-                    },
+                    "values": metrics,
                 },
                 {"type": "table", "rows": rows[:max_rows]},
             ],
@@ -195,11 +204,12 @@ class ReliabilityProvider:
 
     def _pytest(self, path: Path, *, max_rows: int) -> ProviderAnalysis:
         collected: set[str] = set()
-        phase_events: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        phase_events: dict[str, dict[str, list[dict[str, Any]]]] = defaultdict(dict)
         collection_errors: list[dict[str, Any]] = []
         global_failures: list[dict[str, Any]] = []
         finished = False
         interrupted = False
+        exit_status: int | None = None
         for index, event in self._events(path):
             event_name = event.get("event")
             if event_name == "test_collected" and isinstance(event.get("nodeid"), str):
@@ -209,7 +219,8 @@ class ReliabilityProvider:
                 phase = event.get("phase")
                 outcome = event.get("outcome")
                 if all(isinstance(item, str) for item in (nodeid, phase, outcome)):
-                    phase_events[str(nodeid)][str(phase)] = self._pytest_row(index, event)
+                    reports = phase_events[str(nodeid)]
+                    reports.setdefault(str(phase), []).append(self._pytest_row(index, event))
             elif event_name == "collection_error" and isinstance(event.get("nodeid"), str):
                 collection_errors.append(
                     {
@@ -222,21 +233,34 @@ class ReliabilityProvider:
                 )
             elif event_name == "run_finished":
                 finished = True
+                reported_status = event.get("exitstatus")
+                if isinstance(reported_status, int) and not isinstance(reported_status, bool):
+                    exit_status = reported_status
             elif event_name in {"interrupted", "internal_error"}:
                 interrupted = True
                 global_failures.append(
                     {"index": index, "classification": str(event_name), "nodeid": None}
                 )
         phases = {
-            nodeid: {phase: str(event["outcome"]) for phase, event in reports.items()}
+            nodeid: {phase: str(events[-1]["outcome"]) for phase, events in reports.items()}
             for nodeid, reports in phase_events.items()
         }
         outcomes = self._outcomes(phases)
         outcomes["errored"] += len(collection_errors)
+        retried = sum(
+            max(0, len(events) - 1)
+            for reports in phase_events.values()
+            for events in reports.values()
+        )
+        outcome_rows = [
+            self._pytest_outcome_row(nodeid, reports) for nodeid, reports in phase_events.items()
+        ]
+        flaky = sum(row["classification"] == "flaky" for row in outcome_rows)
+        if retried:
+            outcomes["retried"] = retried
+            outcomes["flaky"] = flaky
         diagnostic_rows = [
-            self._pytest_outcome_row(nodeid, reports)
-            for nodeid, reports in phase_events.items()
-            if self._pytest_classification(phases[nodeid]) in {"failed", "errored"}
+            row for row in outcome_rows if row["classification"] in {"failed", "errored", "flaky"}
         ]
         diagnostic_rows.extend(global_failures)
         diagnostic_rows.extend(collection_errors)
@@ -255,7 +279,8 @@ class ReliabilityProvider:
             "failed": 1,
             "internal_error": 2,
             "interrupted": 3,
-            "unexecuted": 4,
+            "flaky": 4,
+            "unexecuted": 5,
         }
         diagnostic_rows.sort(
             key=lambda row: (
@@ -263,20 +288,25 @@ class ReliabilityProvider:
                 str(row.get("nodeid") or ""),
             )
         )
-        completion = "interrupted" if interrupted else "complete" if finished else "incomplete"
+        completion = self._pytest_completion(
+            finished=finished, interrupted=interrupted, exit_status=exit_status
+        )
+        metrics: dict[str, Any] = {
+            "completion": completion,
+            "collected": len(collected),
+            "executed": len(phases),
+            "unexecuted": len(collected.difference(phases)),
+            **outcomes,
+        }
+        if exit_status not in {None, 0}:
+            metrics["exit_status"] = exit_status
         return ProviderAnalysis(
             provider_id="pytest",
             provider_version="event-stream-v1",
             blocks=[
                 {
                     "type": "metrics",
-                    "values": {
-                        "completion": completion,
-                        "collected": len(collected),
-                        "executed": len(phases),
-                        "unexecuted": len(collected.difference(phases)),
-                        **outcomes,
-                    },
+                    "values": metrics,
                 },
                 {"type": "table", "rows": diagnostic_rows[:max_rows]},
             ],
@@ -288,6 +318,14 @@ class ReliabilityProvider:
                 "Failure tracebacks remain in the native pytest artifact and are not projected.",
             ],
         )
+
+    @staticmethod
+    def _pytest_completion(*, finished: bool, interrupted: bool, exit_status: int | None) -> str:
+        if interrupted:
+            return "interrupted"
+        if exit_status not in {None, 0}:
+            return "failed"
+        return "complete" if finished else "incomplete"
 
     @staticmethod
     def _pytest_classification(reports: dict[str, str]) -> str:
@@ -302,20 +340,34 @@ class ReliabilityProvider:
         return "errored"
 
     @classmethod
-    def _pytest_outcome_row(cls, nodeid: str, reports: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        outcomes = {phase: str(event["outcome"]) for phase, event in reports.items()}
+    def _pytest_outcome_row(
+        cls, nodeid: str, reports: dict[str, list[dict[str, Any]]]
+    ) -> dict[str, Any]:
+        attempts = {
+            phase: [str(event["outcome"]) for event in events] for phase, events in reports.items()
+        }
+        outcomes = {phase: values[-1] for phase, values in attempts.items()}
         classification = cls._pytest_classification(outcomes)
+        if classification == "passed" and any("failed" in values for values in attempts.values()):
+            classification = "flaky"
         failing_phase = next(
-            (phase for phase in ("setup", "call", "teardown") if outcomes.get(phase) == "failed"),
+            (
+                phase
+                for phase in ("setup", "call", "teardown")
+                if "failed" in attempts.get(phase, [])
+            ),
             None,
         )
-        return {
-            "index": min(int(event["index"]) for event in reports.values()),
+        row = {
+            "index": min(int(event["index"]) for events in reports.values() for event in events),
             "nodeid": nodeid,
             "classification": classification,
             "failing_phase": failing_phase,
             "phase_outcomes": outcomes,
         }
+        if any(len(values) > 1 for values in attempts.values()):
+            row["phase_attempts"] = attempts
+        return row
 
     def _observations(self, path: Path, *, max_rows: int) -> ProviderAnalysis:
         rows: list[dict[str, Any]] = []

--- a/src/flameox/providers/source_evidence.py
+++ b/src/flameox/providers/source_evidence.py
@@ -92,6 +92,6 @@ class SourceEvidenceProvider:
                 {"type": "table", "rows": rows},
             ],
             rows_observed=coverage.normalized_count + coverage.omitted_count,
-            complete=coverage.omitted_count == 0,
+            complete=parsed.complete and coverage.omitted_count == 0,
             limitations=list(parsed.limitations),
         )

--- a/src/flameox/providers/structured_workers.py
+++ b/src/flameox/providers/structured_workers.py
@@ -16,6 +16,9 @@ from flameox.workers.v8_profiles_contract import (
     V8ProfileRequest,
 )
 
+_V8_MAX_NODES = 100_000
+_V8_MAX_SAMPLES = 1_000_000
+
 
 class StructuredWorkerProviders:
     """Explicit adapters for workers whose result is already bounded structured evidence."""
@@ -91,8 +94,8 @@ class StructuredWorkerProviders:
                     profile_kind="cpu",
                     artifact_path=str(path),
                     artifact_id=input_sha256,
-                    max_nodes=max_rows,
-                    max_samples=max_rows,
+                    max_nodes=_V8_MAX_NODES,
+                    max_samples=_V8_MAX_SAMPLES,
                     max_rows=max_rows,
                 ),
                 timeout_seconds=timeout_seconds,
@@ -113,8 +116,42 @@ class StructuredWorkerProviders:
                     },
                     {"type": "table", "rows": rows},
                 ],
-                rows_observed=result.node_count,
-                complete=len(rows) >= result.node_count,
+                rows_observed=result.frame_count,
+                complete=not result.truncated,
+                limitations=list(result.limitations),
+            )
+        if capability_id == "memory.hotspots" and format_name == "heapprofile":
+            result = self.harness.run_typed_sync(
+                V8_PROFILE_WORKER,
+                V8ProfileRequest(
+                    profile_kind="heap",
+                    artifact_path=str(path),
+                    artifact_id=input_sha256,
+                    max_nodes=_V8_MAX_NODES,
+                    max_samples=_V8_MAX_SAMPLES,
+                    max_rows=max_rows,
+                ),
+                timeout_seconds=timeout_seconds,
+                maximum_rss_bytes=maximum_rss_bytes,
+                maximum_writable_growth_bytes=maximum_output_bytes,
+            )
+            rows = [dict(row) for row in result.frame_measurements]
+            return ProviderAnalysis(
+                provider_id="v8-heap-profile",
+                provider_version=V8_PROFILE_WORKER.implementation,
+                blocks=[
+                    {
+                        "type": "metrics",
+                        "values": {
+                            "node_count": result.node_count,
+                            "sample_count": result.sample_count,
+                            "total_sampled_bytes": result.total_sampled_bytes,
+                        },
+                    },
+                    {"type": "table", "rows": rows},
+                ],
+                rows_observed=result.frame_count,
+                complete=not result.truncated,
                 limitations=list(result.limitations),
             )
         if capability_id == "sanitizer.failures" and format_name == "compute-sanitizer":

--- a/src/flameox/providers/xctrace.py
+++ b/src/flameox/providers/xctrace.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from defusedxml.ElementTree import iterparse  # type: ignore[import-untyped]
+from defusedxml.ElementTree import ParseError, iterparse  # type: ignore[import-untyped]
 
 from flameox.providers.contracts import ProviderAnalysis, ProviderFailure
 
@@ -32,7 +32,7 @@ class XctraceProvider:
                         }
                     )
                 element.clear()
-        except (OSError, ValueError) as error:
+        except (OSError, ParseError, ValueError) as error:
             raise ProviderFailure(
                 "DECODE_FAILURE", "xctrace table-of-contents XML is invalid"
             ) from error

--- a/src/flameox/repository.py
+++ b/src/flameox/repository.py
@@ -18,7 +18,7 @@ from typing import Any, cast
 from uuid import uuid4
 
 from flameox.canonical import canonical_bytes
-from flameox.runtime_contracts import LOWERCASE_SHA256_PATTERN
+from flameox.runtime_contracts import LOWERCASE_SHA256_PATTERN, CaptureTarget, ExperimentDesign
 
 REPOSITORY_FORMAT = "1"
 EVIDENCE_MEDIA_TYPE = "application/vnd.flameox.evidence+json;version=1"
@@ -728,15 +728,104 @@ class EvidenceRepository:
             return
         if not isinstance(value, dict):
             raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+        if set(value) != {"target", "mode", "experiment", "executions"}:
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
         target = value.get("target")
         executions = value.get("executions")
+        try:
+            CaptureTarget.model_validate(target)
+            experiment = value.get("experiment")
+            if experiment is not None:
+                ExperimentDesign.model_validate(experiment)
+        except (TypeError, ValueError) as error:
+            raise RepositoryError(
+                "REPOSITORY_CORRUPTION", "Evidence capture request is invalid."
+            ) from error
+        if value.get("mode") not in {"single", "experiment"} or not isinstance(executions, list):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+        for execution in executions:
+            EvidenceRepository._validate_capture_execution(execution)
+
+    @staticmethod
+    def _validate_capture_execution(value: Any) -> None:
+        fields = {
+            "case",
+            "block",
+            "argv",
+            "capture_argv",
+            "cwd",
+            "returncode",
+            "status",
+            "failure_code",
+            "missing_artifact_roles",
+            "semantic_oracle",
+            "wall_time_ns",
+            "containment",
+            "limit",
+        }
+        if not isinstance(value, dict) or set(value) != fields:
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+        argv_fields = (value.get("argv"), value.get("capture_argv"))
+        missing_roles = value.get("missing_artifact_roles")
+        scalar_valid = (
+            isinstance(value.get("case"), str)
+            and type(value.get("block")) is int
+            and value["block"] >= 1
+            and isinstance(value.get("cwd"), str)
+            and Path(value["cwd"]).is_absolute()
+            and (value.get("returncode") is None or type(value["returncode"]) is int)
+            and value.get("status") in {"pending", "succeeded", "failed"}
+            and (value.get("failure_code") is None or isinstance(value["failure_code"], str))
+            and (value.get("wall_time_ns") is None or type(value["wall_time_ns"]) is int)
+            and isinstance(value.get("containment"), str)
+        )
         if (
-            not isinstance(target, dict)
-            or not isinstance(target.get("provider_id"), str)
-            or not isinstance(target.get("argv"), list)
-            or not isinstance(target.get("environment"), dict)
-            or not isinstance(executions, list)
-            or any(not isinstance(item, dict) for item in executions)
+            not scalar_valid
+            or any(
+                not isinstance(argv, list)
+                or not argv
+                or any(not isinstance(item, str) or not item or "\x00" in item for item in argv)
+                for argv in argv_fields
+            )
+            or not isinstance(missing_roles, list)
+            or any(not isinstance(role, str) or not role for role in missing_roles)
+        ):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+        limit = value.get("limit")
+        if limit is not None and (
+            not isinstance(limit, dict)
+            or set(limit)
+            != {"kind", "configured", "observed", "unit", "observation_available", "recovery"}
+            or not isinstance(limit.get("kind"), str)
+            or not isinstance(limit.get("configured"), int | float)
+            or isinstance(limit.get("configured"), bool)
+            or (
+                limit.get("observed") is not None
+                and (
+                    not isinstance(limit["observed"], int | float)
+                    or isinstance(limit["observed"], bool)
+                )
+            )
+            or not isinstance(limit.get("unit"), str)
+            or type(limit.get("observation_available")) is not bool
+            or not isinstance(limit.get("recovery"), str)
+        ):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+        oracle = value.get("semantic_oracle")
+        if oracle is not None and (
+            not isinstance(oracle, dict)
+            or set(oracle) != {"argv", "returncode", "status", "failure_code"}
+            or not isinstance(oracle.get("argv"), list)
+            or not oracle["argv"]
+            or any(
+                not isinstance(item, str) or not item or "\x00" in item for item in oracle["argv"]
+            )
+            or (oracle.get("returncode") is not None and type(oracle["returncode"]) is not int)
+            or oracle.get("status") not in {"passed", "failed"}
+            or (
+                oracle.get("failure_code") is not None
+                and not isinstance(oracle["failure_code"], str)
+            )
         ):
             raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
 

--- a/src/flameox/repository.py
+++ b/src/flameox/repository.py
@@ -326,6 +326,10 @@ class EvidenceRepository:
             created_before=created_before,
         )
         offset = self._decode_cursor(cursor, inventory_digest, query_digest)
+        if cursor is not None and offset >= len(inventory):
+            raise RepositoryError(
+                "INVALID_INPUT", "Repository query continuation is beyond the inventory."
+            )
         matches: list[dict[str, Any]] = []
         next_offset: int | None = None
         for index, path in enumerate(inventory[offset:], offset):
@@ -671,10 +675,8 @@ class EvidenceRepository:
                 or not item["role"]
             ):
                 raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence input is invalid.")
-        if body["capture_request"] is not None and not isinstance(body["capture_request"], dict):
-            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
-        if not isinstance(body["analysis_request"], dict):
-            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence analysis request is invalid.")
+        EvidenceRepository._validate_capture_request(body["capture_request"])
+        EvidenceRepository._validate_analysis_request(body["analysis_request"])
         episode = body["episode"]
         try:
             created_at = datetime.fromisoformat(episode["created_at"])
@@ -719,6 +721,45 @@ class EvidenceRepository:
         artifacts = body["artifacts"]
         if not isinstance(artifacts, list):
             raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence artifacts are invalid.")
+
+    @staticmethod
+    def _validate_capture_request(value: Any) -> None:
+        if value is None:
+            return
+        if not isinstance(value, dict):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+        target = value.get("target")
+        executions = value.get("executions")
+        if (
+            not isinstance(target, dict)
+            or not isinstance(target.get("provider_id"), str)
+            or not isinstance(target.get("argv"), list)
+            or not isinstance(target.get("environment"), dict)
+            or not isinstance(executions, list)
+            or any(not isinstance(item, dict) for item in executions)
+        ):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence capture request is invalid.")
+
+    @staticmethod
+    def _validate_analysis_request(value: Any) -> None:
+        if not isinstance(value, dict) or not isinstance(value.get("capability_id"), str):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence analysis request is invalid.")
+        inputs = value.get("inputs", [])
+        if not isinstance(inputs, list) or any(
+            not isinstance(item, dict)
+            or not _is_digest(item.get("sha256"))
+            or not isinstance(item.get("format"), str)
+            for item in inputs
+        ):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence analysis request is invalid.")
+        offset = value.get("offset")
+        if offset is not None and (type(offset) is not int or offset < 0):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence analysis request is invalid.")
+        failure = value.get("failure")
+        if failure is not None and (
+            not isinstance(failure, dict) or not isinstance(failure.get("code"), str)
+        ):
+            raise RepositoryError("REPOSITORY_CORRUPTION", "Evidence analysis request is invalid.")
 
     @staticmethod
     def _matches(
@@ -804,8 +845,8 @@ class EvidenceRepository:
                 raise RepositoryError(
                     "INVALID_INPUT", "Repository query continuation does not match its filters."
                 )
-            offset = int(value["offset"])
-            if offset < 0:
+            offset = value["offset"]
+            if type(offset) is not int or offset < 0:
                 raise ValueError
             return offset
         except RepositoryError:

--- a/src/flameox/runtime_contracts.py
+++ b/src/flameox/runtime_contracts.py
@@ -172,6 +172,7 @@ class CompareArguments(StrictModel):
     metric: str | None = Field(
         default=None,
         description="Metric to compare; omit for the capability's default metric.",
+        min_length=1,
         max_length=120,
     )
     baseline_index: int = Field(

--- a/src/flameox/runtime_contracts.py
+++ b/src/flameox/runtime_contracts.py
@@ -182,6 +182,16 @@ class CompareArguments(StrictModel):
     )
 
 
+class InferenceCompareArguments(CompareArguments):
+    allow_heterogeneous: bool = Field(
+        default=False,
+        description=(
+            "Permit a numeric ratio across known-different inference identities and label it "
+            "heterogeneous exploratory evidence."
+        ),
+    )
+
+
 ArgumentModel = type[
     EmptyArguments
     | PreviewArguments
@@ -191,6 +201,7 @@ ArgumentModel = type[
     | StaticArguments
     | WindowArguments
     | CompareArguments
+    | InferenceCompareArguments
 ]
 
 
@@ -580,6 +591,12 @@ CAPTURE_PROVIDER_CONTRACTS = {
             "native V8 CPU profile",
         ),
         _capture_provider(
+            "node-heap-profile",
+            EmptyArguments,
+            (("memory-profile", "heapprofile"),),
+            "native V8 sampling heap profile",
+        ),
+        _capture_provider(
             "memray",
             MemrayCaptureArguments,
             (("memory", "memray"),),
@@ -927,8 +944,8 @@ CAPABILITIES = tuple(
     )
     + _caps(
         ("memory.hotspots",),
-        "Rank bounded allocation hotspots from a Memray capture.",
-        ("memray",),
+        "Rank bounded allocation hotspots from Memray or V8 sampling heap profiles.",
+        ("memray", "heapprofile"),
         EmptyArguments,
     )
     + _caps(
@@ -969,7 +986,7 @@ CAPABILITIES = tuple(
         ("inference.compare",),
         "Compare compatible prompt-free inference measurements.",
         ("aiperf", "vllm-benchmark", "sglang-benchmark", "mooncake-trace"),
-        CompareArguments,
+        InferenceCompareArguments,
         minimum_sources=2,
         maximum_sources=MAX_INPUTS,
     )

--- a/src/flameox/stateless.py
+++ b/src/flameox/stateless.py
@@ -370,6 +370,10 @@ class AnalysisRuntime:
             )
         if provider_analysis is None:
             rows, observed, complete = self._read_rows(resolved, offset, selected_limits.max_rows)
+            if continuation is not None and offset >= observed:
+                raise RuntimeFailure(
+                    "INVALID_INPUT", "Continuation offset is beyond the available evidence"
+                )
             continuation_available = not complete
             truncation_reason = "row_limit"
             blocks: list[dict[str, Any]] = [
@@ -385,6 +389,10 @@ class AnalysisRuntime:
             provider_rows = provider_analysis.blocks[-1]["rows"]
             if not isinstance(provider_rows, list):
                 raise RuntimeFailure("DECODE_FAILURE", "Provider table block is invalid")
+            if continuation is not None and offset >= len(provider_rows):
+                raise RuntimeFailure(
+                    "INVALID_INPUT", "Continuation offset is beyond the available evidence"
+                )
             rows = provider_rows[offset : offset + selected_limits.max_rows]
             observed = provider_analysis.rows_observed
             next_offset = offset + len(rows)
@@ -821,6 +829,7 @@ class AnalysisRuntime:
             )
         except RuntimeFailure as error:
             if not preserve:
+                shutil.rmtree(request_scratch, ignore_errors=True)
                 raise
             result = self._capture_failure_result(
                 target=target,
@@ -1257,7 +1266,9 @@ class AnalysisRuntime:
                     raise RuntimeFailure(exc.code, exc.message) from exc
                 cached.preserved = None
             except OSError as exc:
-                raise RuntimeFailure("REPOSITORY_IO_FAILURE", str(exc)) from exc
+                raise RuntimeFailure(
+                    "REPOSITORY_IO_FAILURE", "Preserved evidence could not be validated."
+                ) from exc
             else:
                 self.analyses.move_to_end(analysis_id)
                 return dict(cached.preserved)
@@ -1313,7 +1324,9 @@ class AnalysisRuntime:
             except RepositoryError as exc:
                 raise RuntimeFailure(exc.code, exc.message) from exc
             except OSError as exc:
-                raise RuntimeFailure("REPOSITORY_IO_FAILURE", str(exc)) from exc
+                raise RuntimeFailure(
+                    "REPOSITORY_IO_FAILURE", "Evidence could not be preserved."
+                ) from exc
         self.analyses.move_to_end(analysis_id)
         return dict(cached.preserved)
 
@@ -1405,7 +1418,9 @@ class AnalysisRuntime:
         except RepositoryError as exc:
             raise RuntimeFailure(exc.code, exc.message) from exc
         except OSError as exc:
-            raise RuntimeFailure("REPOSITORY_IO_FAILURE", str(exc)) from exc
+            raise RuntimeFailure(
+                "REPOSITORY_IO_FAILURE", "The evidence repository could not be queried."
+            ) from exc
 
     def read_evidence(self, evidence_id: str) -> dict[str, Any]:
         try:
@@ -1413,7 +1428,9 @@ class AnalysisRuntime:
         except RepositoryError as exc:
             raise RuntimeFailure(exc.code, exc.message) from exc
         except OSError as exc:
-            raise RuntimeFailure("REPOSITORY_IO_FAILURE", str(exc)) from exc
+            raise RuntimeFailure(
+                "REPOSITORY_IO_FAILURE", "The requested evidence could not be read."
+            ) from exc
 
     def read_evidence_agent_projection(self, evidence_id: str) -> dict[str, Any]:
         try:
@@ -1421,7 +1438,9 @@ class AnalysisRuntime:
         except RepositoryError as exc:
             raise RuntimeFailure(exc.code, exc.message) from exc
         except OSError as exc:
-            raise RuntimeFailure("REPOSITORY_IO_FAILURE", str(exc)) from exc
+            raise RuntimeFailure(
+                "REPOSITORY_IO_FAILURE", "The requested evidence projection could not be read."
+            ) from exc
 
     def _resolve_sources(
         self, sources: Sequence[Source], limits: RequestLimits
@@ -1486,6 +1505,7 @@ class AnalysisRuntime:
             ".csv": "csv",
             ".parquet": "parquet",
             ".cpuprofile": "cpuprofile",
+            ".heapprofile": "heapprofile",
             ".pftrace": "perfetto",
             ".perfetto-trace": "perfetto",
             ".trace": "xctrace",
@@ -2130,11 +2150,17 @@ class AnalysisRuntime:
         self, result: dict[str, Any], limit: int, identity: Mapping[str, Any], offset: int
     ) -> None:
         rows = result["blocks"][1]["rows"]
+        had_rows = bool(rows)
         while len(canonical_bytes(result)) > limit and rows:
             rows.pop()
             result["coverage"].update(rows_returned=len(rows), complete=False)
             result["truncation"] = {"reason": "result_bytes", "next_offset": offset + len(rows)}
             result["continuation"] = self._encode_continuation(identity, offset + len(rows))
+        if had_rows and not rows:
+            raise RuntimeFailure(
+                "LIMIT_EXCEEDED",
+                "A result row exceeds max_result_bytes and cannot form an advancing page",
+            )
         if len(canonical_bytes(result)) > limit:
             raise RuntimeFailure("LIMIT_EXCEEDED", "Result metadata exceeds max_result_bytes")
 
@@ -2321,7 +2347,10 @@ class AnalysisRuntime:
                 or payload["request"] != hashlib.sha256(canonical_bytes(identity)).hexdigest()
             ):
                 raise ValueError
-            return int(payload["offset"])
+            offset = payload["offset"]
+            if type(offset) is not int or offset < 0:
+                raise ValueError
+            return offset
         except (ValueError, TypeError, KeyError, json.JSONDecodeError) as exc:
             raise RuntimeFailure(
                 "INVALID_INPUT", "Continuation does not match this request and its inputs"

--- a/src/flameox/workers/benchmark_samples.py
+++ b/src/flameox/workers/benchmark_samples.py
@@ -55,6 +55,22 @@ def _row(
     }
 
 
+def _series_row(series: BenchmarkSeries, *, series_index: int) -> dict[str, Any]:
+    row = _row(
+        series,
+        series_index=series_index,
+        value_index=0,
+        value=series.samples[0],
+        is_warmup=False,
+    )
+    row.pop("value_index")
+    row["value_int"] = None
+    row["value_float"] = None
+    row["sample_sum"] = sum(series.samples)
+    row["sample_count"] = len(series.samples)
+    return row
+
+
 def _handle(
     request: BenchmarkSamplesWorkerRequest, _job_root: Path
 ) -> BenchmarkSamplesWorkerResult:
@@ -73,6 +89,12 @@ def _handle(
                 f"{series.name} uses asynchronous device timing with "
                 f"synchronization={series.synchronization}."
             )
+        if request.projection == "series":
+            measurement_count += len(series.samples)
+            warmup_count += len(series.warmups)
+            if request.metric in {None, series.name} and len(rows) < request.max_rows:
+                rows.append(_series_row(series, series_index=series_index))
+            continue
         for is_warmup, values in ((True, series.warmups), (False, series.samples)):
             for value_index, value in enumerate(values):
                 if is_warmup:
@@ -90,8 +112,17 @@ def _handle(
                         )
                     )
     observed = measurement_count + warmup_count
-    if observed > len(rows):
-        limitations.append(f"Benchmark rows were truncated to {request.max_rows} entries.")
+    selected_series_count = sum(
+        request.metric in {None, series.name} for series in payload.benchmarks
+    )
+    truncated = (
+        selected_series_count > len(rows)
+        if request.projection == "series"
+        else observed > len(rows)
+    )
+    if truncated:
+        subject = "series" if request.projection == "series" else "rows"
+        limitations.append(f"Benchmark {subject} were truncated to {request.max_rows} entries.")
     return BenchmarkSamplesWorkerResult(
         producer=payload.producer,
         producer_version=payload.producer_version,
@@ -99,7 +130,7 @@ def _handle(
         measurement_count=measurement_count,
         warmup_count=warmup_count,
         rows=cast(tuple[dict[str, JsonValue], ...], tuple(rows)),
-        truncated=observed > len(rows),
+        truncated=truncated,
         limitations=tuple(dict.fromkeys(limitations)),
     )
 

--- a/src/flameox/workers/benchmark_samples.py
+++ b/src/flameox/workers/benchmark_samples.py
@@ -68,6 +68,9 @@ def _series_row(series: BenchmarkSeries, *, series_index: int) -> dict[str, Any]
     row["value_float"] = None
     row["sample_sum"] = sum(series.samples)
     row["sample_count"] = len(series.samples)
+    positive_samples = [value for value in series.samples if value > 0]
+    row["positive_sample_sum"] = sum(positive_samples)
+    row["positive_sample_count"] = len(positive_samples)
     return row
 
 

--- a/src/flameox/workers/benchmark_samples_contract.py
+++ b/src/flameox/workers/benchmark_samples_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field, JsonValue, TypeAdapter
 
@@ -10,7 +10,9 @@ from flameox.workers.protocol import WorkerDefinition, WorkerOperationId
 
 class BenchmarkSamplesWorkerRequest(ContractModel):
     artifact_path: str = Field(min_length=1, max_length=4_096)
-    max_rows: Annotated[int, Field(gt=0, le=1_001)]
+    max_rows: Annotated[int, Field(gt=0, le=100_000)]
+    projection: Literal["samples", "series"] = "samples"
+    metric: str | None = Field(default=None, min_length=1, max_length=200)
 
 
 class BenchmarkSamplesWorkerResult(ContractModel):

--- a/src/flameox/workers/otlp_parser.py
+++ b/src/flameox/workers/otlp_parser.py
@@ -98,41 +98,35 @@ def _normalize(
         table.append(row)
 
     source_ordinal = 0
+    windowed = start_ns is not None and end_ns is not None
     for resource_ordinal, resource_spans in enumerate(request.resource_spans):
         resource = resource_spans.resource
-        append(
-            resources,
-            "resources",
-            {
-                "resource_ordinal": resource_ordinal,
-                "schema_url": resource_spans.schema_url or None,
-                "attributes_json": _json(_attributes(resource.attributes)),
-                "dropped_attributes_count": resource.dropped_attributes_count,
-            },
-        )
+        resource_row = {
+            "resource_ordinal": resource_ordinal,
+            "schema_url": resource_spans.schema_url or None,
+            "attributes_json": _json(_attributes(resource.attributes)),
+            "dropped_attributes_count": resource.dropped_attributes_count,
+        }
+        resource_added = False
+        if not windowed:
+            append(resources, "resources", resource_row)
+            resource_added = True
         for scope_ordinal, scope_spans in enumerate(resource_spans.scope_spans):
             scope = scope_spans.scope
-            append(
-                scopes,
-                "scopes",
-                {
-                    "resource_ordinal": resource_ordinal,
-                    "scope_ordinal": scope_ordinal,
-                    "name": scope.name,
-                    "version": scope.version or None,
-                    "schema_url": scope_spans.schema_url or None,
-                    "attributes_json": _json(_attributes(scope.attributes)),
-                    "dropped_attributes_count": scope.dropped_attributes_count,
-                },
-            )
+            scope_row = {
+                "resource_ordinal": resource_ordinal,
+                "scope_ordinal": scope_ordinal,
+                "name": scope.name,
+                "version": scope.version or None,
+                "schema_url": scope_spans.schema_url or None,
+                "attributes_json": _json(_attributes(scope.attributes)),
+                "dropped_attributes_count": scope.dropped_attributes_count,
+            }
+            scope_added = False
+            if not windowed:
+                append(scopes, "scopes", scope_row)
+                scope_added = True
             for span in scope_spans.spans:
-                trace_id = _id(span.trace_id, 16, "trace_id", limitations)
-                span_id = _id(span.span_id, 8, "span_id", limitations)
-                parent_id = (
-                    _id(span.parent_span_id, 8, "parent_span_id", limitations)
-                    if span.parent_span_id
-                    else None
-                )
                 start = int(span.start_time_unix_nano)
                 end = int(span.end_time_unix_nano)
                 duration = end - start if start and end and end >= start else None
@@ -143,6 +137,19 @@ def _normalize(
                 ):
                     source_ordinal += 1
                     continue
+                if not resource_added:
+                    append(resources, "resources", resource_row)
+                    resource_added = True
+                if not scope_added:
+                    append(scopes, "scopes", scope_row)
+                    scope_added = True
+                trace_id = _id(span.trace_id, 16, "trace_id", limitations)
+                span_id = _id(span.span_id, 8, "span_id", limitations)
+                parent_id = (
+                    _id(span.parent_span_id, 8, "parent_span_id", limitations)
+                    if span.parent_span_id
+                    else None
+                )
                 if start == 0 or end == 0:
                     limitations.append(f"span:{source_ordinal}:missing_timestamp")
                 elif end < start:

--- a/src/flameox/workers/pyperf.py
+++ b/src/flameox/workers/pyperf.py
@@ -71,10 +71,15 @@ def _handle(request: PyperfWorkerRequest, _job_root: Path) -> PyperfWorkerResult
                                 "is_warmup": False,
                                 "sample_sum": 0.0,
                                 "sample_count": 0,
+                                "positive_sample_sum": 0.0,
+                                "positive_sample_count": 0,
                             }
                             series_rows[key] = aggregate
                         aggregate["sample_sum"] += float(normalized_value)
                         aggregate["sample_count"] += 1
+                        if normalized_value > 0:
+                            aggregate["positive_sample_sum"] += float(normalized_value)
+                            aggregate["positive_sample_count"] += 1
                     continue
                 if len(rows) < request.max_rows:
                     rows.append(

--- a/src/flameox/workers/pyperf.py
+++ b/src/flameox/workers/pyperf.py
@@ -24,6 +24,8 @@ def _normalized_value(value: float, unit: str) -> tuple[int | None, float | None
 def _handle(request: PyperfWorkerRequest, _job_root: Path) -> PyperfWorkerResult:
     suite = pyperf.BenchmarkSuite.load(str(Path(request.artifact_path)))
     rows: list[dict[str, Any]] = []
+    series_rows: dict[tuple[str, str, int], dict[str, Any]] = {}
+    series_truncated = False
     measurement_count = 0
     warmup_count = 0
     for benchmark in suite.get_benchmarks():
@@ -32,7 +34,7 @@ def _handle(request: PyperfWorkerRequest, _job_root: Path) -> PyperfWorkerResult
         for run_index, run in enumerate(benchmark.get_runs()):
             for value_index, (loops, value) in enumerate(run.warmups):
                 warmup_count += 1
-                if len(rows) < request.max_rows:
+                if request.projection == "samples" and len(rows) < request.max_rows:
                     value_int, value_float, normalized_unit = _normalized_value(value, unit)
                     rows.append(
                         {
@@ -49,8 +51,32 @@ def _handle(request: PyperfWorkerRequest, _job_root: Path) -> PyperfWorkerResult
             loops = run.get_loops()
             for value_index, value in enumerate(run.values):
                 measurement_count += 1
+                value_int, value_float, normalized_unit = _normalized_value(value, unit)
+                normalized_value = value_int if value_int is not None else value_float
+                assert normalized_value is not None
+                if request.projection == "series":
+                    if request.metric in {None, benchmark_name}:
+                        key = (benchmark_name, normalized_unit, loops)
+                        aggregate = series_rows.get(key)
+                        if aggregate is None:
+                            if len(series_rows) >= request.max_rows:
+                                series_truncated = True
+                                continue
+                            aggregate = {
+                                "benchmark": benchmark_name,
+                                "unit": normalized_unit,
+                                "value_int": None,
+                                "value_float": None,
+                                "loop_count": loops,
+                                "is_warmup": False,
+                                "sample_sum": 0.0,
+                                "sample_count": 0,
+                            }
+                            series_rows[key] = aggregate
+                        aggregate["sample_sum"] += float(normalized_value)
+                        aggregate["sample_count"] += 1
+                    continue
                 if len(rows) < request.max_rows:
-                    value_int, value_float, normalized_unit = _normalized_value(value, unit)
                     rows.append(
                         {
                             "benchmark": benchmark_name,
@@ -64,16 +90,24 @@ def _handle(request: PyperfWorkerRequest, _job_root: Path) -> PyperfWorkerResult
                         }
                     )
     observed = measurement_count + warmup_count
+    if request.projection == "series":
+        rows = list(series_rows.values())
+        truncated = series_truncated
+    else:
+        truncated = observed > len(rows)
     return PyperfWorkerResult(
         reader_version=version("pyperf"),
         benchmark_names=tuple(suite.get_benchmark_names()),
         measurement_count=measurement_count,
         warmup_count=warmup_count,
         rows=cast(tuple[dict[str, JsonValue], ...], tuple(rows)),
-        truncated=observed > len(rows),
+        truncated=truncated,
         limitations=(
-            (f"pyperf rows were truncated to {request.max_rows} entries.",)
-            if observed > len(rows)
+            (
+                f"pyperf {'series' if request.projection == 'series' else 'rows'} were "
+                f"truncated to {request.max_rows} entries.",
+            )
+            if truncated
             else ()
         ),
     )

--- a/src/flameox/workers/pyperf_contract.py
+++ b/src/flameox/workers/pyperf_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field, JsonValue, TypeAdapter
 
@@ -10,7 +10,9 @@ from flameox.workers.protocol import WorkerDefinition, WorkerOperationId
 
 class PyperfWorkerRequest(ContractModel):
     artifact_path: str = Field(min_length=1, max_length=4_096)
-    max_rows: Annotated[int, Field(gt=0, le=1_001)]
+    max_rows: Annotated[int, Field(gt=0, le=100_000)]
+    projection: Literal["samples", "series"] = "samples"
+    metric: str | None = Field(default=None, min_length=1, max_length=200)
 
 
 class PyperfWorkerResult(ContractModel):

--- a/src/flameox/workers/v8_profiles.py
+++ b/src/flameox/workers/v8_profiles.py
@@ -150,6 +150,7 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
     sample_count = 0
     total_sampled_bytes = 0
     node_ids: set[int] = set()
+    sample_node_ids: set[int] = set()
     node_stack: list[dict[str, Any]] = []
     sample: dict[str, Any] | None = None
     with path.open("rb") as stream:
@@ -206,8 +207,7 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
                 sample_node_id = _strict_int(sample.get("nodeId"), "sample node id")
                 if size < 0:
                     _malformed("V8 heap sample size cannot be negative.")
-                if sample_node_id not in node_ids:
-                    _malformed("V8 heap sample references an unknown node.")
+                sample_node_ids.add(sample_node_id)
                 total_sampled_bytes += size
                 sample_count += 1
                 sample = None
@@ -241,6 +241,8 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
                 node_count += 1
     if node_stack or sample is not None:
         _malformed("V8 heap profile contains an incomplete object.")
+    if not sample_node_ids.issubset(node_ids):
+        _malformed("V8 heap sample references an unknown node.")
     frames, measurements, truncated = _bounded_profile_rows(request, frame_rows, aggregates)
     return V8ProfileResult(
         profile_kind="heap",

--- a/src/flameox/workers/v8_profiles.py
+++ b/src/flameox/workers/v8_profiles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any, NoReturn, cast
 
@@ -44,17 +45,22 @@ def _parse_cpu(request: V8ProfileRequest) -> V8ProfileResult:
             }
     if not nodes:
         _malformed("V8 CPU profile nodes array cannot be empty.")
-    sample_count = _count_cpu_samples(Path(request.artifact_path), request.max_samples)
+    sample_count = _count_cpu_samples(
+        Path(request.artifact_path), request.max_samples, known_node_ids=nodes.keys()
+    )
     return _aggregate_cpu(request, nodes, sample_count)
 
 
-def _count_cpu_samples(path: Path, limit: int) -> int:
+def _count_cpu_samples(path: Path, limit: int, *, known_node_ids: Collection[int]) -> int:
+    known = frozenset(known_node_ids)
     count = 0
     with path.open("rb") as stream:
         for sample in ijson.items(stream, "samples.item"):
             if count >= limit:
                 _limit("V8 CPU profile sample limit exceeded.")
-            _strict_int(sample, "sample node id")
+            sample_id = _strict_int(sample, "sample node id")
+            if sample_id not in known:
+                _malformed("V8 CPU profile sample references an unknown node.")
             count += 1
     return count
 
@@ -109,27 +115,26 @@ def _aggregate_cpu(
 
     if len(visited) != len(nodes):
         _malformed("V8 CPU profile contains disconnected or unreachable nodes.")
-    _check_rows(request, len(frame_rows), len(aggregates))
+    frames, measurements, truncated = _bounded_profile_rows(request, frame_rows, aggregates)
     return V8ProfileResult(
         profile_kind="cpu",
         node_count=len(nodes),
         sample_count=sample_count,
-        frames=tuple(frame_rows.values()),
+        frame_count=len(aggregates),
+        truncated=truncated,
+        frames=frames,
         frame_measurements=tuple(
-            {
-                "frame_id": frame_id,
-                "metric": "cpu.hit_count",
-                "self_value": values["self"],
-                "inclusive_value": values["inclusive"],
-                "unit": "count",
-                "sample_count": values["samples"],
-            }
-            for frame_id, values in sorted(aggregates.items())
+            {**row, "metric": "cpu.hit_count", "unit": "count"} for row in measurements
         ),
         limitations=(
             "V8 CPU samples represent execution time, not allocation or memory evidence.",
             "The CPU profile contains sampled stack locations; source-map resolution is not "
             "applied.",
+            *(
+                (f"V8 hotspot rows were truncated to {request.max_rows} entries.",)
+                if truncated
+                else ()
+            ),
         ),
     )
 
@@ -144,15 +149,22 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
     node_count = 0
     sample_count = 0
     total_sampled_bytes = 0
+    node_ids: set[int] = set()
     node_stack: list[dict[str, Any]] = []
     sample: dict[str, Any] | None = None
     with path.open("rb") as stream:
         for prefix, event, value in ijson.parse(stream):
             if event == "start_map" and (prefix == "head" or prefix.endswith(".children.item")):
-                if len(node_stack) >= request.max_nodes:
+                if node_count + len(node_stack) >= request.max_nodes:
                     _limit("V8 heap profile node limit exceeded.")
                 node_stack.append(
-                    {"call_frame": None, "self_size": None, "children": False, "child_total": 0}
+                    {
+                        "call_frame": None,
+                        "id": None,
+                        "self_size": None,
+                        "children": False,
+                        "child_total": 0,
+                    }
                 )
                 continue
             if event == "start_map" and prefix == "samples.item":
@@ -167,6 +179,8 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
                 elif event in {"string", "number", "null"}:
                     if prefix.endswith(".selfSize"):
                         current["self_size"] = value
+                    elif prefix.endswith(".id"):
+                        current["id"] = value
                     elif prefix.endswith(".callFrame.functionName"):
                         current.setdefault("call_frame_values", {})["functionName"] = value
                     elif prefix.endswith(".callFrame.url"):
@@ -189,9 +203,11 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
                 if sample_count >= request.max_samples:
                     _limit("V8 heap profile sample limit exceeded.")
                 size = _strict_int(sample.get("size"), "sample size")
-                _strict_int(sample.get("nodeId"), "sample node id")
+                sample_node_id = _strict_int(sample.get("nodeId"), "sample node id")
                 if size < 0:
                     _malformed("V8 heap sample size cannot be negative.")
+                if sample_node_id not in node_ids:
+                    _malformed("V8 heap sample references an unknown node.")
                 total_sampled_bytes += size
                 sample_count += 1
                 sample = None
@@ -206,8 +222,12 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
                 if not isinstance(call_frame, dict) or not current["children"]:
                     _malformed("V8 heap profile node is missing callFrame or children.")
                 self_size = _strict_int(current["self_size"], "self size")
+                node_id = _strict_int(current["id"], "node id")
                 if self_size < 0:
                     _malformed("V8 heap profile selfSize cannot be negative.")
+                if node_id in node_ids:
+                    _malformed("V8 heap profile contains duplicate node IDs.")
+                node_ids.add(node_id)
                 if node_stack:
                     node_stack[-1]["child_total"] += self_size + current["child_total"]
                 identity = _frame_identity(call_frame, request)
@@ -221,23 +241,17 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
                 node_count += 1
     if node_stack or sample is not None:
         _malformed("V8 heap profile contains an incomplete object.")
-    _check_rows(request, len(frame_rows), len(aggregates))
+    frames, measurements, truncated = _bounded_profile_rows(request, frame_rows, aggregates)
     return V8ProfileResult(
         profile_kind="heap",
         node_count=node_count,
         sample_count=sample_count,
+        frame_count=len(aggregates),
+        truncated=truncated,
         total_sampled_bytes=total_sampled_bytes,
-        frames=tuple(frame_rows.values()),
+        frames=frames,
         frame_measurements=tuple(
-            {
-                "frame_id": frame_id,
-                "metric": "memory.self_size",
-                "self_value": values["self"],
-                "inclusive_value": values["inclusive"],
-                "unit": "bytes",
-                "sample_count": values["samples"],
-            }
-            for frame_id, values in sorted(aggregates.items())
+            {**row, "metric": "memory.self_size", "unit": "bytes"} for row in measurements
         ),
         limitations=(
             "Sampled allocation bytes are an estimate from V8's sampling heap profiler, not "
@@ -245,6 +259,11 @@ def _parse_heap(request: V8ProfileRequest) -> V8ProfileResult:  # noqa: C901 - s
             "Only allocations sampled by V8 are reported; small or short-lived allocations "
             "may be underrepresented.",
             "Source-map resolution is not applied by this extractor.",
+            *(
+                (f"V8 hotspot rows were truncated to {request.max_rows} entries.",)
+                if truncated
+                else ()
+            ),
         ),
     )
 
@@ -322,9 +341,33 @@ def _frame_identity(call_frame: dict[str, Any], request: V8ProfileRequest) -> di
     }
 
 
-def _check_rows(request: V8ProfileRequest, frame_count: int, measurement_count: int) -> None:
-    if frame_count + measurement_count > request.max_rows:
-        _limit("V8 profile normalized row limit exceeded.")
+def _bounded_profile_rows(
+    request: V8ProfileRequest,
+    frame_rows: dict[str, dict[str, Any]],
+    aggregates: dict[str, dict[str, int]],
+) -> tuple[tuple[dict[str, Any], ...], tuple[dict[str, Any], ...], bool]:
+    measurements: list[dict[str, Any]] = [
+        {
+            "frame_id": frame_id,
+            "self_value": values["self"],
+            "inclusive_value": values["inclusive"],
+            "sample_count": values["samples"],
+        }
+        for frame_id, values in aggregates.items()
+    ]
+    measurements.sort(
+        key=lambda row: (
+            -cast(int, row["self_value"]),
+            -cast(int, row["inclusive_value"]),
+            str(row["frame_id"]),
+        ),
+    )
+    selected = measurements[: request.max_rows]
+    return (
+        tuple(frame_rows[str(row["frame_id"])] for row in selected),
+        tuple(selected),
+        len(measurements) > len(selected),
+    )
 
 
 def _malformed(message: str) -> NoReturn:

--- a/src/flameox/workers/v8_profiles_contract.py
+++ b/src/flameox/workers/v8_profiles_contract.py
@@ -21,6 +21,8 @@ class V8ProfileResult(ContractModel):
     profile_kind: Literal["cpu", "heap"]
     node_count: Annotated[int, Field(ge=0)]
     sample_count: Annotated[int, Field(ge=0)]
+    frame_count: Annotated[int, Field(ge=0)]
+    truncated: bool = False
     total_sampled_bytes: Annotated[int, Field(ge=0)] = 0
     frames: tuple[dict[str, JsonValue], ...]
     frame_measurements: tuple[dict[str, JsonValue], ...]

--- a/tests/providers/test_cpu.py
+++ b/tests/providers/test_cpu.py
@@ -113,9 +113,83 @@ def test_pyspy_speedscope_profile_ranks_typed_frames(tmp_path: Path) -> None:
         runtime.close()
 
     assert result["provider"]["id"] == "py-spy-speedscope"
-    assert result["blocks"][0]["values"] == {"frame_count": 2, "sample_count": 3}
+    assert result["blocks"][0]["values"] == {
+        "frame_count": 2,
+        "sample_count": 3,
+        "weight_unit": "seconds",
+    }
     assert result["blocks"][1]["rows"][0]["function"] == "work"
     assert result["blocks"][1]["rows"][0]["self_weight"] == 2
+
+
+def test_speedscope_profiles_with_different_units_are_not_pooled(tmp_path: Path) -> None:
+    profile = tmp_path / "mixed-units.speedscope.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "shared": {"frames": [{"name": "work"}]},
+                "profiles": [
+                    {
+                        "type": "sampled",
+                        "name": "time",
+                        "unit": "seconds",
+                        "samples": [[0]],
+                        "weights": [1],
+                    },
+                    {
+                        "type": "sampled",
+                        "name": "allocations",
+                        "unit": "bytes",
+                        "samples": [[0]],
+                        "weights": [1_000],
+                    },
+                ],
+            }
+        )
+    )
+    with pytest.raises(RuntimeFailure) as failure:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            runtime.analyze(
+                "cpu.hotspots",
+                [PathSource(path=str(profile), format="py-spy", producer="py-spy")],
+                {},
+            )
+        finally:
+            runtime.close()
+
+    assert failure.value.code == "UNSUPPORTED_FORMAT"
+
+
+def test_speedscope_rejects_a_weight_that_cannot_be_represented(tmp_path: Path) -> None:
+    profile = tmp_path / "overflow.speedscope.json"
+    profile.write_text(
+        json.dumps(
+            {
+                "shared": {"frames": [{"name": "work"}]},
+                "profiles": [
+                    {
+                        "type": "sampled",
+                        "unit": "seconds",
+                        "samples": [[0]],
+                        "weights": [10**400],
+                    }
+                ],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "cpu.hotspots",
+                [PathSource(path=str(profile), format="py-spy", producer="py-spy")],
+                {},
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "DECODE_FAILURE"
 
 
 def test_pyspy_speedscope_profile_keeps_resolved_samples_when_one_stack_is_empty(
@@ -149,6 +223,7 @@ def test_pyspy_speedscope_profile_keeps_resolved_samples_when_one_stack_is_empty
     assert result["blocks"][0]["values"] == {
         "frame_count": 1,
         "sample_count": 2,
+        "weight_unit": "samples",
         "unresolved_sample_count": 1,
     }
     assert result["blocks"][1]["rows"] == [
@@ -160,6 +235,7 @@ def test_pyspy_speedscope_profile_keeps_resolved_samples_when_one_stack_is_empty
             "column": None,
             "self_weight": 2.0,
             "inclusive_weight": 2.0,
+            "unit": "samples",
         }
     ]
     assert any("1 of 2" in limitation for limitation in result["limitations"])

--- a/tests/providers/test_inference_exports.py
+++ b/tests/providers/test_inference_exports.py
@@ -74,7 +74,15 @@ def test_vllm_summary_and_comparison_are_prompt_free(tmp_path: Path) -> None:
     assert "private endpoint" not in json.dumps(summary)
     assert comparison["blocks"][1]["rows"][0]["ratio"] == 2.0
     assert comparison["blocks"][1]["rows"][0]["compatibility"] == "partial"
-    assert comparison["blocks"][1]["rows"][0]["identity_unavailable"] == ["system"]
+    assert comparison["blocks"][1]["rows"][0]["identity_unavailable"] == [
+        "system.backend",
+        "system.model",
+        "system.tokenizer",
+        "workload.dataset_name",
+        "workload.max_concurrency",
+        "workload.num_prompts",
+        "workload.request_rate",
+    ]
 
 
 def test_inference_compare_rejects_known_differences_unless_explicit(tmp_path: Path) -> None:
@@ -107,13 +115,41 @@ def test_inference_compare_rejects_known_differences_unless_explicit(tmp_path: P
         runtime.close()
 
     assert failure.value.code == "INVALID_INPUT"
-    assert failure.value.details == {"differing_fields": ["system", "workload"]}
+    assert failure.value.details == {"differing_fields": ["system.model", "workload.dataset_name"]}
     row = exploratory["blocks"][1]["rows"][0]
     assert row["ratio"] == 2.0
     assert row["compatibility"] == "heterogeneous"
-    assert set(row["identity_differences"]) == {"system", "workload"}
+    assert set(row["identity_differences"]) == {"system.model", "workload.dataset_name"}
     assert "model-a" not in json.dumps(exploratory)
     assert "model-b" not in json.dumps(exploratory)
+
+
+def test_inference_compare_treats_one_sided_optional_identity_as_partial(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline_payload = _vllm_payload(throughput=5.0)
+    baseline_payload["model"] = "model-a"
+    candidate_payload = _vllm_payload(throughput=10.0)
+    candidate_payload.update({"model": "model-a", "backend": "ray"})
+    baseline.write_text(json.dumps(baseline_payload))
+    candidate.write_text(json.dumps(candidate_payload))
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "inference.compare",
+            [
+                PathSource(path=str(baseline), format="vllm-benchmark"),
+                PathSource(path=str(candidate), format="vllm-benchmark"),
+            ],
+            {"metric": "vllm.request_throughput"},
+        )
+    finally:
+        runtime.close()
+
+    row = result["blocks"][1]["rows"][0]
+    assert row["compatibility"] == "partial"
+    assert row["identity_differences"] == {}
+    assert "system.backend" in row["identity_unavailable"]
 
 
 def test_sglang_rejects_detailed_output_and_projects_scalars(tmp_path: Path) -> None:

--- a/tests/providers/test_inference_exports.py
+++ b/tests/providers/test_inference_exports.py
@@ -73,6 +73,47 @@ def test_vllm_summary_and_comparison_are_prompt_free(tmp_path: Path) -> None:
     assert "must not escape" not in json.dumps(summary)
     assert "private endpoint" not in json.dumps(summary)
     assert comparison["blocks"][1]["rows"][0]["ratio"] == 2.0
+    assert comparison["blocks"][1]["rows"][0]["compatibility"] == "partial"
+    assert comparison["blocks"][1]["rows"][0]["identity_unavailable"] == ["system"]
+
+
+def test_inference_compare_rejects_known_differences_unless_explicit(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline_payload = _vllm_payload(throughput=5.0)
+    baseline_payload.update({"model": "model-a", "dataset_name": "set-a"})
+    candidate_payload = _vllm_payload(throughput=10.0)
+    candidate_payload.update({"model": "model-b", "dataset_name": "set-b"})
+    baseline.write_text(json.dumps(baseline_payload))
+    candidate.write_text(json.dumps(candidate_payload))
+    sources = [
+        PathSource(path=str(baseline), format="vllm-benchmark"),
+        PathSource(path=str(candidate), format="vllm-benchmark"),
+    ]
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "inference.compare",
+                sources,
+                {"metric": "vllm.request_throughput"},
+            )
+        exploratory = runtime.analyze(
+            "inference.compare",
+            sources,
+            {"metric": "vllm.request_throughput", "allow_heterogeneous": True},
+        )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "INVALID_INPUT"
+    assert failure.value.details == {"differing_fields": ["system", "workload"]}
+    row = exploratory["blocks"][1]["rows"][0]
+    assert row["ratio"] == 2.0
+    assert row["compatibility"] == "heterogeneous"
+    assert set(row["identity_differences"]) == {"system", "workload"}
+    assert "model-a" not in json.dumps(exploratory)
+    assert "model-b" not in json.dumps(exploratory)
 
 
 def test_sglang_rejects_detailed_output_and_projects_scalars(tmp_path: Path) -> None:

--- a/tests/providers/test_kernel_evidence.py
+++ b/tests/providers/test_kernel_evidence.py
@@ -99,6 +99,37 @@ def test_kernel_validation_summary_and_comparison_use_typed_rows(tmp_path: Path)
     assert not (tmp_path / ".flameox").exists()
 
 
+def test_kernel_compare_requires_complete_semantic_identity(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps(_kernel_document(1.0)))
+    changed = _kernel_document(2.0)
+    changed_output = changed["cases"][0]["outputs"][0]  # type: ignore[index]
+    changed_output["shape"] = [1_024]
+    changed_output["dtype"] = "int8"
+    changed_output["metrics"][0]["unit"] = "percent"
+    candidate.write_text(json.dumps(changed))
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "kernel.compare",
+            [
+                PathSource(path=str(baseline), format="kernel-validation"),
+                PathSource(path=str(candidate), format="kernel-validation"),
+            ],
+            {"metric": "max_abs_error"},
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][1]["rows"] == []
+    assert result["blocks"][0]["values"] == {
+        "input_count": 2,
+        "compatible_metric_count": 0,
+        "unmatched_identity_count": 2,
+    }
+
+
 def test_kernel_validation_rejects_an_unknown_native_schema(tmp_path: Path) -> None:
     artifact = tmp_path / "validation.json"
     document = _kernel_document(0.0)

--- a/tests/providers/test_nsight_systems.py
+++ b/tests/providers/test_nsight_systems.py
@@ -90,6 +90,32 @@ def test_nsight_systems_projects_native_uint64_identifiers_losslessly(tmp_path: 
     assert preserved["evidence_id"]
 
 
+def test_nsight_systems_cuda_api_only_is_negative_accelerator_evidence(tmp_path: Path) -> None:
+    parquetdir = tmp_path / "report.parquetdir"
+    parquetdir.mkdir()
+    pq.write_table(
+        pa.table({"name": ["cudaGetDeviceCount"]}),
+        parquetdir / "CUDA_API_TRACE.parquet",
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "gpu.launches",
+            [PathSource(path=str(parquetdir), format="nsys-parquet")],
+            {},
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][0]["values"] == {
+        "table_count": 0,
+        "row_count": 0,
+        "accelerator_activity_observed": False,
+    }
+    assert result["blocks"][1]["rows"] == []
+    assert "no_accelerator_activity_observed" in result["limitations"]
+
+
 def test_nsight_systems_trace_projections_select_semantic_table_families(
     tmp_path: Path,
 ) -> None:

--- a/tests/providers/test_nvbench.py
+++ b/tests/providers/test_nvbench.py
@@ -98,6 +98,30 @@ def test_nvbench_directory_preserves_native_sample_values_and_compares(tmp_path:
     }
 
 
+def test_nvbench_compare_does_not_pair_different_states(tmp_path: Path) -> None:
+    baseline = _bundle(tmp_path / "baseline", [1.0], elements=16)
+    candidate = _bundle(tmp_path / "candidate", [2.0], elements=1_024)
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.compare",
+            [
+                PathSource(path=str(baseline), format="nvbench"),
+                PathSource(path=str(candidate), format="nvbench"),
+            ],
+            {"metric": "cub.scan.sample_times"},
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][1]["rows"] == []
+    assert result["blocks"][0]["values"] == {
+        "input_count": 2,
+        "compatible_metric_count": 0,
+        "unmatched_identity_count": 2,
+    }
+
+
 def test_nvbench_scaling_uses_numeric_state_dimensions(tmp_path: Path) -> None:
     sources = [
         PathSource(
@@ -119,6 +143,35 @@ def test_nvbench_scaling_uses_numeric_state_dimensions(tmp_path: Path) -> None:
     row = result["blocks"][1]["rows"][0]
     assert row["status"] == "estimated"
     assert row["point_count"] == 3
+    assert row["exponent"] == pytest.approx(2.0)
+
+
+def test_nvbench_scaling_aggregates_beyond_the_sample_row_ceiling(tmp_path: Path) -> None:
+    sources = [
+        PathSource(
+            path=str(
+                _bundle(
+                    tmp_path / f"size-{elements}",
+                    [duration] * 1_002,
+                    elements=elements,
+                )
+            ),
+            format="nvbench",
+        )
+        for elements, duration in ((10, 1.0), (20, 4.0))
+    ]
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            sources,
+            {"input_dimension": "elements", "metric": "cub.scan.sample_times"},
+        )
+    finally:
+        runtime.close()
+
+    row = result["blocks"][1]["rows"][0]
+    assert row["point_count"] == 2
     assert row["exponent"] == pytest.approx(2.0)
 
 

--- a/tests/providers/test_v8_profiles.py
+++ b/tests/providers/test_v8_profiles.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+
+from flameox.providers.capture import CAPTURE_BUILDERS
+from flameox.runtime_contracts import CAPTURE_PROVIDER_CONTRACTS, CaptureTarget
+from flameox.stateless import AnalysisRuntime
+
+
+def test_every_capture_contract_has_exactly_one_registered_builder() -> None:
+    assert set(CAPTURE_BUILDERS) == set(CAPTURE_PROVIDER_CONTRACTS)
+
+
+@pytest.mark.process
+def test_node_heap_capture_is_analyzable_memory_evidence(tmp_path: Path) -> None:
+    executable = tmp_path / "fake-node"
+    executable.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+directory = Path(next(
+    value.split("=", 1)[1]
+    for value in sys.argv
+    if value.startswith("--heap-prof-dir=")
+))
+name = next(
+    value.split("=", 1)[1]
+    for value in sys.argv
+    if value.startswith("--heap-prof-name=")
+)
+(directory / name).write_text(json.dumps({
+    "head": {
+        "callFrame": {
+            "functionName": "captured", "url": "app.js",
+            "lineNumber": 0, "columnNumber": 0
+        },
+        "selfSize": 128,
+        "id": 1,
+        "children": []
+    },
+    "samples": [{"size": 128, "nodeId": 1}]
+}))
+"""
+    )
+    executable.chmod(0o755)
+
+    async def exercise() -> dict[str, Any]:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            return await runtime.capture_and_analyze(
+                CaptureTarget(
+                    argv=[str(executable), "app.js"],
+                    cwd=str(tmp_path),
+                    provider_id="node-heap-profile",
+                ),
+                "memory.hotspots",
+            )
+        finally:
+            runtime.close()
+
+    result = anyio.run(exercise)
+    capture = result["capture"]
+    assert isinstance(capture, dict)
+    capture_argv = capture["executions"][0]["capture_argv"]
+    assert capture_argv[1] == "--heap-prof"
+    assert any(value == "--heap-prof-name=profile.heapprofile" for value in capture_argv)
+    assert result["provider"]["id"] == "v8-heap-profile"

--- a/tests/providers/test_v8_profiles.py
+++ b/tests/providers/test_v8_profiles.py
@@ -7,7 +7,7 @@ import anyio
 import pytest
 
 from flameox.providers.capture import CAPTURE_BUILDERS
-from flameox.runtime_contracts import CAPTURE_PROVIDER_CONTRACTS, CaptureTarget
+from flameox.runtime_contracts import CAPTURE_PROVIDER_CONTRACTS, CaptureTarget, PathSource
 from flameox.stateless import AnalysisRuntime
 
 
@@ -71,3 +71,21 @@ name = next(
     assert capture_argv[1] == "--heap-prof"
     assert any(value == "--heap-prof-name=profile.heapprofile" for value in capture_argv)
     assert result["provider"]["id"] == "v8-heap-profile"
+
+
+def test_heap_profile_accepts_samples_before_referenced_nodes(tmp_path: Path) -> None:
+    profile = tmp_path / "profile.heapprofile"
+    profile.write_text(
+        '{"samples":[{"size":128,"nodeId":1}],"head":'
+        '{"callFrame":{"functionName":"work","url":"app.js",'
+        '"lineNumber":0,"columnNumber":0},"selfSize":128,"id":1,"children":[]}}'
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "memory.hotspots", [PathSource(path=str(profile), format="heapprofile")], {}
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][0]["values"]["sample_count"] == 1

--- a/tests/providers/test_xctrace.py
+++ b/tests/providers/test_xctrace.py
@@ -8,8 +8,21 @@ from typing import Any
 import anyio
 import pytest
 
+from flameox.providers.contracts import ProviderFailure
+from flameox.providers.xctrace import XctraceProvider
 from flameox.runtime_contracts import CaptureTarget
 from flameox.stateless import AnalysisRuntime
+
+
+@pytest.mark.unit
+def test_xctrace_malformed_toc_is_a_typed_decode_failure(tmp_path: Path) -> None:
+    toc = tmp_path / "toc.xml"
+    toc.write_text("<trace><run></trace>")
+
+    with pytest.raises(ProviderFailure) as failure:
+        XctraceProvider.analyze(toc, max_rows=10, provider_version="test")
+
+    assert failure.value.code == "DECODE_FAILURE"
 
 
 @pytest.mark.process

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -32,11 +32,12 @@ from flameox.mcp.capability_tools import (
     capture_tool_name,
 )
 from flameox.providers.contracts import ProviderAnalysis
-from flameox.repository import AGENT_EVIDENCE_MEDIA_TYPE, EvidenceRepository
+from flameox.repository import AGENT_EVIDENCE_MEDIA_TYPE, EvidenceRepository, RepositoryError
 from flameox.runtime_contracts import (
     CAPABILITIES,
     MAX_ROWS,
     CaptureTarget,
+    CompareArguments,
     EvidenceSource,
     ExperimentCase,
     ExperimentDesign,
@@ -49,6 +50,38 @@ from flameox.runtime_errors import DomainError, ErrorCode
 from flameox.setup import ExternalRequirement, ProviderPreparation, ProviderSelectionFailure
 from flameox.stateless import AnalysisRuntime
 from flameox.workers.v8_profiles_contract import V8_PROFILE_WORKER, V8ProfileRequest
+
+
+@pytest.mark.unit
+def test_compare_metric_rejects_empty_value_at_public_contract() -> None:
+    with pytest.raises(ValidationError):
+        CompareArguments(metric="")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    [("argv", [{}]), ("environment", {"NAME": 1})],
+)
+def test_repository_rejects_invalid_nested_capture_target(field: str, invalid: Any) -> None:
+    target: dict[str, Any] = {
+        "argv": ["python"],
+        "cwd": "/workspace",
+        "environment": {},
+        "provider_id": "direct",
+        "capture_arguments": {},
+        "analysis_arguments": {},
+    }
+    request: dict[str, Any] = {
+        "target": target,
+        "mode": "single",
+        "experiment": None,
+        "executions": [],
+    }
+    target[field] = invalid
+
+    with pytest.raises(RepositoryError):
+        EvidenceRepository._validate_capture_request(request)
 
 
 @pytest.mark.unit
@@ -1490,6 +1523,45 @@ def test_benchmark_scaling_aggregates_beyond_the_sample_row_ceiling(tmp_path: Pa
 
 
 @pytest.mark.process
+def test_benchmark_scaling_excludes_nonpositive_samples_from_series_aggregates(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "scaling.samples.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "flameox.benchmark-samples.v1",
+                "producer": "example-benchmark",
+                "benchmarks": [
+                    {
+                        "name": "operation",
+                        "unit": "ns",
+                        "measurement_clock": "host_monotonic",
+                        "synchronization": "not_required",
+                        "dimensions": {"elements": str(elements)},
+                        "samples": samples,
+                    }
+                    for elements, samples in ((10, [10, -10]), (20, [40, -1]))
+                ],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            [PathSource(path=str(artifact), format="samples")],
+            {"input_dimension": "elements", "metric": "operation"},
+        )
+    finally:
+        runtime.close()
+
+    row = result["blocks"][1]["rows"][0]
+    assert row["point_count"] == 2
+    assert row["exponent"] == pytest.approx(2.0)
+
+
+@pytest.mark.process
 def test_benchmark_scaling_reports_inconclusive_without_declared_dimension_values(
     tmp_path: Path,
 ) -> None:
@@ -2397,6 +2469,31 @@ def test_pytest_retries_preserve_failed_attempts(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_pytest_rerun_outcome_is_flaky_attempt(tmp_path: Path) -> None:
+    events = tmp_path / "pytest.jsonl"
+    payloads = [
+        {"event": "test_collected", "nodeid": "test_flaky"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "setup", "outcome": "passed"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "call", "outcome": "rerun"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "call", "outcome": "passed"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "teardown", "outcome": "passed"},
+        {"event": "run_finished", "exitstatus": 0},
+    ]
+    events.write_text("\n".join(json.dumps(event) for event in payloads) + "\n")
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "failures.summary", [PathSource(path=str(events), format="pytest")], {}
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][0]["values"]["flaky"] == 1
+    assert result["blocks"][1]["rows"][0]["classification"] == "flaky"
+    assert result["blocks"][1]["rows"][0]["failing_phase"] == "call"
+
+
+@pytest.mark.unit
 def test_pytest_fixture_projection_aggregates_workers_and_preserves_incomplete_runs(
     tmp_path: Path,
 ) -> None:
@@ -2900,6 +2997,32 @@ def test_mcp_analysis_does_not_expose_unexpected_exception_details(
         assert result.structured_content["code"] == "DECODE_FAILURE"
         assert result.structured_content["message"] == "Input could not be read during analysis."
         assert secret_path not in json.dumps(result.structured_content)
+
+    anyio.run(exercise)
+
+
+@pytest.mark.unit
+def test_mcp_analysis_wraps_unexpected_provider_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("private provider state")
+
+    monkeypatch.setattr(AnalysisRuntime, "analyze", fail)
+
+    async def exercise() -> None:
+        async with Client(
+            create_server(evidence_directory=tmp_path / ".flameox"), raise_exceptions=True
+        ) as client:
+            result = await client.call_tool(
+                "preview_artifact",
+                {"sources": [{"kind": "path", "path": str(tmp_path / "input.json")}]},
+            )
+
+        assert result.is_error is True
+        assert result.structured_content["code"] == "ANALYSIS_FAILURE"
+        assert result.structured_content["message"] == "Analysis failed unexpectedly."
+        assert "private provider state" not in json.dumps(result.structured_content)
 
     anyio.run(exercise)
 

--- a/tests/test_stateless.py
+++ b/tests/test_stateless.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import os
@@ -44,8 +45,10 @@ from flameox.runtime_contracts import (
     RuntimeFailure,
     compatible_capture_providers,
 )
+from flameox.runtime_errors import DomainError, ErrorCode
 from flameox.setup import ExternalRequirement, ProviderPreparation, ProviderSelectionFailure
 from flameox.stateless import AnalysisRuntime
+from flameox.workers.v8_profiles_contract import V8_PROFILE_WORKER, V8ProfileRequest
 
 
 @pytest.mark.unit
@@ -355,6 +358,92 @@ def test_analysis_is_bounded_deterministic_and_does_not_change_input(tmp_path: P
     assert first["continuation"]
     assert first["truncation"] == {"reason": "row_limit", "next_offset": 2}
     assert artifact.read_bytes() == before
+
+
+@pytest.mark.unit
+def test_analysis_rejects_a_negative_continuation_offset(tmp_path: Path) -> None:
+    artifact = tmp_path / "samples.json"
+    artifact.write_text(json.dumps([{"value": value} for value in range(4)]))
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        limits = RequestLimits(max_rows=2)
+        first = runtime.analyze(
+            "artifact.preview", [PathSource(path=str(artifact))], {}, limits=limits
+        )
+        decoded = json.loads(
+            base64.urlsafe_b64decode(
+                first["continuation"] + "=" * (-len(first["continuation"]) % 4)
+            )
+        )
+        decoded["payload"]["offset"] = -1
+        decoded["checksum"] = hashlib.sha256(canonical_bytes(decoded["payload"])).hexdigest()
+        continuation = base64.urlsafe_b64encode(canonical_bytes(decoded)).decode().rstrip("=")
+
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "artifact.preview",
+                [PathSource(path=str(artifact))],
+                {},
+                limits=limits,
+                continuation=continuation,
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "INVALID_INPUT"
+
+
+@pytest.mark.unit
+def test_analysis_rejects_a_continuation_beyond_the_evidence(tmp_path: Path) -> None:
+    artifact = tmp_path / "samples.json"
+    artifact.write_text(json.dumps([{"value": value} for value in range(4)]))
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        limits = RequestLimits(max_rows=2)
+        first = runtime.analyze(
+            "artifact.preview", [PathSource(path=str(artifact))], {}, limits=limits
+        )
+        decoded = json.loads(
+            base64.urlsafe_b64decode(
+                first["continuation"] + "=" * (-len(first["continuation"]) % 4)
+            )
+        )
+        decoded["payload"]["offset"] = 100
+        decoded["checksum"] = hashlib.sha256(canonical_bytes(decoded["payload"])).hexdigest()
+        continuation = base64.urlsafe_b64encode(canonical_bytes(decoded)).decode().rstrip("=")
+
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "artifact.preview",
+                [PathSource(path=str(artifact))],
+                {},
+                limits=limits,
+                continuation=continuation,
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "INVALID_INPUT"
+
+
+@pytest.mark.unit
+def test_analysis_rejects_a_row_that_cannot_fit_the_result_byte_limit(tmp_path: Path) -> None:
+    artifact = tmp_path / "oversized.jsonl"
+    artifact.write_text(json.dumps({"value": "x" * 20_000}) + "\n")
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "artifact.preview",
+                [PathSource(path=str(artifact))],
+                {},
+                limits=RequestLimits(max_rows=10, max_result_bytes=4_096),
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "LIMIT_EXCEEDED"
+    assert "row" in failure.value.message.lower()
 
 
 @pytest.mark.unit
@@ -684,6 +773,226 @@ def test_cpu_profile_uses_explicit_isolated_worker_without_repository(tmp_path: 
 
 
 @pytest.mark.process
+def test_cpu_profile_rejects_samples_for_unknown_nodes(tmp_path: Path) -> None:
+    profile = tmp_path / "cpu.cpuprofile"
+    profile.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": 1,
+                        "callFrame": {
+                            "functionName": "main",
+                            "url": "app.js",
+                            "scriptId": "1",
+                            "lineNumber": 1,
+                            "columnNumber": 0,
+                        },
+                        "hitCount": 1,
+                        "children": [],
+                    }
+                ],
+                "samples": [2],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze(
+                "cpu.hotspots",
+                [PathSource(path=str(profile), format="cpuprofile")],
+                {},
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "DECODE_FAILURE"
+
+
+@pytest.mark.process
+def test_v8_heap_profile_is_registered_as_memory_hotspot_evidence(tmp_path: Path) -> None:
+    profile = tmp_path / "memory.heapprofile"
+    profile.write_text(
+        json.dumps(
+            {
+                "head": {
+                    "callFrame": {
+                        "functionName": "allocate",
+                        "url": "app.js",
+                        "scriptId": "1",
+                        "lineNumber": 1,
+                        "columnNumber": 0,
+                    },
+                    "selfSize": 64,
+                    "id": 1,
+                    "children": [],
+                },
+                "samples": [{"size": 64, "nodeId": 1}],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze("memory.hotspots", [PathSource(path=str(profile))], {})
+    finally:
+        runtime.close()
+
+    assert result["provider"]["id"] == "v8-heap-profile"
+    assert result["blocks"][0]["values"] == {
+        "node_count": 1,
+        "sample_count": 1,
+        "total_sampled_bytes": 64,
+    }
+    assert result["blocks"][1]["rows"][0]["unit"] == "bytes"
+
+
+@pytest.mark.process
+def test_v8_heap_profile_rejects_samples_for_unknown_nodes(tmp_path: Path) -> None:
+    profile = tmp_path / "memory.heapprofile"
+    profile.write_text(
+        json.dumps(
+            {
+                "head": {
+                    "callFrame": {"functionName": "allocate", "url": "app.js"},
+                    "selfSize": 64,
+                    "id": 1,
+                    "children": [],
+                },
+                "samples": [{"size": 64, "nodeId": 2}],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.analyze("memory.hotspots", [PathSource(path=str(profile))], {})
+    finally:
+        runtime.close()
+
+    assert failure.value.code == "DECODE_FAILURE"
+
+
+@pytest.mark.process
+def test_v8_heap_profile_enforces_total_node_limit(tmp_path: Path) -> None:
+    profile = tmp_path / "wide.heapprofile"
+    child = {
+        "callFrame": {"functionName": "child", "url": "app.js"},
+        "id": 2,
+        "selfSize": 1,
+        "children": [],
+    }
+    profile.write_text(
+        json.dumps(
+            {
+                "head": {
+                    "callFrame": {"functionName": "root", "url": "app.js"},
+                    "id": 1,
+                    "selfSize": 0,
+                    "children": [child, child],
+                },
+                "samples": [],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        with pytest.raises(DomainError) as failure:
+            runtime.workers.run_typed_sync(
+                V8_PROFILE_WORKER,
+                V8ProfileRequest(
+                    profile_kind="heap",
+                    artifact_path=str(profile),
+                    artifact_id="test",
+                    max_nodes=2,
+                    max_samples=10,
+                    max_rows=10,
+                ),
+                timeout_seconds=5,
+                maximum_rss_bytes=256 * 1024 * 1024,
+                maximum_writable_growth_bytes=1024,
+            )
+    finally:
+        runtime.close()
+
+    assert failure.value.code is ErrorCode.LIMIT_EXCEEDED
+
+
+@pytest.mark.process
+def test_v8_raw_node_bound_is_independent_from_hotspot_row_limit(tmp_path: Path) -> None:
+    profile = tmp_path / "large.cpuprofile"
+    nodes = [
+        {
+            "id": index,
+            "callFrame": {
+                "functionName": "shared",
+                "url": "app.js",
+                "scriptId": "1",
+                "lineNumber": 1,
+                "columnNumber": 0,
+            },
+            "hitCount": 1 if index == 1 else 0,
+            "children": [index + 1] if index < 1_002 else [],
+        }
+        for index in range(1, 1_003)
+    ]
+    profile.write_text(json.dumps({"nodes": nodes, "samples": [1]}))
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "cpu.hotspots",
+            [PathSource(path=str(profile), format="cpuprofile")],
+            {},
+            limits=RequestLimits(max_rows=10),
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][0]["values"] == {"node_count": 1_002, "sample_count": 1}
+    assert len(result["blocks"][1]["rows"]) == 1
+    assert result["coverage"] == {"rows_returned": 1, "rows_observed": 1, "complete": True}
+
+
+@pytest.mark.process
+def test_v8_hotspot_projection_bounds_distinct_aggregated_frames(tmp_path: Path) -> None:
+    profile = tmp_path / "many-frames.cpuprofile"
+    nodes = [
+        {
+            "id": index,
+            "callFrame": {
+                "functionName": f"frame-{index}",
+                "url": "app.js",
+                "scriptId": "1",
+                "lineNumber": index,
+                "columnNumber": 0,
+            },
+            "hitCount": 1 if index == 1 else 0,
+            "children": [index + 1] if index < 1_002 else [],
+        }
+        for index in range(1, 1_003)
+    ]
+    profile.write_text(json.dumps({"nodes": nodes, "samples": [1]}))
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "cpu.hotspots",
+            [PathSource(path=str(profile), format="cpuprofile")],
+            {},
+            limits=RequestLimits(max_rows=10),
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][0]["values"] == {"node_count": 1_002, "sample_count": 1}
+    assert result["coverage"] == {
+        "rows_returned": 10,
+        "rows_observed": 1_002,
+        "complete": False,
+    }
+    assert result["blocks"][1]["rows"][0]["self_value"] == 1
+
+
+@pytest.mark.process
 def test_coverage_data_uses_isolated_reader_and_continuation(tmp_path: Path) -> None:
     source = tmp_path / "module.py"
     source.write_text("one = 1\ntwo = 2\nthree = 3\n")
@@ -820,6 +1129,44 @@ def test_sarif_candidates_are_scoped_to_project_paths(tmp_path: Path) -> None:
     assert not (tmp_path / ".flameox").exists()
 
 
+@pytest.mark.unit
+def test_truncated_sarif_never_reports_complete_coverage(tmp_path: Path) -> None:
+    artifact = tmp_path / "truncated.sarif"
+    payload = json.dumps(
+        {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "scanner"}},
+                    "results": [
+                        {
+                            "ruleId": "slow-loop",
+                            "message": {"text": "candidate"},
+                            "locations": [
+                                {"physicalLocation": {"artifactLocation": {"uri": "src/slow.py"}}}
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    artifact.write_text(payload[:-1])
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "static.performance_candidates",
+            [PathSource(path=str(artifact), format="sarif")],
+            {},
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][1]["rows"]
+    assert result["coverage"]["complete"] is False
+    assert any("stopped before the document ended" in item for item in result["limitations"])
+
+
 def _write_pyperf_suite(path: Path, values: list[float]) -> None:
     run = pyperf.Run(
         values,
@@ -943,6 +1290,28 @@ def test_pyperf_compare_reads_explicit_artifacts_directly(tmp_path: Path) -> Non
 
 
 @pytest.mark.process
+def test_pyperf_compare_aggregates_beyond_the_sample_row_ceiling(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    _write_pyperf_suite(baseline, [0.010] * 1_002)
+    _write_pyperf_suite(candidate, [0.005] * 1_002)
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.compare",
+            [
+                PathSource(path=str(baseline), format="pyperf"),
+                PathSource(path=str(candidate), format="pyperf"),
+            ],
+            {"metric": "workload"},
+        )
+    finally:
+        runtime.close()
+
+    assert result["blocks"][1]["rows"][0]["ratio"] == 0.5
+
+
+@pytest.mark.process
 def test_structured_benchmark_samples_are_isolated_and_comparable(tmp_path: Path) -> None:
     baseline = tmp_path / "baseline.samples.json"
     candidate = tmp_path / "candidate.samples.json"
@@ -973,6 +1342,66 @@ def test_structured_benchmark_samples_are_isolated_and_comparable(tmp_path: Path
 
 
 @pytest.mark.process
+def test_benchmark_compare_retains_series_dimensions_and_timing_protocol(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.samples.json"
+    candidate = tmp_path / "candidate.samples.json"
+
+    def write(path: Path, small: int, large: int, *, clock: str = "host_monotonic") -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "flameox.benchmark-samples.v1",
+                    "producer": "example-benchmark",
+                    "benchmarks": [
+                        {
+                            "name": "operation",
+                            "unit": "ns",
+                            "measurement_clock": clock,
+                            "synchronization": "not_required",
+                            "dimensions": {"size": size},
+                            "samples": [value],
+                        }
+                        for size, value in (("small", small), ("large", large))
+                    ],
+                }
+            )
+        )
+
+    write(baseline, 1, 100)
+    write(candidate, 2, 50)
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        comparison = runtime.analyze(
+            "benchmark.compare",
+            [
+                PathSource(path=str(baseline), format="samples"),
+                PathSource(path=str(candidate), format="samples"),
+            ],
+            {"metric": "operation"},
+        )
+        write(candidate, 2, 50, clock="cuda_event")
+        incompatible = runtime.analyze(
+            "benchmark.compare",
+            [
+                PathSource(path=str(baseline), format="samples"),
+                PathSource(path=str(candidate), format="samples"),
+            ],
+            {"metric": "operation"},
+        )
+    finally:
+        runtime.close()
+
+    rows = comparison["blocks"][1]["rows"]
+    assert {row["dimensions"]["size"]: row["ratio"] for row in rows} == {
+        "small": 2.0,
+        "large": 0.5,
+    }
+    assert all(row["dimensions"]["measurement_clock"] == "host_monotonic" for row in rows)
+    assert incompatible["blocks"][1]["rows"] == []
+    assert incompatible["blocks"][0]["values"]["unmatched_identity_count"] == 4
+
+
+@pytest.mark.process
 def test_benchmark_scaling_estimates_power_law_from_declared_numeric_dimension(
     tmp_path: Path,
 ) -> None:
@@ -996,6 +1425,68 @@ def test_benchmark_scaling_estimates_power_law_from_declared_numeric_dimension(
     assert row["point_count"] == 3
     assert row["exponent"] == pytest.approx(2.0)
     assert row["r_squared"] == pytest.approx(1.0)
+
+
+@pytest.mark.process
+def test_benchmark_compare_aggregates_beyond_the_sample_row_ceiling(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.samples.json"
+    candidate = tmp_path / "candidate.samples.json"
+    _write_benchmark_samples(baseline, [10] * 1_002)
+    _write_benchmark_samples(candidate, [5] * 1_002)
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.compare",
+            [
+                PathSource(path=str(baseline), format="samples"),
+                PathSource(path=str(candidate), format="samples"),
+            ],
+            {"metric": "operation"},
+        )
+    finally:
+        runtime.close()
+
+    row = result["blocks"][1]["rows"][0]
+    assert row["baseline_mean"] == 10
+    assert row["candidate_mean"] == 5
+    assert row["ratio"] == 0.5
+
+
+@pytest.mark.process
+def test_benchmark_scaling_aggregates_beyond_the_sample_row_ceiling(tmp_path: Path) -> None:
+    artifact = tmp_path / "scaling.samples.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "flameox.benchmark-samples.v1",
+                "producer": "example-benchmark",
+                "benchmarks": [
+                    {
+                        "name": "operation",
+                        "unit": "ns",
+                        "measurement_clock": "host_monotonic",
+                        "synchronization": "not_required",
+                        "dimensions": {"elements": str(elements)},
+                        "samples": [duration] * 1_002,
+                    }
+                    for elements, duration in ((10, 100), (20, 400))
+                ],
+            }
+        )
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "benchmark.scaling",
+            [PathSource(path=str(artifact), format="samples")],
+            {"input_dimension": "elements", "metric": "operation"},
+        )
+    finally:
+        runtime.close()
+
+    row = result["blocks"][1]["rows"][0]
+    assert row["point_count"] == 2
+    assert row["exponent"] == pytest.approx(2.0)
 
 
 @pytest.mark.process
@@ -1214,6 +1705,33 @@ def test_failed_provider_capture_returns_preservable_stream_evidence(tmp_path: P
 
 
 @pytest.mark.process
+def test_unpreserved_capture_analysis_failure_removes_request_scratch(tmp_path: Path) -> None:
+    code = "import os,pathlib; pathlib.Path(os.environ['FLAMEOX_BENCHMARK_OUTPUT']).write_text('{')"
+
+    async def exercise() -> None:
+        runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+        try:
+            for _attempt in range(2):
+                with pytest.raises(RuntimeFailure) as failure:
+                    await runtime.capture_and_analyze(
+                        CaptureTarget(
+                            argv=[sys.executable, "-c", code],
+                            cwd=str(tmp_path),
+                            provider_id="benchmark-samples",
+                        ),
+                        "benchmark.summary",
+                        preserve=False,
+                    )
+                assert failure.value.code == "DECODE_FAILURE"
+                assert list(runtime.scratch.glob("capture-*")) == []
+                assert runtime.analyses == {}
+        finally:
+            runtime.close()
+
+    anyio.run(exercise)
+
+
+@pytest.mark.process
 def test_coverage_capture_uses_explicit_empty_config_and_native_data(tmp_path: Path) -> None:
     script = tmp_path / "covered.py"
     script.write_text("value = 1\nprint(value)\n")
@@ -1406,6 +1924,41 @@ def test_otlp_window_filters_inside_isolated_parser(tmp_path: Path) -> None:
 
     span_rows = [row for row in result["blocks"][1]["rows"] if row["table"] == "spans"]
     assert [row["name"] for row in span_rows] == ["span-2"]
+
+
+@pytest.mark.process
+def test_otlp_window_filters_before_applying_the_normalization_row_limit(tmp_path: Path) -> None:
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+        ExportTraceServiceRequest,
+    )
+
+    request = ExportTraceServiceRequest()
+    for _index in range(1_001):
+        request.resource_spans.add().scope_spans.add()
+    matching_scope = request.resource_spans.add().scope_spans.add()
+    matching = matching_scope.spans.add()
+    matching.trace_id = bytes.fromhex("01" * 16)
+    matching.span_id = bytes.fromhex("02" * 8)
+    matching.name = "matching-span"
+    matching.start_time_unix_nano = 200
+    matching.end_time_unix_nano = 210
+    trace = tmp_path / "trace.otlp"
+    trace.write_bytes(request.SerializeToString())
+
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "trace.window",
+            [PathSource(path=str(trace), format="otlp")],
+            {"start_ns": 150, "end_ns": 250},
+        )
+    finally:
+        runtime.close()
+
+    assert result["coverage"]["complete"] is True
+    assert [row["name"] for row in result["blocks"][1]["rows"] if row["table"] == "spans"] == [
+        "matching-span"
+    ]
 
 
 @pytest.mark.process
@@ -1757,10 +2310,90 @@ def test_pytest_interruption_is_not_overwritten_by_session_finish(tmp_path: Path
         result = runtime.analyze(
             "failures.summary", [PathSource(path=str(events), format="pytest")], {}
         )
+        fixtures = runtime.analyze(
+            "pytest.fixtures", [PathSource(path=str(events), format="pytest")], {}
+        )
     finally:
         runtime.close()
 
     assert result["blocks"][0]["values"]["completion"] == "interrupted"
+    assert fixtures["blocks"][0]["values"]["completion"] == "interrupted"
+
+
+@pytest.mark.unit
+def test_pytest_nonzero_session_exit_remains_visible(tmp_path: Path) -> None:
+    events = tmp_path / "pytest.jsonl"
+    events.write_text(
+        "\n".join(
+            json.dumps(event)
+            for event in (
+                {"event": "run_started", "run_started_at_ns": 1},
+                {"event": "run_finished", "exitstatus": 5},
+            )
+        )
+        + "\n"
+    )
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "failures.summary", [PathSource(path=str(events), format="pytest")], {}
+        )
+        fixtures = runtime.analyze(
+            "pytest.fixtures", [PathSource(path=str(events), format="pytest")], {}
+        )
+    finally:
+        runtime.close()
+
+    metrics = result["blocks"][0]["values"]
+    assert metrics["completion"] == "failed"
+    assert metrics["exit_status"] == 5
+    assert fixtures["blocks"][0]["values"]["completion"] == "failed"
+    assert fixtures["blocks"][0]["values"]["exit_status"] == 5
+
+
+@pytest.mark.unit
+def test_pytest_retries_preserve_failed_attempts(tmp_path: Path) -> None:
+    events = tmp_path / "pytest.jsonl"
+    payloads = [
+        {"event": "test_collected", "nodeid": "test_flaky"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "setup", "outcome": "passed"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "call", "outcome": "failed"},
+        {"event": "test_phase", "nodeid": "test_flaky", "phase": "call", "outcome": "passed"},
+        {
+            "event": "test_phase",
+            "nodeid": "test_flaky",
+            "phase": "teardown",
+            "outcome": "passed",
+        },
+        {"event": "run_finished", "exitstatus": 0},
+    ]
+    events.write_text("\n".join(json.dumps(event) for event in payloads) + "\n")
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze(
+            "failures.summary", [PathSource(path=str(events), format="pytest")], {}
+        )
+    finally:
+        runtime.close()
+
+    metrics = result["blocks"][0]["values"]
+    assert metrics["passed"] == 1
+    assert metrics["flaky"] == 1
+    assert metrics["retried"] == 1
+    assert result["blocks"][1]["rows"] == [
+        {
+            "index": 1,
+            "nodeid": "test_flaky",
+            "classification": "flaky",
+            "failing_phase": "call",
+            "phase_outcomes": {"setup": "passed", "call": "passed", "teardown": "passed"},
+            "phase_attempts": {
+                "setup": ["passed"],
+                "call": ["failed", "passed"],
+                "teardown": ["passed"],
+            },
+        }
+    ]
 
 
 @pytest.mark.unit
@@ -2150,6 +2783,11 @@ def test_mcp_tools_are_generated_from_typed_capabilities() -> None:
             "perf": "#/$defs/PerfProvider",
             "py-spy": "#/$defs/PySpyProvider",
         }
+        memory_capture_schema = by_name["capture_memory_hotspots"].input_schema
+        assert memory_capture_schema["properties"]["provider"]["discriminator"]["mapping"] == {
+            "memray": "#/$defs/MemrayProvider",
+            "node-heap-profile": "#/$defs/NodeHeapProfileProvider",
+        }
         assert capture_schema["required"] == ["target", "provider", "execution"]
         assert by_name["capture_trace_window"].input_schema["required"] == [
             "target",
@@ -2236,6 +2874,73 @@ def test_mcp_tools_are_generated_from_typed_capabilities() -> None:
         assert templates[0].mime_type == AGENT_EVIDENCE_MEDIA_TYPE
 
     anyio.run(inspect)
+
+
+@pytest.mark.unit
+def test_mcp_analysis_does_not_expose_unexpected_exception_details(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret_path = "/private/agent-workspace/customer-secret.json"
+
+    def fail(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise OSError(2, "No such file", secret_path)
+
+    monkeypatch.setattr(AnalysisRuntime, "analyze", fail)
+
+    async def exercise() -> None:
+        async with Client(
+            create_server(evidence_directory=tmp_path / ".flameox"), raise_exceptions=True
+        ) as client:
+            result = await client.call_tool(
+                "preview_artifact",
+                {"sources": [{"kind": "path", "path": str(tmp_path / "input.json")}]},
+            )
+
+        assert result.is_error is True
+        assert result.structured_content["code"] == "DECODE_FAILURE"
+        assert result.structured_content["message"] == "Input could not be read during analysis."
+        assert secret_path not in json.dumps(result.structured_content)
+
+    anyio.run(exercise)
+
+
+@pytest.mark.process
+def test_mcp_terminal_provider_limit_recommends_recovery_not_preservation(tmp_path: Path) -> None:
+    source = tmp_path / "module.py"
+    source.write_text("\n" * (MAX_ROWS + 204))
+    artifact = tmp_path / ".coverage"
+    data = CoverageData(basename=str(artifact))
+    data.add_lines({str(source): set(range(1, MAX_ROWS + 205))})
+    data.write()
+
+    async def exercise() -> None:
+        async with Client(
+            create_server(evidence_directory=tmp_path / ".flameox"), raise_exceptions=True
+        ) as client:
+            continuation: str | None = None
+            terminal = None
+            for _ in range(12):
+                terminal = await client.call_tool(
+                    "analyze_coverage_summary",
+                    {
+                        "sources": [{"kind": "path", "path": str(artifact), "format": "coverage"}],
+                        "limits": {"max_rows": 100},
+                        "continuation": continuation,
+                    },
+                )
+                continuation = terminal.structured_content["continuation"]
+                if continuation is None:
+                    break
+
+        assert terminal is not None
+        assert terminal.structured_content["truncation"]["reason"] == "provider_limit"
+        summary = terminal.content[0]
+        assert isinstance(summary, TextContent)
+        assert "no continuation is available" in summary.text
+        assert "narrow" in summary.text
+        assert "preserve" not in summary.text
+
+    anyio.run(exercise)
 
 
 @pytest.mark.unit
@@ -3219,6 +3924,35 @@ def test_repository_rejects_self_consistent_manifest_with_invalid_body_shape(
 
 
 @pytest.mark.integration
+def test_repository_rejects_invalid_nested_analysis_request_before_projection(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / "samples.json"
+    artifact.write_text("[]")
+    runtime = AnalysisRuntime(evidence_directory=tmp_path / ".flameox")
+    try:
+        result = runtime.analyze("artifact.preview", [PathSource(path=str(artifact))], {})
+        preserved = runtime.preserve_evidence(result["analysis_id"])
+        evidence_id = preserved["evidence_id"]
+        bundle = tmp_path / ".flameox" / "evidence" / "sha256" / evidence_id[:2] / evidence_id
+        manifest = json.loads((bundle / "manifest.json").read_text())
+        manifest["body"]["analysis_request"]["inputs"] = ["not-an-input"]
+        malformed_id = hashlib.sha256(canonical_bytes(manifest["body"])).hexdigest()
+        manifest["evidence_id"] = malformed_id
+        malformed_bundle = bundle.parent.parent / malformed_id[:2] / malformed_id
+        malformed_bundle.parent.mkdir()
+        bundle.rename(malformed_bundle)
+        (malformed_bundle / "manifest.json").write_bytes(canonical_bytes(manifest))
+
+        with pytest.raises(RuntimeFailure) as failure:
+            runtime.read_evidence_agent_projection(malformed_id)
+
+        assert failure.value.code == "REPOSITORY_CORRUPTION"
+    finally:
+        runtime.close()
+
+
+@pytest.mark.integration
 def test_repeated_preservation_revalidates_bundle_and_returns_defensive_reference(
     tmp_path: Path,
 ) -> None:
@@ -3259,6 +3993,25 @@ def test_query_pagination_is_deterministic_and_inventory_bound(tmp_path: Path) -
         assert ids == sorted(ids)
         assert len(ids) == 3
         assert second["continuation"] is None
+
+        decoded_cursor = json.loads(
+            base64.urlsafe_b64decode(
+                first["continuation"] + "=" * (-len(first["continuation"]) % 4)
+            )
+        )
+        decoded_cursor["offset"] = 100
+        beyond_inventory = (
+            base64.urlsafe_b64encode(canonical_bytes(decoded_cursor)).decode().rstrip("=")
+        )
+        with pytest.raises(RuntimeFailure) as invalid_offset:
+            runtime.query_evidence(limit=2, cursor=beyond_inventory)
+        assert invalid_offset.value.code == "INVALID_INPUT"
+
+        decoded_cursor["offset"] = "1"
+        non_integer_offset = base64.urlsafe_b64encode(canonical_bytes(decoded_cursor)).decode()
+        with pytest.raises(RuntimeFailure) as invalid_type:
+            runtime.query_evidence(limit=2, cursor=non_integer_offset)
+        assert invalid_type.value.code == "INVALID_INPUT"
 
         filtered = runtime.query_evidence(limit=1, capability_id="artifact.preview")
         with pytest.raises(RuntimeFailure) as changed_filters:


### PR DESCRIPTION
## Summary

Fixes #441, #442, #443, #444, #445, #446, #447, #448, #449, #450, #451, #452, #453, and #454.

Several providers could return internally valid JSON while describing the wrong semantic population, pooling incompatible measurements, losing failed attempts, or claiming complete evidence after an upstream bound. This change makes filtering, identity, aggregation, truncation, and recovery behavior agree across the runtime.

It also restores the V8 sampling heap workflow that was left unwired during the stateless migration and hardens continuation, repository-manifest, and MCP error boundaries found while testing the same invariants.

## Problem and expected behavior

The affected paths shared four failure modes:

- semantic filtering happened after a native row ceiling, so matching evidence could disappear behind unrelated rows;
- comparison keys omitted dimensions such as device, dtype, timing protocol, or provider identity;
- parsers confused raw-input bounds with projected-row bounds or accepted unresolved native references;
- incomplete or failed evidence was presented as complete, overwritten, leaked in scratch, or given an ineffective recovery action.

The expected contract is that returned rows, `rows_observed`, `coverage.complete`, truncation, identity, units, and recovery guidance all describe the same bounded evidence population.

## Change

- Preserve benchmark and inference series identity and aggregate complete bounded sample populations before projection.
- Apply OTLP window selection before normalization limits and distinguish trace operation and lifecycle projections.
- Enforce kernel comparison compatibility across shape, dtype, device, unit, and provider identity.
- Preserve pytest exit status and retry attempts, and classify flaky outcomes without erasing failed attempts.
- Correct SARIF, Nsight Systems, xctrace, result-byte pagination, capture scratch cleanup, and terminal provider-limit behavior.
- Separate V8 raw node/sample limits from output rows, validate sample-to-node references, normalize Speedscope time units, and restore `node-heap-profile` capture plus `.heapprofile` analysis for `memory.hotspots`.
- Reject invalid or out-of-range analysis continuations and repository cursors.
- Parse nested persisted request structures before projection and keep unexpected MCP and repository failures path-free.
- Document registration completeness, unit compatibility, native-reference integrity, cursor validity, persisted-boundary parsing, and safe error projection.

`memory.retained` remains Memray-only: a V8 sampling heap profile supports allocation hotspots, not retained-memory claims.

## Suggested review order

1. `src/flameox/runtime_contracts.py` and `src/flameox/stateless.py` for the public capability, pagination, and lifecycle invariants.
2. `src/flameox/providers/` and `src/flameox/workers/` for format-specific identity, filtering, and aggregation.
3. `src/flameox/repository.py` and `src/flameox/mcp/server.py` for persistence parsing and protocol-safe failures.
4. `tests/test_stateless.py` and `tests/providers/` for the regressions.
5. `docs/` for the resulting contribution rules.

## Contract and boundary impact

- Semantic owner and changed stage: provider normalization, comparison, and runtime result projection.
- Public CLI or MCP contract: adds V8 heap capture/analysis to `memory.hotspots`; invalid continuations fail instead of returning misleading pages; terminal bounded results recommend narrowing or recapture.
- Storage, artifact, provenance, or schema contract: repository format remains version 1; readers more strictly validate nested manifest structures.
- Adapter, provider, platform, or direct-target compatibility: restores Node/V8 sampling heap support; `memory.retained` is unchanged.
- Cancellation, concurrency, security, or containment impact: unpreserved failed captures release request scratch; MCP fallback errors no longer expose raw exception text or host paths.
- Native artifact, failed-attempt, and observed/derived/inferred claim handling: native artifacts remain unchanged and preservable; failed attempts and incompleteness remain explicit.

## Evidence and regression coverage

- Tests added or updated: public-runtime regressions cover every linked issue plus V8 heap registration, V8 reference integrity, Speedscope units and overflow, continuation bounds, nested manifest parsing, capture-builder registration, and MCP error redaction.
- Base reproduction or other evidence: each regression was run before its fix and failed by returning the incorrect result, accepting malformed evidence, leaking scratch/error details, or raising an untyped exception.
- User-visible MCP example: an out-of-range continuation now returns `INVALID_INPUT`; an unexpected input I/O failure returns `DECODE_FAILURE` with `Input could not be read during analysis.` rather than the underlying host path.
- Remaining proof gaps: the optional AIPerf process test was skipped because AIPerf is not installed. AIPerf normalization is covered by deterministic provider tests.

- [x] Observed, derived, and inferred claims remain distinguishable.
- [x] Inputs, versions, provenance, and relevant artifact identity remain bound.
- [x] Compatibility, limitation, incompleteness, and uncertainty are exposed to callers.

## Validation

- `uv run pytest -q` — 192 passed.
- `uv run pytest -m process -q` — 97 passed, 1 optional AIPerf test skipped.
- `uv run pytest -m performance -q` — 3 passed.
- `uv run ruff format --check src tests` — 110 files formatted.
- `uv run ruff check src tests tools` — passed.
- `uv run mypy src tests tools` — passed for 111 source files.
- `uv run lint-imports` — 2 architecture contracts kept.
- `uv run vulture src/flameox --min-confidence 80` — no findings.
- `git diff --check origin/main...HEAD` — passed.
- Validation commit: `46a639e`.

## Compatibility and safety

- Breaking changes or migration steps: none. Previously accepted malformed or semantically incompatible evidence now fails with a typed error or remains explicitly incomplete.
- Supported platform/provider changes: Node/V8 sampling heap profiles are again available for `memory.hotspots` through explicit `.heapprofile` input and `node-heap-profile` capture.
- Security, privacy, or containment review: repository paths and arbitrary exception strings are not projected through MCP fallback errors; execution authority and containment are unchanged.
- Performance or resource-budget impact: aggregation reads remain bounded; raw parser ceilings are independent from output rows. The existing performance acceptance suite passes.

## Review checklist

- [x] The PR has one focused outcome and the title follows `type(scope): outcome`.
- [x] Related issues are linked.
- [x] Tests cover changed observable behavior and meaningful failure paths.
- [x] Regression proofs failed on the affected tree before their fixes.
- [x] Owning contracts and documentation are updated.
- [x] User-visible MCP behavior includes representative output above.
- [x] The final diff was checked for secrets, unrelated cleanup, and unsupported claims.
